### PR TITLE
Remove apk update & apk upgrade

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u151-jre-alpine
+FROM openjdk:8u171-jre-alpine
 
 # Versions of Hazelcast and Hazelcast plugins
 ARG HZ_VERSION=3.10.2

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -14,10 +14,8 @@ ARG HZ_INSTALL_NAME="hazelcast-enterprise-${HZ_VERSION}"
 ARG HZ_INSTALL_ZIP="hazelcast-enterprise-${HZ_VERSION}.zip"
 ARG HZ_INSTALL_DIR="${HZ_HOME}/${HZ_INSTALL_NAME}"
 
-# Update alpine, and, install bash & curl
-RUN apk update \
- && apk upgrade \
- && apk add --update bash curl \
+# Install bash & curl
+RUN apk add --no-cache bash curl \
  && rm -rf /var/cache/apk/*
 
 # Set up build directory

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u151-jre-alpine
+FROM openjdk:8u171-jre-alpine
 
 # Versions of Hazelcast and Hazelcast plugins
 ARG HZ_VERSION=3.10.2

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -11,10 +11,8 @@ ARG HZ_HOME="/opt/hazelcast"
 ARG HZ_JAR="hazelcast-all-${HZ_VERSION}.jar"
 ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 
-# Update alpine, and, install bash & curl
-RUN apk update \
- && apk upgrade \
- && apk add --update bash curl \
+# Install bash & curl
+RUN apk add --no-cache bash curl \
  && rm -rf /var/cache/apk/*
 
 # Set up build directory


### PR DESCRIPTION
Changes:
- Remove `apk upgrade` and `apk upgrade` (these commands upgrade all packages from Linux Alpine, which is not needed and increases significantly the size of Docker images)
- Update the version of base image (not critical, but why not to keep it up-to-date)