### PR TITLE
Use openjdk:8-jre base image instead of outdated java:* images

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:8-jre
 ENV HZ_VERSION 3.8.3
 ENV HZ_HOME /opt/hazelcast/
 RUN mkdir -p $HZ_HOME

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 ENV HZ_VERSION 3.8.3
 ENV HZ_HOME /opt/hazelcast/
 RUN mkdir -p $HZ_HOME

--- a/jet/Dockerfile
+++ b/jet/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 ENV JET_VERSION 0.4
 ENV JET_HOME /opt/hazelcast-jet/
 RUN mkdir -p $JET_HOME

--- a/management-center/Dockerfile
+++ b/management-center/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:8-jre
 ENV HZ_VERSION 3.8.2
 ENV HZ_HOME /opt/hazelcast/
 # Persistent VOLUME definitions


### PR DESCRIPTION
Resolves #34
