### PR TITLE
Remove deprecated '--link' from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ $ docker run -e HZ_LICENSE_KEY=<your_license_key> hazelcast/hazelcast-enterprise
 To run two Hazelcast nodes with Management Center, use the following commands.
 
 ```
-$ docker run -p 8080:8080 --name mancenter hazelcast/management-center
-$ docker run -p 5701:5701 -e HZ_LICENSE_KEY=<your_license_key> -e MANCENTER_URL="http://mancenter:8080/hazelcast-mancenter" -e JAVA_OPTS="-Dhazelcast.local.publicAddress=<host_ip>:5701" --link mancenter hazelcast/hazelcast-enterprise
-$ docker run -p 5702:5701 -e HZ_LICENSE_KEY=<your_license_key> -e MANCENTER_URL="http://mancenter:8080/hazelcast-mancenter" -e JAVA_OPTS="-Dhazelcast.local.publicAddress=<host_ip>:5702" --link mancenter hazelcast/hazelcast-enterprise
+$ docker run -p 8080:8080 hazelcast/management-center
+$ docker run -p 5701:5701 -e HZ_LICENSE_KEY=<your_license_key> -e MANCENTER_URL="http://<host_ip>:8080/hazelcast-mancenter" -e JAVA_OPTS="-Dhazelcast.local.publicAddress=<host_ip>:5701" hazelcast/hazelcast-enterprise
+$ docker run -p 5702:5701 -e HZ_LICENSE_KEY=<your_license_key> -e MANCENTER_URL="http://<host_ip>:8080/hazelcast-mancenter" -e JAVA_OPTS="-Dhazelcast.local.publicAddress=<host_ip>:5702" hazelcast/hazelcast-enterprise
 ```
 
-Note that the `MANCENTER_URL` environment variable defines the address of the Management Center application. In this case, it is available at `http://mancenter:8080/hazelcast-mancenter`.
+Note that the `MANCENTER_URL` environment variable defines the address of the Management Center application. In this case, it is available at `http://<host_ip>:8080/hazelcast-mancenter`.
 
 Now, if you open a browser at [http://localhost:8080/hazelcast-mancenter](http://localhost:8080/hazelcast-mancenter), you should see your cluster with 2 nodes. You can start the [client](https://github.com/hazelcast/hazelcast-code-samples/tree/master/clients/basic) and observe in Management Center that the map data has been added.
 


### PR DESCRIPTION
The Hello World example is changed to use the host interface to connect to Management Center.

Another possibility would be to use `docker network` and create a user defined network, but in this simple example I doesn't add any value and is longer for the user to execute.