### PR TITLE
CLASSPATH_ARG added to the management-center image to update mancenter app's classpath dynamically

### DIFF
--- a/management-center/Dockerfile
+++ b/management-center/Dockerfile
@@ -3,9 +3,11 @@ ENV HZ_VERSION 3.8.2
 ENV HZ_HOME /opt/hazelcast/
 # Persistent VOLUME definitions
 ENV MANCENTER_DATA /data
+ENV CLASSPATH_ARG /opt/lib
 VOLUME ["/data"]
 
 RUN mkdir -p $HZ_HOME
+RUN mkdir -p $CLASSPATH_ARG
 WORKDIR $HZ_HOME
 
 # Download Hazelcast distribution

--- a/management-center/start.sh
+++ b/management-center/start.sh
@@ -18,4 +18,4 @@ echo "# JAVA_OPTS=$JAVA_OPTS"
 echo "# starting now...."
 echo "########################################"
 
-java -server $JAVA_OPTS -Dhazelcast.mancenter.home=$MANCENTER_DATA -cp mancenter-$HZ_VERSION.war:$HAZELCAST_HOME/*:$CLASSPATH_ARG/* Launcher 8080 mancenter
+java -server $JAVA_OPTS -Dhazelcast.mancenter.home=$MANCENTER_DATA -cp mancenter-$HZ_VERSION.war:$CLASSPATH_ARG/* Launcher 8080 mancenter

--- a/management-center/start.sh
+++ b/management-center/start.sh
@@ -12,12 +12,10 @@ if [ "x$MAX_HEAP_SIZE" != "x" ]; then
 	JAVA_OPTS="$JAVA_OPTS -Xmx${MAX_HEAP_SIZE}"
 fi
 
-export CLASSPATH=$HAZELCAST_HOME/*:$CLASSPATH/*
-
 echo "########################################"
 echo "# RUN_JAVA=$RUN_JAVA"
 echo "# JAVA_OPTS=$JAVA_OPTS"
 echo "# starting now...."
 echo "########################################"
 
-java -server $JAVA_OPTS -Dhazelcast.mancenter.home=$MANCENTER_DATA -jar mancenter-$HZ_VERSION.war
+java -server $JAVA_OPTS -Dhazelcast.mancenter.home=$MANCENTER_DATA -cp mancenter-$HZ_VERSION.war:$HAZELCAST_HOME/*:$CLASSPATH_ARG/* Launcher 8080 mancenter


### PR DESCRIPTION
We have changed this part; 

`-java -server $JAVA_OPTS -Dhazelcast.mancenter.home=$MANCENTER_DATA -jar mancenter-$HZ_VERSION.war`

> Because when you use the -jar option, the specified JAR file is the source of all user classes, and other class path settings are ignored.

See http://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html

And we have removed export part;

`export CLASSPATH=$HAZELCAST_HOME/*:$CLASSPATH/*`

 

> Because specifying -cp overrides any setting of the CLASSPATH environment variable.



