### PR TITLE
Make user defined JAVA_OPTS take precedence over the default parameters

### DIFF
--- a/hazelcast-enterprise/start-hazelcast.sh
+++ b/hazelcast-enterprise/start-hazelcast.sh
@@ -18,19 +18,21 @@ else
 fi
 
 if [ -n "${MIN_HEAP_SIZE}" ]; then
-  export JAVA_OPTS="${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}"
+  export JAVA_OPTS="-Xms${MIN_HEAP_SIZE} ${JAVA_OPTS}"
 fi
 
 if [ -n "${MAX_HEAP_SIZE}" ]; then
-  export JAVA_OPTS="${JAVA_OPTS} -Xmx${MAX_HEAP_SIZE}"
+  export JAVA_OPTS="-Xmx${MAX_HEAP_SIZE} ${JAVA_OPTS}"
 fi
 
 if [ -n "${MANCENTER_URL}" ]; then
-  export JAVA_OPTS="${JAVA_OPTS} -Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL}"
+  export JAVA_OPTS="-Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL} ${JAVA_OPTS}"
+else
+  export JAVA_OPTS="-Dhazelcast.mancenter.enabled=false ${JAVA_OPTS}"
 fi
 
 if [ -n "${PROMETHEUS_PORT}" ]; then
-  export JAVA_OPTS="${JAVA_OPTS} -javaagent:${HZ_HOME}/lib/jmx_prometheus_javaagent.jar=${PROMETHEUS_PORT}:${PROMETHEUS_CONFIG}"
+  export JAVA_OPTS="-javaagent:${HZ_HOME}/lib/jmx_prometheus_javaagent.jar=${PROMETHEUS_PORT}:${PROMETHEUS_CONFIG} ${JAVA_OPTS}"
 fi
 
 if [ -n "${HZ_LICENSE_KEY}" ]; then

--- a/hazelcast-enterprise/start-hazelcast.sh
+++ b/hazelcast-enterprise/start-hazelcast.sh
@@ -27,14 +27,10 @@ fi
 
 if [ -n "${MANCENTER_URL}" ]; then
   export JAVA_OPTS="${JAVA_OPTS} -Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL}"
-else
-  export JAVA_OPTS="${JAVA_OPTS} -Dhazelcast.mancenter.enabled=false"
 fi
 
 if [ -n "${PROMETHEUS_PORT}" ]; then
   export JAVA_OPTS="${JAVA_OPTS} -javaagent:${HZ_HOME}/lib/jmx_prometheus_javaagent.jar=${PROMETHEUS_PORT}:${PROMETHEUS_CONFIG}"
-else
-  export JAVA_OPTS="${JAVA_OPTS}"
 fi
 
 if [ -n "${HZ_LICENSE_KEY}" ]; then

--- a/hazelcast-oss/start-hazelcast.sh
+++ b/hazelcast-oss/start-hazelcast.sh
@@ -18,19 +18,21 @@ else
 fi
 
 if [ -n "${MIN_HEAP_SIZE}" ]; then
-  export JAVA_OPTS="${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}"
+  export JAVA_OPTS="-Xms${MIN_HEAP_SIZE} ${JAVA_OPTS}"
 fi
 
 if [ -n "${MAX_HEAP_SIZE}" ]; then
-  export JAVA_OPTS="${JAVA_OPTS} -Xmx${MAX_HEAP_SIZE}"
+  export JAVA_OPTS="-Xmx${MAX_HEAP_SIZE} ${JAVA_OPTS}"
 fi
 
 if [ -n "${MANCENTER_URL}" ]; then
-  export JAVA_OPTS="${JAVA_OPTS} -Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL}"
+  export JAVA_OPTS="-Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL} ${JAVA_OPTS}"
+else
+  export JAVA_OPTS="-Dhazelcast.mancenter.enabled=false ${JAVA_OPTS}"
 fi
 
 if [ -n "${PROMETHEUS_PORT}" ]; then
-  export JAVA_OPTS="${JAVA_OPTS} -javaagent:${HZ_HOME}/lib/jmx_prometheus_javaagent.jar=${PROMETHEUS_PORT}:${PROMETHEUS_CONFIG}"
+  export JAVA_OPTS="-javaagent:${HZ_HOME}/lib/jmx_prometheus_javaagent.jar=${PROMETHEUS_PORT}:${PROMETHEUS_CONFIG} ${JAVA_OPTS}"
 fi
 
 echo "########################################"

--- a/hazelcast-oss/start-hazelcast.sh
+++ b/hazelcast-oss/start-hazelcast.sh
@@ -27,14 +27,10 @@ fi
 
 if [ -n "${MANCENTER_URL}" ]; then
   export JAVA_OPTS="${JAVA_OPTS} -Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL}"
-else
-  export JAVA_OPTS="${JAVA_OPTS} -Dhazelcast.mancenter.enabled=false"
 fi
 
 if [ -n "${PROMETHEUS_PORT}" ]; then
   export JAVA_OPTS="${JAVA_OPTS} -javaagent:${HZ_HOME}/lib/jmx_prometheus_javaagent.jar=${PROMETHEUS_PORT}:${PROMETHEUS_CONFIG}"
-else
-  export JAVA_OPTS="${JAVA_OPTS}"
 fi
 
 echo "########################################"


### PR DESCRIPTION
Remove default `JAVA_OPTS` for the environment variable not passed.

There was an issue with Helm Charts which does not use `MANCENTER_URL`, but take care of Management Center configuration on their own.