### PR TITLE
Dockerfile buildable with Redhat repos and subscription

### DIFF
--- a/hazelcast-openshift-rhel/Dockerfile
+++ b/hazelcast-openshift-rhel/Dockerfile
@@ -31,18 +31,19 @@ LABEL name="hazelcast/hazelcast-openshift-rhel" \
 USER root
 
 RUN mkdir -p $HZ_HOME
-RUN mkdir -p $HZ_CP_MOUNT 
+RUN mkdir -p $HZ_CP_MOUNT
 WORKDIR $HZ_HOME
 
+### add hazelcast enterprise
 ### Adding Hazelcast
 ADD ${REPOSITORY_URL}/com/hazelcast/hazelcast-all/${HZ_MAVEN_DIR}/hazelcast-all-${HZ_VERSION}.jar $HZ_HOME
 
 ### Adding Logging redirector
 ADD https://repo1.maven.org/maven2/org/slf4j/jul-to-slf4j/1.7.12/jul-to-slf4j-1.7.12.jar $HZ_HOME
 
-### Adding JCache 
+### Adding JCache
 ADD https://repo1.maven.org/maven2/javax/cache/cache-api/1.0.0/cache-api-1.0.0.jar $HZ_HOME
- 
+
 ADD hazelcast.xml $HZ_HOME/hazelcast.xml
 ADD start.sh $HZ_HOME/start.sh
 ADD stop.sh $HZ_HOME/stop.sh
@@ -51,13 +52,22 @@ ADD healthcheck.sh $HZ_HOME/healthcheck.sh
 ### Atomic Help File
 COPY help.md /tmp/
 
+ARG user
+ARG password
+
+RUN subscription-manager register --username $user --password $password --auto-attach
+
 RUN yum clean all && \
     yum-config-manager --disable \* && \
 ### Add necessary Red Hat repos here
-    yum-config-manager --enable rhel-7-server-rpms,rhel-7-server-optional-rpms,rhel-7-server-thirdparty-oracle-java-rpms && \
+    subscription-manager repos --enable rhel-7-server-rpms && \
+    subscription-manager repos --enable rhel-7-server-optional-rpms && \
+### subscription-manager repos --enable rhel-7-server-thirdparty-oracle-java-rpms && \
+    subscription-manager repos --enable rhel-7-server-supplementary-rpms && \
     yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical --setopt=tsflags=nodocs && \
-### Install Oracle Java 8
-    yum -y install --setopt=tsflags=nodocs java-1.8.0-oracle-devel && \
+### Install Oracle Java 8 command will be updated when Redhat replies, currently works on openjdk
+### yum -y install --setopt=tsflags=nodocs java-1.8.0-oracle && \
+    yum -y install java-1.8.0-openjdk-devel && \
 ### help markdown to man conversion
 ### Add your package needs to this installation line
     yum -y install --setopt=tsflags=nodocs golang-github-cpuguy83-go-md2man && \
@@ -90,4 +100,3 @@ EXPOSE 5701
 
 ### Start hazelcast standalone server.
 CMD ["/bin/sh", "-c", "./start.sh"]
-

--- a/hazelcast-openshift-rhel/hazelcast-template.js
+++ b/hazelcast-openshift-rhel/hazelcast-template.js
@@ -35,7 +35,7 @@
 				},
 				"spec": {
 					"containers": [{
-						"image": "hazelcast/hazelcast-openshift-rhel",
+						"image": "hazelcast/openshift",
 						"name": "hazelcast-openshift-rhel",
 						"env": [{
 							"name": "HAZELCAST_KUBERNETES_SERVICE_DNS",
@@ -56,22 +56,22 @@
 						"ports": [{
 							"containerPort": 5701,
 							"protocol": "TCP"
-						}]
-					}],
-					"livenessProbe": {
-						"exec": [
-							"/opt/hazelcast/healthcheck.sh"
-						],
-						"initialDelaySeconds": 60,
-						"timeoutSeconds": 10
-					},
-					"readinessProbe": {
-						"exec": [
-							"/opt/hazelcast/healthcheck.sh"
-						],
-						"initialDelaySeconds": 20,
-						"timeoutSeconds": 10
-					}
+						}],
+						"readinessProbe": {
+							"exec": {
+								"command": ["./healthcheck.sh"]
+							},
+							"initialDelaySeconds": 1,
+							"timeoutSeconds": 5
+						},
+						"livenessProbe": {
+							"exec": {
+								"command": ["./healthcheck.sh"]
+							},
+							"initialDelaySeconds": 60,
+							"timeoutSeconds": 5
+						}
+					}]
 				}
 			},
 			"triggers": {


### PR DESCRIPTION
FIX: Kubernetes supports readiness and liveness health checks
NOTE: kubernetes file image is from openshift origin just for demonstration, it should be updated with locally built docker image with valid Redhat subscription