### PR TITLE
Changed Dockerfile and server.sh script, so that signals can be handled to stop instance

### DIFF
--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -10,5 +10,5 @@ ADD stop.sh /$HZ_HOME/stop.sh
 RUN chmod +x /$HZ_HOME/server.sh
 RUN chmod +x /$HZ_HOME/stop.sh
 # Start hazelcast standalone server.
-CMD ./server.sh
+CMD ["./server.sh"]
 EXPOSE 5701


### PR DESCRIPTION
Made changes to `Dockerfile` and `server.sh`, in order to receive and handle signals (mainly `SIGTERM`, produced by `docker stop` and `SIGINT` produced when pressing `ctrl+c` in non-daemon mode), so that the container can be gracefully stopped, without needing to execute `stop.sh` (however it is still usable).

### Dockerfile
Changed Dockerfile to use the _exec_ form of `CMD` (json-array-like parameters), which runs the command straight as PID 1, thus allowing it to receive signals.
Example:
previously, with `CMD ./server.sh`, output of `docker exec -it <hazelcast_instance> ps xf`

    PID TTY      STAT   TIME COMMAND
    68 ?        Rs+    0:00 ps xf
    1 ?        Ss+    0:00 /bin/sh -c ./server.sh
    6 ?        S+     0:00 /bin/sh ./server.sh
    9 ?        Sl+    0:01  \_ java -server com.hazelcast.core.server.StartServe
    10 ?        S+     0:00  \_ sleep infinity

with `CMD ["./server.sh"]`:

    PID TTY      STAT   TIME COMMAND
    75 ?        Rs+    0:00 ps xf
    1 ?        Ss+    0:00 /bin/bash ./server.sh
    9 ?        Sl+    0:02 java -server com.hazelcast.core.server.StartServe

### server.sh
Changes in `server.sh` were made in order to trap signals, so as to `kill` the hazelcast instance process, as `stop.sh` does.
These changes include:

- Changed `shebang` line to `/bin/bash`, so as to be able to set up trapping
- Added trap for SIGTERM and SIGINT signals and a function called when any of these signals is caught, which `kills` hazelcast instance process
- Added PID variable, holding hazelcast instance PID (also persisted to PID_FILE)
- Replaced `sleep infinity` with double waiting on hazelcast instance PID. The double waiting is performed because if a signal is caught, then the script will move to the next command, while the hazelcast instance process might not be stopped yet. The second wait makes sure that the script does not finish earlier than the hazelcast instance process.