### PR TITLE
Template Management Center URL into hazelcast.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ $ docker run -p 5701:5701 -e HZ_LICENSE_KEY=<your_license_key> -e MANCENTER_URL=
 $ docker run -p 5702:5701 -e HZ_LICENSE_KEY=<your_license_key> -e MANCENTER_URL="http://mancenter:8080/hazelcast-mancenter" -e JAVA_OPTS="-Dhazelcast.local.publicAddress=192.168.1.1:5702" --link mancenter hazelcast/hazelcast-enterprise
 ```
 
+Note that the `MANCENTER_URL` environment variable defines the address of the Management Center application. In this case, it is available at `http://mancenter:8080/hazelcast-mancenter`.
+
 Now, if you open a browser at [http://localhost:8080/hazelcast-mancenter](http://localhost:8080/hazelcast-mancenter), you should see your cluster with 2 nodes. You can start the [client](https://github.com/hazelcast/hazelcast-code-samples/tree/master/clients/basic) and observe in Management Center that the map data has been added.
 
-Read more about Management Center image [here](https://github.com/hazelcast/management-center-docker).
+Read more about the Management Center image [here](https://github.com/hazelcast/management-center-docker).
 
 # Hazelcast Docker Repositories
 
@@ -71,22 +73,36 @@ N.B. Hazelcast Docker Images (Enterprise Edition and Open Source) are based on A
 
 # Hazelcast Defined Environment Variables
 
+### MAX_HEAP_SIZE
+
 You can give environment variables to the Hazelcast member within your Docker command. Currently, we support the variables  `MIN_HEAP_SIZE` and `MAX_HEAP_SIZE` inside our start script. An example command is as follows:
 
 ```
-docker run -e MIN_HEAP_SIZE="1g" hazelcast/hazelcast
+$ docker run -e MIN_HEAP_SIZE="1g" hazelcast/hazelcast
 ```
 
-You can also define your environment variables inside a file as shown in the following example command:
-
-```
-docker run --env-file <file-path> hazelcast/hazelcast
-```
+### JAVA_OPTS
 
 As shown below, you can use `JAVA_OPTS` environment variable if you need to pass multiple VM arguments to your Hazelcast member.
 
 ```
-docker run -e JAVA_OPTS="-Xms512M -Xmx1024M" hazelcast/hazelcast
+$ docker run -e JAVA_OPTS="-Xms512M -Xmx1024M" hazelcast/hazelcast
+```
+
+### HZ_LICENSE_KEY (Hazelcast Enterprise Only)
+
+The license key for Hazelcast Enterprise can be defined using the `HZ_LICENSE_KEY` variable
+
+```
+$ docker run -e HZ_LICENSE_KEY=<your_license_key> hazelcast/hazelcast-enterprise
+```
+
+### MANCENTER_URL (Hazelcast Enterprise Only)
+
+The address to the Management Center application can be defined using the `MANCENTER_URL` variable.
+
+```
+$ docker run -e MANCENTER_URL=<mancenter_url> hazelcast/hazelcast-enterprise
 ```
 
 # Using Custom Hazelcast Configuration File
@@ -94,7 +110,7 @@ docker run -e JAVA_OPTS="-Xms512M -Xmx1024M" hazelcast/hazelcast
 If you need to configure with your own `hazelcast.xml` or jar files with your own domain classes, you need to mount the folder that has those files. Also, while running the Docker image, you need to pass the `hazelcast.xml` file path to `hazelcast.config` in `JAVA_OPTS` parameter. Please see the following example:
 
 ```
-docker run -e JAVA_OPTS="-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcast.xml" -v PATH_TO_LOCAL_CONFIG_FOLDER:/opt/hazelcast/config_ext hazelcast/hazelcast
+$ docker run -e JAVA_OPTS="-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcast.xml" -v PATH_TO_LOCAL_CONFIG_FOLDER:/opt/hazelcast/config_ext hazelcast/hazelcast
 ```
 
 # Extending Hazelcast Base Image
@@ -114,7 +130,7 @@ ENV JAVA_OPTS -Dhazelcast.config=${HZ_HOME}/hazelcast.xml
 After creating the `Dockerfile` you need to build it by running the command below:
 
 ```
-docker build .
+$ docker build .
 ```
 
 Now you can run your own container with its ID or tag (if you provided `-t` option while building the image) using the `docker run` command.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 You can launch Hazelcast Docker Container by running the following command. You can find the full list of Hazelcast versions to replace $HAZELCAST_VERSION at [Official Hazelcast Docker Hub](https://store.docker.com/community/images/hazelcast/hazelcast/tags).
 
 ```
-docker run -ti hazelcast/hazelcast:$HAZELCAST_VERSION
+$ docker run hazelcast/hazelcast:$HAZELCAST_VERSION
 ```
 This command will pull Hazelcast Docker image and run a new Hazelcast Instance.
 
@@ -28,8 +28,8 @@ This command will pull Hazelcast Docker image and run a new Hazelcast Instance.
 For the simplest end-to-end scenario, you can create a Hazelcast cluster with two Docker containers and access it from the client application.
 
 ```
-docker run -it -e JAVA_OPTS="-Dhazelcast.local.publicAddress=<host_ip>:5701" -p 5701:5701 hazelcast/hazelcast
-docker run -it -e JAVA_OPTS="-Dhazelcast.local.publicAddress=<host_ip>:5702" -p 5702:5701 hazelcast/hazelcast 
+$ docker run -e JAVA_OPTS="-Dhazelcast.local.publicAddress=<host_ip>:5701" -p 5701:5701 hazelcast/hazelcast
+$ docker run -e JAVA_OPTS="-Dhazelcast.local.publicAddress=<host_ip>:5702" -p 5702:5701 hazelcast/hazelcast 
 ```
 
 Note that:
@@ -42,11 +42,25 @@ After setting up the cluster, you can start the [client](https://github.com/haze
 
 You can launch Hazelcast Enterprise Docker Container by running the following command. You can find the full list of Hazelcast Enterprise versions to replace $HAZELCAST_VERSION at [Official Hazelcast Docker Hub](https://store.docker.com/community/images/hazelcast/hazelcast-enterprise/tags).
 
-please contact sales@hazelcast.com for trial license.
+Please request trial license [here](https://hazelcast.com/hazelcast-enterprise-download/) or contact sales@hazelcast.com.
 
 ```
-docker run -ti -e HZ_LICENSE_KEY=YOUR_LICENSE_KEY hazelcast/hazelcast-enterprise:$HAZELCAST_VERSION
+$ docker run -e HZ_LICENSE_KEY=<your_license_key> hazelcast/hazelcast-enterprise:$HAZELCAST_VERSION
 ```
+
+# Hazelcast Enterprise Hello World
+
+To run two Hazelcast nodes with Management Center, use the following commands.
+
+```
+$ docker run -p 8080:8080 --name mancenter hazelcast/management-center
+$ docker run -p 5701:5701 -e HZ_LICENSE_KEY=<your_license_key> -e MANCENTER_URL="http://mancenter:8080/hazelcast-mancenter" -e JAVA_OPTS="-Dhazelcast.local.publicAddress=192.168.1.1:5701" --link mancenter hazelcast/hazelcast-enterprise
+$ docker run -p 5702:5701 -e HZ_LICENSE_KEY=<your_license_key> -e MANCENTER_URL="http://mancenter:8080/hazelcast-mancenter" -e JAVA_OPTS="-Dhazelcast.local.publicAddress=192.168.1.1:5702" --link mancenter hazelcast/hazelcast-enterprise
+```
+
+Now, if you open a browser at [http://localhost:8080/hazelcast-mancenter](http://localhost:8080/hazelcast-mancenter), you should see your cluster with 2 nodes. You can start the [client](https://github.com/hazelcast/hazelcast-code-samples/tree/master/clients/basic) and observe in Management Center that the map data has been added.
+
+Read more about Management Center image [here](https://github.com/hazelcast/management-center-docker).
 
 # Hazelcast Docker Repositories
 
@@ -60,19 +74,19 @@ N.B. Hazelcast Docker Images (Enterprise Edition and Open Source) are based on A
 You can give environment variables to the Hazelcast member within your Docker command. Currently, we support the variables  `MIN_HEAP_SIZE` and `MAX_HEAP_SIZE` inside our start script. An example command is as follows:
 
 ```
-docker run -e MIN_HEAP_SIZE="1g" -ti hazelcast/hazelcast
+docker run -e MIN_HEAP_SIZE="1g" hazelcast/hazelcast
 ```
 
 You can also define your environment variables inside a file as shown in the following example command:
 
 ```
-docker run --env-file <file-path> -ti hazelcast/hazelcast
+docker run --env-file <file-path> hazelcast/hazelcast
 ```
 
 As shown below, you can use `JAVA_OPTS` environment variable if you need to pass multiple VM arguments to your Hazelcast member.
 
 ```
-docker run -e JAVA_OPTS="-Xms512M -Xmx1024M" -ti hazelcast/hazelcast
+docker run -e JAVA_OPTS="-Xms512M -Xmx1024M" hazelcast/hazelcast
 ```
 
 # Using Custom Hazelcast Configuration File
@@ -80,7 +94,7 @@ docker run -e JAVA_OPTS="-Xms512M -Xmx1024M" -ti hazelcast/hazelcast
 If you need to configure with your own `hazelcast.xml` or jar files with your own domain classes, you need to mount the folder that has those files. Also, while running the Docker image, you need to pass the `hazelcast.xml` file path to `hazelcast.config` in `JAVA_OPTS` parameter. Please see the following example:
 
 ```
-docker run -e JAVA_OPTS="-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcast.xml" -v PATH_TO_LOCAL_CONFIG_FOLDER:/opt/hazelcast/config_ext -ti hazelcast/hazelcast
+docker run -e JAVA_OPTS="-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcast.xml" -v PATH_TO_LOCAL_CONFIG_FOLDER:/opt/hazelcast/config_ext hazelcast/hazelcast
 ```
 
 # Extending Hazelcast Base Image

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -35,13 +35,16 @@ RUN curl -svf -o ${HZ_HOME}/${HZ_INSTALL_ZIP} \
 RUN curl -svf -o ${HZ_HOME}/${CACHE_API_JAR} \
          -L https://repo1.maven.org/maven2/javax/cache/cache-api/${CACHE_API_VERSION}/${CACHE_API_JAR}
 
+ADD hazelcast.xml $HZ_HOME/hazelcast.xml
+
 # Runtime environment variables
 ENV CLASSPATH_DEFAULT "${HZ_INSTALL_DIR}/lib/${HZ_INSTALL_JAR}:${HZ_HOME}/${CACHE_API_JAR}"
-ENV JAVA_OPTS_DEFAULT "-Djava.net.preferIPv4Stack=true"
+ENV JAVA_OPTS_DEFAULT "-Djava.net.preferIPv4Stack=true -Dhazelcast.mancenter.enabled=false"
 
 ENV MIN_HEAP_SIZE ""
 ENV MAX_HEAP_SIZE ""
 ENV HZ_LICENSE_KEY ""
+ENV MANCENTER_URL ""
 
 ENV CLASSPATH ""
 ENV JAVA_OPTS ""
@@ -53,6 +56,7 @@ CMD ["bash", "-c", "set -euo pipefail \
       && if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi \
       && if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi \
       && if [[ \"x${HZ_LICENSE_KEY}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Dhazelcast.enterprise.license.key=${HZ_LICENSE_KEY}\"; fi \
+      && if [[ \"x${MANCENTER_URL}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL}\"; fi \
       && echo \"########################################\" \
       && echo \"# JAVA_OPTS=${JAVA_OPTS}\" \
       && echo \"# CLASSPATH=${CLASSPATH}\" \

--- a/hazelcast-enterprise/hazelcast.xml
+++ b/hazelcast-enterprise/hazelcast.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <management-center enabled="${hazelcast.mancenter.enabled}">${hazelcast.mancenter.url}</management-center>
+
+</hazelcast>


### PR DESCRIPTION
Changes:
- Add hazelcast.xml with Management Center template to Hazelcast Enterprise Docker image, now Management Center can by enabled by `docker run -e MANCENTER_URL="http://<mancenter_url>"`
- Remove `-it` parameter from `docker run` (in README), I don't think it's useful (AFAIK `-it` helps only if you interact with the app from the console, which we don't do)
- Add "Hazelcast Enterprise Hello World " to README

fix #75 