### PR TITLE
Add"hazelcast-kubernetes" and "hazelcast-eureka" into hazelcast-oss and hazelcast-enterprise

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -15,10 +15,10 @@ ARG HZ_INSTALL_ZIP="hazelcast-enterprise-${HZ_VERSION}.zip"
 ARG HZ_INSTALL_DIR="${HZ_HOME}/${HZ_INSTALL_NAME}"
 
 # Update alpine, and, install bash & curl
-RUN apk update && \
-    apk upgrade && \
-    apk add --update bash curl && \
-    rm -rf /var/cache/apk/*
+RUN apk update \
+ && apk upgrade \
+ && apk add --update bash curl \
+ && rm -rf /var/cache/apk/*
 
 # Set up build directory
 RUN mkdir -p ${HZ_HOME}
@@ -26,12 +26,12 @@ WORKDIR ${HZ_HOME}
 
 # Download & install Hazelcast
 RUN curl -svf -o ${HZ_HOME}/${HZ_INSTALL_ZIP} \
-         -L https://download.hazelcast.com/enterprise/${HZ_INSTALL_ZIP} && \
-    unzip ${HZ_INSTALL_ZIP} \
+         -L https://download.hazelcast.com/enterprise/${HZ_INSTALL_ZIP} \
+ && unzip ${HZ_INSTALL_ZIP} \
          -x ${HZ_INSTALL_NAME}/code-samples/* \
          -x ${HZ_INSTALL_NAME}/demo/* \
-         -x ${HZ_INSTALL_NAME}/docs/* && \
-    rm -rf ${HZ_INSTALL_ZIP}
+         -x ${HZ_INSTALL_NAME}/docs/* \
+ && rm -rf ${HZ_INSTALL_ZIP}
 
 # Download & install JCache
 RUN curl -svf -o ${HZ_HOME}/${CACHE_API_JAR} \
@@ -40,22 +40,22 @@ RUN curl -svf -o ${HZ_HOME}/${CACHE_API_JAR} \
 # Download and install Hazelcast plugins (hazelcast-kubernetes and hazelcast-eureka) with dependencies
 # Use Maven Wrapper to fetch dependencies specified in mvnw/dependency-copy.xml
 RUN curl -svf -o ${HZ_HOME}/maven-wrapper.tar.gz \
-         -L https://github.com/takari/maven-wrapper/archive/maven-wrapper-0.3.0.tar.gz && \
-    tar zxf maven-wrapper.tar.gz && \
-    rm -fr maven-wrapper.tar.gz && \
-    mv maven-wrapper* mvnw
+         -L https://github.com/takari/maven-wrapper/archive/maven-wrapper-0.3.0.tar.gz \
+ && tar zxf maven-wrapper.tar.gz \
+ && rm -fr maven-wrapper.tar.gz \
+ && mv maven-wrapper* mvnw
 COPY mvnw ${HZ_HOME}/mvnw
-RUN cd mvnw && \
-    chmod +x mvnw && \
-    sync && \
-    ./mvnw -f dependency-copy.xml \
+RUN cd mvnw \
+ && chmod +x mvnw \
+ && sync \
+ && ./mvnw -f dependency-copy.xml \
            -Dhazelcast-kubernetes-version=${HZ_KUBE_VERSION} \
            -Dhazelcast-eureka-version=${HZ_EUREKA_VERSION} \
-           dependency:copy-dependencies && \
-    cd .. && \
-    rm -rf $HZ_HOME/mvnw && \
-    rm -rf ~/.m2 && \
-    chmod -R +r $HZ_HOME
+           dependency:copy-dependencies \
+ && cd .. \
+ && rm -rf $HZ_HOME/mvnw \
+ && rm -rf ~/.m2 \
+ && chmod -R +r $HZ_HOME
 
 ADD hazelcast.xml $HZ_HOME/hazelcast.xml
 
@@ -73,18 +73,18 @@ ENV CLASSPATH ""
 ENV JAVA_OPTS ""
 
 # Start Hazelcast server
-CMD ["bash", "-c", "set -euo pipefail && \
-      if [[ \"x${CLASSPATH}\" != \"x\" ]]; then export CLASSPATH=\"${CLASSPATH_DEFAULT}:${CLASSPATH}\"; else export CLASSPATH=\"${CLASSPATH_DEFAULT}\"; fi && \
-      if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi && \
-      if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi && \
-      if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi && \
-      if [[ \"x${HZ_LICENSE_KEY}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Dhazelcast.enterprise.license.key=${HZ_LICENSE_KEY}\"; fi && \
-      if [[ \"x${MANCENTER_URL}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL}\"; fi && \
-      echo \"########################################\" && \
-      echo \"# JAVA_OPTS=${JAVA_OPTS}\" && \
-      echo \"# CLASSPATH=${CLASSPATH}\" && \
-      echo \"# starting now....\" && \
-      echo \"########################################\" && \
-      set -x && \
-      exec java -server ${JAVA_OPTS} com.hazelcast.core.server.StartServer \
+CMD ["bash", "-c", "set -euo pipefail \
+      && if [[ \"x${CLASSPATH}\" != \"x\" ]]; then export CLASSPATH=\"${CLASSPATH_DEFAULT}:${CLASSPATH}\"; else export CLASSPATH=\"${CLASSPATH_DEFAULT}\"; fi \
+      && if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi \
+      && if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi \
+      && if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi \
+      && if [[ \"x${HZ_LICENSE_KEY}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Dhazelcast.enterprise.license.key=${HZ_LICENSE_KEY}\"; fi \
+      && if [[ \"x${MANCENTER_URL}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL}\"; fi \
+      && echo \"########################################\" \
+      && echo \"# JAVA_OPTS=${JAVA_OPTS}\" \
+      && echo \"# CLASSPATH=${CLASSPATH}\" \
+      && echo \"# starting now....\" \
+      && echo \"########################################\" \
+      && set -x \
+      && exec java -server ${JAVA_OPTS} com.hazelcast.core.server.StartServer \
      "]

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -1,46 +1,69 @@
 FROM openjdk:8u151-jre-alpine
 
-ENV HZ_VERSION 3.10.2
-ENV HZ_HOME /opt/hazelcast
+# Versions of Hazelcast and Hazelcast plugins
+ARG HZ_VERSION=3.10.2
+ARG CACHE_API_VERSION=1.0.0
+ARG HZ_KUBE_VERSION=1.1.0
+ARG HZ_EUREKA_VERSION=1.0.2
 
-ENV HZ_INSTALL_NAME "hazelcast-enterprise-${HZ_VERSION}"
-ENV HZ_INSTALL_ZIP "hazelcast-enterprise-${HZ_VERSION}.zip"
-ENV HZ_INSTALL_DIR "${HZ_HOME}/${HZ_INSTALL_NAME}"
-ENV HZ_INSTALL_JAR "hazelcast-enterprise-all-${HZ_VERSION}.jar"
-
-ENV CACHE_API_VERSION 1.0.0
-ENV CACHE_API_JAR "cache-api-${CACHE_API_VERSION}.jar"
+# Build constants
+ARG HZ_HOME="/opt/hazelcast"
+ARG HZ_JAR="hazelcast-enterprise-all-${HZ_VERSION}.jar"
+ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
+ARG HZ_INSTALL_NAME="hazelcast-enterprise-${HZ_VERSION}"
+ARG HZ_INSTALL_ZIP="hazelcast-enterprise-${HZ_VERSION}.zip"
+ARG HZ_INSTALL_DIR="${HZ_HOME}/${HZ_INSTALL_NAME}"
 
 # Update alpine, and, install bash & curl
-RUN apk update \
- && apk upgrade \
- && apk add --update \
-      bash \
-      curl \
- && rm -rf /var/cache/apk/*
+RUN apk update && \
+    apk upgrade && \
+    apk add --update bash curl && \
+    rm -rf /var/cache/apk/*
 
+# Set up build directory
 RUN mkdir -p ${HZ_HOME}
 WORKDIR ${HZ_HOME}
 
 # Download & install Hazelcast
 RUN curl -svf -o ${HZ_HOME}/${HZ_INSTALL_ZIP} \
-         -L https://download.hazelcast.com/enterprise/${HZ_INSTALL_ZIP} \
- && unzip ${HZ_INSTALL_ZIP} \
-      -x ${HZ_INSTALL_NAME}/code-samples/* \
-      -x ${HZ_INSTALL_NAME}/demo/* \
-      -x ${HZ_INSTALL_NAME}/docs/* \
- && rm -rf ${HZ_INSTALL_ZIP}
+         -L https://download.hazelcast.com/enterprise/${HZ_INSTALL_ZIP} && \
+    unzip ${HZ_INSTALL_ZIP} \
+         -x ${HZ_INSTALL_NAME}/code-samples/* \
+         -x ${HZ_INSTALL_NAME}/demo/* \
+         -x ${HZ_INSTALL_NAME}/docs/* && \
+    rm -rf ${HZ_INSTALL_ZIP}
 
 # Download & install JCache
 RUN curl -svf -o ${HZ_HOME}/${CACHE_API_JAR} \
          -L https://repo1.maven.org/maven2/javax/cache/cache-api/${CACHE_API_VERSION}/${CACHE_API_JAR}
 
+# Download and install Hazelcast plugins (hazelcast-kubernetes and hazelcast-eureka) with dependencies
+# Use Maven Wrapper to fetch dependencies specified in mvnw/dependency-copy.xml
+RUN curl -svf -o ${HZ_HOME}/maven-wrapper.tar.gz \
+         -L https://github.com/takari/maven-wrapper/archive/maven-wrapper-0.3.0.tar.gz && \
+    tar zxf maven-wrapper.tar.gz && \
+    rm -fr maven-wrapper.tar.gz && \
+    mv maven-wrapper* mvnw
+COPY mvnw ${HZ_HOME}/mvnw
+RUN cd mvnw && \
+    chmod +x mvnw && \
+    sync && \
+    ./mvnw -f dependency-copy.xml \
+           -Dhazelcast-kubernetes-version=${HZ_KUBE_VERSION} \
+           -Dhazelcast-eureka-version=${HZ_EUREKA_VERSION} \
+           dependency:copy-dependencies && \
+    cd .. && \
+    rm -rf $HZ_HOME/mvnw && \
+    rm -rf ~/.m2 && \
+    chmod -R +r $HZ_HOME
+
 ADD hazelcast.xml $HZ_HOME/hazelcast.xml
 
-# Runtime environment variables
-ENV CLASSPATH_DEFAULT "${HZ_INSTALL_DIR}/lib/${HZ_INSTALL_JAR}:${HZ_HOME}/${CACHE_API_JAR}"
+# Runtime constants
+ENV CLASSPATH_DEFAULT "${HZ_INSTALL_DIR}/lib/${HZ_JAR}:${HZ_HOME}/*"
 ENV JAVA_OPTS_DEFAULT "-Djava.net.preferIPv4Stack=true -Dhazelcast.mancenter.enabled=false"
 
+# Runtime environment variables
 ENV MIN_HEAP_SIZE ""
 ENV MAX_HEAP_SIZE ""
 ENV HZ_LICENSE_KEY ""
@@ -50,18 +73,18 @@ ENV CLASSPATH ""
 ENV JAVA_OPTS ""
 
 # Start Hazelcast server
-CMD ["bash", "-c", "set -euo pipefail \
-      && if [[ \"x${CLASSPATH}\" != \"x\" ]]; then export CLASSPATH=\"${CLASSPATH_DEFAULT}:${CLASSPATH}\"; else export CLASSPATH=\"${CLASSPATH_DEFAULT}\"; fi \
-      && if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi \
-      && if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi \
-      && if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi \
-      && if [[ \"x${HZ_LICENSE_KEY}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Dhazelcast.enterprise.license.key=${HZ_LICENSE_KEY}\"; fi \
-      && if [[ \"x${MANCENTER_URL}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL}\"; fi \
-      && echo \"########################################\" \
-      && echo \"# JAVA_OPTS=${JAVA_OPTS}\" \
-      && echo \"# CLASSPATH=${CLASSPATH}\" \
-      && echo \"# starting now....\" \
-      && echo \"########################################\" \
-      && set -x \
-      && exec java -server ${JAVA_OPTS} com.hazelcast.core.server.StartServer \
+CMD ["bash", "-c", "set -euo pipefail && \
+      if [[ \"x${CLASSPATH}\" != \"x\" ]]; then export CLASSPATH=\"${CLASSPATH_DEFAULT}:${CLASSPATH}\"; else export CLASSPATH=\"${CLASSPATH_DEFAULT}\"; fi && \
+      if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi && \
+      if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi && \
+      if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi && \
+      if [[ \"x${HZ_LICENSE_KEY}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Dhazelcast.enterprise.license.key=${HZ_LICENSE_KEY}\"; fi && \
+      if [[ \"x${MANCENTER_URL}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL}\"; fi && \
+      echo \"########################################\" && \
+      echo \"# JAVA_OPTS=${JAVA_OPTS}\" && \
+      echo \"# CLASSPATH=${CLASSPATH}\" && \
+      echo \"# starting now....\" && \
+      echo \"########################################\" && \
+      set -x && \
+      exec java -server ${JAVA_OPTS} com.hazelcast.core.server.StartServer \
      "]

--- a/hazelcast-enterprise/mvnw/dependency-copy.xml
+++ b/hazelcast-enterprise/mvnw/dependency-copy.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>dep-download</groupId>
+  <artifactId>dep-download</artifactId>
+  <version>0.0.0</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.hazelcast</groupId>
+      <artifactId>hazelcast-kubernetes</artifactId>
+      <version>${hazelcast-kubernetes-version}</version>
+      <exclusions>
+        <exclusion>
+	  <groupId>com.hazelcast</groupId>
+	  <artifactId>hazelcast</artifactId>
+	</exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <configuration>
+          <outputDirectory>${env.HZ_HOME}</outputDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,11 +1,15 @@
 FROM openjdk:8u151-jre-alpine
 
-ENV HZ_VERSION 3.10.2
-ENV HZ_HOME /opt/hazelcast
-ENV HZ_JAR "hazelcast-all-${HZ_VERSION}.jar"
+# Versions of Hazelcast and Hazelcast plugins
+ARG HZ_VERSION=3.10.2
+ARG CACHE_API_VERSION=1.0.0
+ARG HZ_KUBE_VERSION=1.1.0
+ARG HZ_EUREKA_VERSION=1.0.2
 
-ENV CACHE_API_VERSION 1.0.0
-ENV CACHE_API_JAR "cache-api-${CACHE_API_VERSION}.jar"
+# Build constants
+ARG HZ_HOME="/opt/hazelcast"
+ARG HZ_JAR="hazelcast-all-${HZ_VERSION}.jar"
+ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 
 # Update alpine, and, install bash & curl
 RUN apk update \
@@ -15,6 +19,7 @@ RUN apk update \
       curl \
  && rm -rf /var/cache/apk/*
 
+# Set up build directory
 RUN mkdir -p ${HZ_HOME}
 WORKDIR ${HZ_HOME}
 
@@ -26,14 +31,30 @@ RUN curl -svf -o ${HZ_HOME}/${HZ_JAR} \
 RUN curl -svf -o ${HZ_HOME}/${CACHE_API_JAR} \
          -L https://repo1.maven.org/maven2/javax/cache/cache-api/${CACHE_API_VERSION}/${CACHE_API_JAR}
 
-# Runtime environment variables
-ENV CLASSPATH_DEFAULT "${HZ_HOME}/${HZ_JAR}:${HZ_HOME}/${CACHE_API_JAR}"
+# Download and install Hazelcast plugins (hazelcast-kubernetes and hazelcast-eureka) with dependencies
+# Use Maven Wrapper to fetch dependencies specified in mvnw/dependency-copy.xml
+RUN curl -svf -o ${HZ_HOME}/maven-wrapper.tar.gz \
+         -L https://github.com/takari/maven-wrapper/archive/maven-wrapper-0.3.0.tar.gz \
+ && tar zxf maven-wrapper.tar.gz \
+ && rm -fr maven-wrapper.tar.gz \
+ && mv maven-wrapper* mvnw
+COPY mvnw ${HZ_HOME}/mvnw
+RUN cd mvnw && \
+    chmod +x mvnw && \
+    sync && \
+    ./mvnw -f dependency-copy.xml -Dhazelcast-kubernetes-version=${HZ_KUBE_VERSION} -Dhazelcast-eureka-version=${HZ_EUREKA_VERSION} dependency:copy-dependencies \
+    && cd .. \
+    && rm -rf $HZ_HOME/mvnw \
+    && rm -rf ~/.m2 \
+    && chmod -R +r $HZ_HOME
+
+# Runtime constants
+ENV CLASSPATH_DEFAULT "${HZ_HOME}/*"
 ENV JAVA_OPTS_DEFAULT "-Djava.net.preferIPv4Stack=true"
 
+# Runtime variables
 ENV MIN_HEAP_SIZE ""
 ENV MAX_HEAP_SIZE ""
-ENV HZ_LICENSE_KEY ""
-
 ENV CLASSPATH ""
 ENV JAVA_OPTS ""
 

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -12,12 +12,10 @@ ARG HZ_JAR="hazelcast-all-${HZ_VERSION}.jar"
 ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 
 # Update alpine, and, install bash & curl
-RUN apk update \
- && apk upgrade \
- && apk add --update \
-      bash \
-      curl \
- && rm -rf /var/cache/apk/*
+RUN apk update && \
+    apk upgrade && \
+    apk add --update bash curl && \
+    rm -rf /var/cache/apk/*
 
 # Set up build directory
 RUN mkdir -p ${HZ_HOME}
@@ -34,41 +32,44 @@ RUN curl -svf -o ${HZ_HOME}/${CACHE_API_JAR} \
 # Download and install Hazelcast plugins (hazelcast-kubernetes and hazelcast-eureka) with dependencies
 # Use Maven Wrapper to fetch dependencies specified in mvnw/dependency-copy.xml
 RUN curl -svf -o ${HZ_HOME}/maven-wrapper.tar.gz \
-         -L https://github.com/takari/maven-wrapper/archive/maven-wrapper-0.3.0.tar.gz \
- && tar zxf maven-wrapper.tar.gz \
- && rm -fr maven-wrapper.tar.gz \
- && mv maven-wrapper* mvnw
+         -L https://github.com/takari/maven-wrapper/archive/maven-wrapper-0.3.0.tar.gz && \
+    tar zxf maven-wrapper.tar.gz && \
+    rm -fr maven-wrapper.tar.gz && \
+    mv maven-wrapper* mvnw
 COPY mvnw ${HZ_HOME}/mvnw
 RUN cd mvnw && \
     chmod +x mvnw && \
     sync && \
-    ./mvnw -f dependency-copy.xml -Dhazelcast-kubernetes-version=${HZ_KUBE_VERSION} -Dhazelcast-eureka-version=${HZ_EUREKA_VERSION} dependency:copy-dependencies \
-    && cd .. \
-    && rm -rf $HZ_HOME/mvnw \
-    && rm -rf ~/.m2 \
-    && chmod -R +r $HZ_HOME
+    ./mvnw -f dependency-copy.xml \
+           -Dhazelcast-kubernetes-version=${HZ_KUBE_VERSION} \
+           -Dhazelcast-eureka-version=${HZ_EUREKA_VERSION} \
+           dependency:copy-dependencies && \
+    cd .. && \
+    rm -rf $HZ_HOME/mvnw && \
+    rm -rf ~/.m2 && \
+    chmod -R +r $HZ_HOME
 
 # Runtime constants
 ENV CLASSPATH_DEFAULT "${HZ_HOME}/*"
 ENV JAVA_OPTS_DEFAULT "-Djava.net.preferIPv4Stack=true"
 
-# Runtime variables
+# Runtime environment variables
 ENV MIN_HEAP_SIZE ""
 ENV MAX_HEAP_SIZE ""
 ENV CLASSPATH ""
 ENV JAVA_OPTS ""
 
 # Start Hazelcast server
-CMD ["bash", "-c", "set -euo pipefail \
-      && if [[ \"x${CLASSPATH}\" != \"x\" ]]; then export CLASSPATH=\"${CLASSPATH_DEFAULT}:${CLASSPATH}\"; else export CLASSPATH=\"${CLASSPATH_DEFAULT}\"; fi \
-      && if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi \
-      && if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi \
-      && if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi \
-      && echo \"########################################\" \
-      && echo \"# JAVA_OPTS=${JAVA_OPTS}\" \
-      && echo \"# CLASSPATH=${CLASSPATH}\" \
-      && echo \"# starting now....\" \
-      && echo \"########################################\" \
-      && set -x \
-      && exec java -server ${JAVA_OPTS} com.hazelcast.core.server.StartServer \
+CMD ["bash", "-c", "set -euo pipefail && \
+      if [[ \"x${CLASSPATH}\" != \"x\" ]]; then export CLASSPATH=\"${CLASSPATH_DEFAULT}:${CLASSPATH}\"; else export CLASSPATH=\"${CLASSPATH_DEFAULT}\"; fi && \
+      if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi && \
+      if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi && \
+      if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi && \
+      echo \"########################################\" && \
+      echo \"# JAVA_OPTS=${JAVA_OPTS}\" && \
+      echo \"# CLASSPATH=${CLASSPATH}\" && \
+      echo \"# starting now....\" && \
+      echo \"########################################\" && \
+      set -x && \
+      exec java -server ${JAVA_OPTS} com.hazelcast.core.server.StartServer \
      "]

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -12,10 +12,10 @@ ARG HZ_JAR="hazelcast-all-${HZ_VERSION}.jar"
 ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 
 # Update alpine, and, install bash & curl
-RUN apk update && \
-    apk upgrade && \
-    apk add --update bash curl && \
-    rm -rf /var/cache/apk/*
+RUN apk update \
+ && apk upgrade \
+ && apk add --update bash curl \
+ && rm -rf /var/cache/apk/*
 
 # Set up build directory
 RUN mkdir -p ${HZ_HOME}
@@ -32,22 +32,22 @@ RUN curl -svf -o ${HZ_HOME}/${CACHE_API_JAR} \
 # Download and install Hazelcast plugins (hazelcast-kubernetes and hazelcast-eureka) with dependencies
 # Use Maven Wrapper to fetch dependencies specified in mvnw/dependency-copy.xml
 RUN curl -svf -o ${HZ_HOME}/maven-wrapper.tar.gz \
-         -L https://github.com/takari/maven-wrapper/archive/maven-wrapper-0.3.0.tar.gz && \
-    tar zxf maven-wrapper.tar.gz && \
-    rm -fr maven-wrapper.tar.gz && \
-    mv maven-wrapper* mvnw
+         -L https://github.com/takari/maven-wrapper/archive/maven-wrapper-0.3.0.tar.gz \
+ && tar zxf maven-wrapper.tar.gz \
+ && rm -fr maven-wrapper.tar.gz \
+ && mv maven-wrapper* mvnw
 COPY mvnw ${HZ_HOME}/mvnw
-RUN cd mvnw && \
-    chmod +x mvnw && \
-    sync && \
-    ./mvnw -f dependency-copy.xml \
+RUN cd mvnw \
+ && chmod +x mvnw \
+ && sync \
+ && ./mvnw -f dependency-copy.xml \
            -Dhazelcast-kubernetes-version=${HZ_KUBE_VERSION} \
            -Dhazelcast-eureka-version=${HZ_EUREKA_VERSION} \
-           dependency:copy-dependencies && \
-    cd .. && \
-    rm -rf $HZ_HOME/mvnw && \
-    rm -rf ~/.m2 && \
-    chmod -R +r $HZ_HOME
+           dependency:copy-dependencies \
+ && cd .. \
+ && rm -rf $HZ_HOME/mvnw \
+ && rm -rf ~/.m2 \
+ && chmod -R +r $HZ_HOME
 
 # Runtime constants
 ENV CLASSPATH_DEFAULT "${HZ_HOME}/*"
@@ -60,16 +60,16 @@ ENV CLASSPATH ""
 ENV JAVA_OPTS ""
 
 # Start Hazelcast server
-CMD ["bash", "-c", "set -euo pipefail && \
-      if [[ \"x${CLASSPATH}\" != \"x\" ]]; then export CLASSPATH=\"${CLASSPATH_DEFAULT}:${CLASSPATH}\"; else export CLASSPATH=\"${CLASSPATH_DEFAULT}\"; fi && \
-      if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi && \
-      if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi && \
-      if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi && \
-      echo \"########################################\" && \
-      echo \"# JAVA_OPTS=${JAVA_OPTS}\" && \
-      echo \"# CLASSPATH=${CLASSPATH}\" && \
-      echo \"# starting now....\" && \
-      echo \"########################################\" && \
-      set -x && \
-      exec java -server ${JAVA_OPTS} com.hazelcast.core.server.StartServer \
+CMD ["bash", "-c", "set -euo pipefail \
+      && if [[ \"x${CLASSPATH}\" != \"x\" ]]; then export CLASSPATH=\"${CLASSPATH_DEFAULT}:${CLASSPATH}\"; else export CLASSPATH=\"${CLASSPATH_DEFAULT}\"; fi \
+      && if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi \
+      && if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi \
+      && if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi \
+      && echo \"########################################\" \
+      && echo \"# JAVA_OPTS=${JAVA_OPTS}\" \
+      && echo \"# CLASSPATH=${CLASSPATH}\" \
+      && echo \"# starting now....\" \
+      && echo \"########################################\" \
+      && set -x \
+      && exec java -server ${JAVA_OPTS} com.hazelcast.core.server.StartServer \
      "]

--- a/hazelcast-oss/mvnw/dependency-copy.xml
+++ b/hazelcast-oss/mvnw/dependency-copy.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>dep-download</groupId>
+  <artifactId>dep-download</artifactId>
+  <version>0.0.0</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.hazelcast</groupId>
+      <artifactId>hazelcast-kubernetes</artifactId>
+      <version>${hazelcast-kubernetes-version}</version>
+      <exclusions>
+        <exclusion>
+	  <groupId>com.hazelcast</groupId>
+	  <artifactId>hazelcast</artifactId>
+	</exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.hazelcast</groupId>
+      <artifactId>hazelcast-eureka-one</artifactId>
+      <version>${hazelcast-eureka-version}</version>
+      <exclusions>
+        <exclusion>
+	  <groupId>com.hazelcast</groupId>
+	  <artifactId>hazelcast</artifactId>
+	      </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <configuration>
+          <outputDirectory>${env.HZ_HOME}</outputDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
With these dependencies in place, we will not need "hazelcast-kubernetes" and "hazelcast-enterprise-kubernetes" images. The images "hazelcast" and "hazelcast-enterprise" can be used directly in Kubernetes.

Change in the image size (hazelcast-oss): 102MB -> 136MB

Changes:
- Add "hazelcast-kubernetes" and "hazelcast-eureka" JARs into hazelcast Dockerfiles
- Change "ENV" to "ARG" for build constants (which should not be specified by users)
- Fix formatting (e.g. "&&" at the end of the line)

Tests performed:
- hazelcast - Pure Docker
- hazelcast - Kubernetes (Minikube)
- hazelcast-enterprise - Pure Docker
- hazelcast-enterprise - Kubernetes (Minikube)

Note that "hazelcast-kubernetes" and "hazelcast-enterprise-kubernetes" will be removed in separate PR(s).

fix #77 
fix #10 