### PR TITLE
Print Warning when the license key variable is misspelled

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -67,6 +67,7 @@ ENV JAVA_OPTS_DEFAULT "-Djava.net.preferIPv4Stack=true -Dhazelcast.mancenter.ena
 # Runtime environment variables
 ENV MIN_HEAP_SIZE ""
 ENV MAX_HEAP_SIZE ""
+ENV HZ_LICENCE_KEY ""
 ENV HZ_LICENSE_KEY ""
 ENV MANCENTER_URL ""
 
@@ -84,6 +85,7 @@ CMD ["bash", "-c", "set -euo pipefail \
       && if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi \
       && if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi \
       && if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xmx${MAX_HEAP_SIZE}\"; fi \
+      && if [[ \"x${HZ_LICENCE_KEY}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Dhazelcast.enterprise.license.key=${HZ_LICENCE_KEY}\"; fi \
       && if [[ \"x${HZ_LICENSE_KEY}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Dhazelcast.enterprise.license.key=${HZ_LICENSE_KEY}\"; fi \
       && if [[ \"x${MANCENTER_URL}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL}\"; fi \
       && echo \"########################################\" \


### PR DESCRIPTION
After this change, you will see the following logs if you define `HZ_LICENCE_KEY`, but not `HZ_LICENSE_KEY`.

```
$ docker run -e HZ_LICENCE_KEY=fdasfas hazelcast-enterprise
########################################
# JAVA_OPTS=-Djava.net.preferIPv4Stack=true -Dhazelcast.mancenter.enabled=false
# CLASSPATH=/opt/hazelcast:/opt/hazelcast/hazelcast-enterprise-3.11/lib/hazelcast-enterprise-all-3.11.jar:/opt/hazelcast/*
# starting now....
########################################

WARNING: Misspelled License Key variable, define HZ_LICENSE_KEY instead of HZ_LICENCE_KEY

+ exec java -server -Djava.net.preferIPv4Stack=true -Dhazelcast.mancenter.enabled=false com.hazelcast.core.server.StartServer
Dec 07, 2018 10:33:13 AM com.hazelcast.config.XmlConfigLocator
INFO: Loading 'hazelcast.xml' from working directory.
Dec 07, 2018 10:33:13 AM com.hazelcast.config.AbstractConfigBuilder
WARNING: Could not find a replacement for '${hazelcast.mancenter.url}' on node 'null'
Dec 07, 2018 10:33:13 AM com.hazelcast.config.AbstractXmlConfigHelper
WARNING: Name of the hazelcast schema location is incorrect, using default
Dec 07, 2018 10:33:14 AM com.hazelcast.instance.AddressPicker
INFO: [LOCAL] [dev] [3.11] Prefer IPv4 stack is true, prefer IPv6 addresses is false
Dec 07, 2018 10:33:14 AM com.hazelcast.instance.AddressPicker
INFO: [LOCAL] [dev] [3.11] Picked [172.17.0.2]:5701, using socket ServerSocket[addr=/0.0.0.0,localport=5701], bind any local is true
Dec 07, 2018 10:33:14 AM com.hazelcast.security.impl.weaksecretrules.DictionaryRule
WARNING: Dictionary secret policy disabled, word-list file </usr/share/dict/words> not found.
Dec 07, 2018 10:33:14 AM com.hazelcast.system
WARNING: [172.17.0.2]:5701 [dev] [3.11]
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ SECURITY WARNING @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Group Password does not meet the current policy and complexity requirements.
*Must not be set to the default.
*Must have at least 1 lower and 1 upper case characters.
*Must contain at least 1 number.

@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Dec 07, 2018 10:33:14 AM com.hazelcast.system
INFO: [172.17.0.2]:5701 [dev] [3.11] Hazelcast Enterprise 3.11 (20181023 - a50617f, 1500bbb) starting at [172.17.0.2]:5701
Dec 07, 2018 10:33:14 AM com.hazelcast.system
INFO: [172.17.0.2]:5701 [dev] [3.11] Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
Dec 07, 2018 10:33:14 AM com.hazelcast.instance.Node
INFO: [172.17.0.2]:5701 [dev] [3.11] A non-empty group password is configured for the Hazelcast member. Starting with Hazelcast version 3.8.2, members with the same group name, but with different group passwords (that do not use authentication) form a cluster. The group password configuration will be removed completely in a future release.
Dec 07, 2018 10:33:14 AM com.hazelcast.instance.NodeExtension
INFO: [172.17.0.2]:5701 [dev] [3.11] Checking Hazelcast Enterprise license...
Dec 07, 2018 10:33:14 AM com.hazelcast.instance.NodeExtension
INFO: [172.17.0.2]:5701 [dev] [3.11] Destroying node NodeExtension.
Exception in thread "main" com.hazelcast.license.exception.InvalidLicenseException: License Key not configured!
        at com.hazelcast.license.util.LicenseHelper.getLicense(LicenseHelper.java:140)
        at com.hazelcast.instance.EnterpriseNodeExtension.beforeStart(EnterpriseNodeExtension.java:165)
        at com.hazelcast.instance.Node.<init>(Node.java:215)
        at com.hazelcast.instance.HazelcastInstanceImpl.createNode(HazelcastInstanceImpl.java:156)
        at com.hazelcast.instance.HazelcastInstanceImpl.<init>(HazelcastInstanceImpl.java:126)
        at com.hazelcast.instance.HazelcastInstanceFactory.constructHazelcastInstance(HazelcastInstanceFactory.java:202)
        at com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:181)
        at com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:131)
        at com.hazelcast.core.Hazelcast.newHazelcastInstance(Hazelcast.java:57)
        at com.hazelcast.core.server.StartServer.main(StartServer.java:46)
```

fix #68 