### PR TITLE
Update pattern and help message

### DIFF
--- a/hazelcast-enterprise/jmx_agent_config.yaml
+++ b/hazelcast-enterprise/jmx_agent_config.yaml
@@ -6,6 +6,10 @@ whitelistObjectNames: ["com.hazelcast:*"]
 rules:
 # HELP com_hazelcast_hzInstance_1_dev_clusterTime Cluster-wide Time (com.hazelcast<instance=_hzInstance_1_dev, name=_hzInstance_1_dev, type=HazelcastInstance><>clusterTime)
   #com.hazelcast:instance=_hzInstance_1_dev,name=_hzInstance_1_dev,type=HazelcastInstance.PartitionServiceMBean
+
+  # EX of java bean for topic and map:
+  #com.hazelcast<name=mytopic-event, instance=_hzInstance_1_dev, type=ITopic><>localCreationTime
+  #com.hazelcast<name=mymap, instance=_hzInstance_1_dev, type=IMap><>localTotalPutLatency
 - pattern: '<instance=(\w+), name=(\w+), type=(.*)><>(.*):'
   name: hazelcast_$3_$4
   #value: $4
@@ -16,11 +20,11 @@ rules:
     type: $3
   help: "Hazelcast metric instance=$1 name=$2 type=$3 attribute=$4"
   attrNameSnakeCase: false
-- pattern: '<name=(\w+), instance=(\w+), type=(\w+.*)'
-  name: hazelcast_$1_$3
+- pattern: '<name=([\w-_]+), instance=(\w+), type=(\w+.*):'
+  name: hazelcast_$3
   labels:
-    instance: $2
     name: $1
+    instance: $2
     type: $3
-  help: "Hazelcast metric instance=$1 name=$2 type=$3"
+  help: "Hazelcast metric instance=$2 name=$1 type=$3"
   attrNameSnakeCase: false

--- a/hazelcast-oss/jmx_agent_config.yaml
+++ b/hazelcast-oss/jmx_agent_config.yaml
@@ -6,6 +6,10 @@ whitelistObjectNames: ["com.hazelcast:*"]
 rules:
 # HELP com_hazelcast_hzInstance_1_dev_clusterTime Cluster-wide Time (com.hazelcast<instance=_hzInstance_1_dev, name=_hzInstance_1_dev, type=HazelcastInstance><>clusterTime)
   #com.hazelcast:instance=_hzInstance_1_dev,name=_hzInstance_1_dev,type=HazelcastInstance.PartitionServiceMBean
+
+  # EX of java bean for topic and map:
+  #com.hazelcast<name=mytopic-event, instance=_hzInstance_1_dev, type=ITopic><>localCreationTime
+  #com.hazelcast<name=mymap, instance=_hzInstance_1_dev, type=IMap><>localTotalPutLatency
 - pattern: '<instance=(\w+), name=(\w+), type=(.*)><>(.*):'
   name: hazelcast_$3_$4
   #value: $4
@@ -16,11 +20,11 @@ rules:
     type: $3
   help: "Hazelcast metric instance=$1 name=$2 type=$3 attribute=$4"
   attrNameSnakeCase: false
-- pattern: '<name=(\w+), instance=(\w+), type=(\w+.*)'
-  name: hazelcast_$1_$3
+- pattern: '<name=([\w-_]+), instance=(\w+), type=(\w+.*):'
+  name: hazelcast_$3
   labels:
-    instance: $2
     name: $1
+    instance: $2
     type: $3
-  help: "Hazelcast metric instance=$1 name=$2 type=$3"
+  help: "Hazelcast metric instance=$2 name=$1 type=$3"
   attrNameSnakeCase: false


### PR DESCRIPTION
Fix help string: name is capture group 1 not 2.

Add colon to pattern to avoid.
Before:
`hazelcast_HazelcastInstance_clusterTime:_1553256269561{instance="hazelcast0c",name="_hzInstance_1_Test",type="HazelcastInstance"} 1553256269561` Occur on some beans. This make promethus treat each entry as its own time series (because of the underscore)
Now:
`hazelcast_HazelcastInstance_clusterTime:{instance="hazelcast0c",name="_hzInstance_1_Test",type="HazelcastInstance"} 1553256269561`

Update time series name
Before:
`hazelcast_mymapname_IMap_localOwnedEntryMemoryCost{instance="hazelcast0c",name="mymapname",type="IMap><>localOwnedEntryMemoryCost",} 0.0`
Now:
`hazelcast_IMap_localOwnedEntryMemoryCost{instance="hazelcast0c",name="mymapname",type="IMap><>localOwnedEntryMemoryCost",} 0.0`
I think this make more sense since you can use the `name` field to filter or aggregate.

Added underscore and dash to pattern, so beans with name e.g 'mytopic-event' also is matched