### PR TITLE
Add setting logging level and building custom docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ $ docker run -e MANCENTER_URL=<mancenter_url> hazelcast/hazelcast-enterprise
 
 The port of the JMX Prometheus agent. For example, if you set `PROMETHEUS_PORT=8080`, then you can access metrics at: `http://<hostname>:8080/metrics`. You can also use `PROMETHEUS_CONFIG` to set a path to the custom configuration.
 
+### LOGGING_LEVEL
+
+The logging level can be changed using the `LOGGING_LEVEL` variable, for example, to see the `FINEST` logs.
+
+```
+$ docker run -e LOGGING_LEVEL=FINEST hazelcast/hazelcast
+```
+
+Note that if you need some more custom logging configuration, you can configure the `logging.properties` file and build your own Hazelcast image.
+
 ### HZ_LICENSE_KEY (Hazelcast Enterprise Only)
 
 The license key for Hazelcast Enterprise can be defined using the `HZ_LICENSE_KEY` variable
@@ -149,25 +159,13 @@ The other option is to use the `GRACEFUL` shutdown, which triggers the partition
 	* Value should be greater or equal `hazelcast.graceful.shutdown.max.wait`
 	* Alternatively, you can configure the Docker timeout upfront by `docker run --stop-timeout <seconds>`
 
-## Debugging, Managing, and Monitoring
-
 You can debug and monitor Hazelcast instance running inside Docker container.
 
-### Debugging
-
-To debug your Hazelcast with the standard Java Tools support, use the following command to start Hazelcast container:
-
-```
-$ docker run -p 5005:5005 -e JAVA_TOOL_OPTIONS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005' hazelcast/hazelcast
-```
-
-Now you can connect with your remote debugger using the address: `localhost:5005`.
-
-### Managing and Monitoring
+## Managing and Monitoring
 
 You can use JMX or Prometheus for the application monitoring.
 
-#### JMX
+### JMX
 
 You can use the standard JMX protocol to monitor your Hazelcast instance. Start Hazelcast container with the following parameters.
 
@@ -177,7 +175,7 @@ $ docker run -p 9999:9999 -e JAVA_OPTS='-Dhazelcast.jmx=true -Dcom.sun.managemen
 
 Now you can connect using the address: `localhost:9999`.
 
-#### Prometheus
+### Prometheus
 
 You can use JMX Prometheus agent and expose JVM and JMX Hazelcast metrics.
 
@@ -186,6 +184,33 @@ $ docker run -p 8080:8080 -e PROMETHEUS_PORT=8080
 ```
 
 Then, the metrics are available at: `http://localhost:8080/metrics`. Note that you can add also `-e JAVA_OPTS='-Dhazelcast.jmx=true'` to expose JMX via Prometheus (otherwise just JVM metrics are visible).
+
+## Debugging
+
+### Remote Debugger
+
+To debug your Hazelcast with the standard Java Tools support, use the following command to start Hazelcast container:
+
+```
+$ docker run -p 5005:5005 -e JAVA_TOOL_OPTIONS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005' hazelcast/hazelcast
+```
+
+Now you can connect with your remote debugger using the address: `localhost:5005`.
+
+### Building Your Own Hazelcast Image
+
+You may want to build your own Hazelcast Docker image with some custom JARs. For example, if you want to test if your change in the Hazelcast Root repository works fine in the Kubernetes environment or you just need to use an entry processor JAR. To do it, place the your JARs into the current directory, build the image, and push it into Docker registry.
+
+Taking our first example, imagine you did some change in the Hazelcast Root repository and would like to test it on Kubernetes. You need to build `hazelcast-SNAPSHOT.jar` and then do the following.
+
+```
+$ cd hazelcast-oss
+$ cp <path-to-hazelcast-jar> ./
+$ docker build -t <username>/hazelcast:test .
+$ docker push <username>/hazelcast:test
+```
+
+Then, use the image `<username>/hazelcast:test` in your Kubernetes environment to test your change.
 
 ## Docker Images Usages
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ The logging level can be changed using the `LOGGING_LEVEL` variable, for example
 $ docker run -e LOGGING_LEVEL=FINEST hazelcast/hazelcast
 ```
 
+Available logging levels are (from highest to lowest): `SEVERE`, `WARNING`, `INFO`, `CONFIG`, `FINE`, `FINER`, and `FINEST`. The default logging level is `INFO`.
+
 Note that if you need some more custom logging configuration, you can configure the `logging.properties` file and build your own Hazelcast image.
 
 ### HZ_LICENSE_KEY (Hazelcast Enterprise Only)

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -16,24 +16,26 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
-    CLASSPATH_DEFAULT="${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true" \
+    CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     HZ_LICENSE_KEY="" \
     MANCENTER_URL="" \
     PROMETHEUS_PORT="" \
     PROMETHEUS_CONFIG="${HZ_HOME}/jmx_agent_config.yaml" \
+    LOGGING_LEVEL="" \
     CLASSPATH="" \
     JAVA_OPTS=""
 
 # Expose port
 EXPOSE 5701
 
-COPY *.xml *.sh *.yaml ${HZ_HOME}/
+COPY *.xml *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Updating Alpine system" \
+    && apk add --no-cache nss \
     && apk upgrade --update-cache --available \
     && echo "Installing new APK packages" \
     && apk add openjdk8-jre maven bash apr openssl curl procps \

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -35,10 +35,9 @@ COPY *.xml *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Updating Alpine system" \
-    && apk add --no-cache nss \
     && apk upgrade --update-cache --available \
     && echo "Installing new APK packages" \
-    && apk add openjdk8-jre maven bash apr openssl curl procps \
+    && apk add openjdk8-jre maven bash apr openssl curl procps nss \
     && echo "Installing Hazelcast" \
     && cd "${HZ_HOME}" \
     && mkdir lib \

--- a/hazelcast-enterprise/logging.properties
+++ b/hazelcast-enterprise/logging.properties
@@ -1,0 +1,58 @@
+############################################################
+#       Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#       Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+#handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = %h/java%u.log
+java.util.logging.FileHandler.limit = 50000
+java.util.logging.FileHandler.count = 1
+java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# Example to customize the SimpleFormatter output format
+# to print one-line log message like this:
+#     <level>: <log message> [<date/time>]
+#
+# java.util.logging.SimpleFormatter.format=%4$s: %5$s [%1$tc]%n
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+# For example, set the com.xyz.foo logger to only log SEVERE
+# messages:
+com.xyz.foo.level = SEVERE

--- a/hazelcast-enterprise/start-hazelcast.sh
+++ b/hazelcast-enterprise/start-hazelcast.sh
@@ -36,8 +36,8 @@ if [ -n "${PROMETHEUS_PORT}" ]; then
 fi
 
 if [ -n "${LOGGING_LEVEL}" ]; then
-  echo "java.util.logging.ConsoleHandler.level = ${LOGGING_LEVEL}" >> "${HZ_HOME}/logging.properties"
-  echo ".level= ${LOGGING_LEVEL}" >> "${HZ_HOME}/logging.properties"
+  sed -i "s/java.util.logging.ConsoleHandler.level = INFO/java.util.logging.ConsoleHandler.level = ${LOGGING_LEVEL}/g" logging.properties
+  sed -i "s/.level= INFO/.level= ${LOGGING_LEVEL}/g" logging.properties
 fi
 
 if [ -n "${HZ_LICENSE_KEY}" ]; then

--- a/hazelcast-enterprise/start-hazelcast.sh
+++ b/hazelcast-enterprise/start-hazelcast.sh
@@ -35,6 +35,11 @@ if [ -n "${PROMETHEUS_PORT}" ]; then
   export JAVA_OPTS="-javaagent:${HZ_HOME}/lib/jmx_prometheus_javaagent.jar=${PROMETHEUS_PORT}:${PROMETHEUS_CONFIG} ${JAVA_OPTS}"
 fi
 
+if [ -n "${LOGGING_LEVEL}" ]; then
+  echo "java.util.logging.ConsoleHandler.level = ${LOGGING_LEVEL}" >> "${HZ_HOME}/logging.properties"
+  echo ".level= ${LOGGING_LEVEL}" >> "${HZ_HOME}/logging.properties"
+fi
+
 if [ -n "${HZ_LICENSE_KEY}" ]; then
   export JAVA_OPTS="${JAVA_OPTS} -Dhazelcast.enterprise.license.key=${HZ_LICENSE_KEY}"
 else

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -32,10 +32,9 @@ COPY *.xml *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Updating Alpine system" \
-    && apk add --no-cache nss \
     && apk upgrade --update-cache --available \
     && echo "Installing new APK packages" \
-    && apk add openjdk8-jre maven bash curl procps \
+    && apk add openjdk8-jre maven bash curl procps nss \
     && echo "Installing Hazelcast" \
     && cd "${HZ_HOME}" \
     && mkdir lib \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -14,23 +14,25 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
-    CLASSPATH_DEFAULT="${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true" \
+    CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     MANCENTER_URL="" \
     PROMETHEUS_PORT="" \
     PROMETHEUS_CONFIG="${HZ_HOME}/jmx_agent_config.yaml" \
+    LOGGING_LEVEL="" \
     CLASSPATH="" \
     JAVA_OPTS=""
 
 # Expose port
 EXPOSE 5701
 
-COPY *.xml *.sh *.yaml ${HZ_HOME}/
+COPY *.xml *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Updating Alpine system" \
+    && apk add --no-cache nss \
     && apk upgrade --update-cache --available \
     && echo "Installing new APK packages" \
     && apk add openjdk8-jre maven bash curl procps \

--- a/hazelcast-oss/logging.properties
+++ b/hazelcast-oss/logging.properties
@@ -1,0 +1,58 @@
+############################################################
+#       Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#       Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+#handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = %h/java%u.log
+java.util.logging.FileHandler.limit = 50000
+java.util.logging.FileHandler.count = 1
+java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# Example to customize the SimpleFormatter output format
+# to print one-line log message like this:
+#     <level>: <log message> [<date/time>]
+#
+# java.util.logging.SimpleFormatter.format=%4$s: %5$s [%1$tc]%n
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+# For example, set the com.xyz.foo logger to only log SEVERE
+# messages:
+com.xyz.foo.level = SEVERE

--- a/hazelcast-oss/start-hazelcast.sh
+++ b/hazelcast-oss/start-hazelcast.sh
@@ -35,6 +35,11 @@ if [ -n "${PROMETHEUS_PORT}" ]; then
   export JAVA_OPTS="-javaagent:${HZ_HOME}/lib/jmx_prometheus_javaagent.jar=${PROMETHEUS_PORT}:${PROMETHEUS_CONFIG} ${JAVA_OPTS}"
 fi
 
+if [ -n "${LOGGING_LEVEL}" ]; then
+  echo "java.util.logging.ConsoleHandler.level = ${LOGGING_LEVEL}" >> "${HZ_HOME}/logging.properties"
+  echo ".level= ${LOGGING_LEVEL}" >> "${HZ_HOME}/logging.properties"
+fi
+
 echo "########################################"
 echo "# JAVA_OPTS=${JAVA_OPTS}"
 echo "# CLASSPATH=${CLASSPATH}"

--- a/hazelcast-oss/start-hazelcast.sh
+++ b/hazelcast-oss/start-hazelcast.sh
@@ -36,8 +36,8 @@ if [ -n "${PROMETHEUS_PORT}" ]; then
 fi
 
 if [ -n "${LOGGING_LEVEL}" ]; then
-  echo "java.util.logging.ConsoleHandler.level = ${LOGGING_LEVEL}" >> "${HZ_HOME}/logging.properties"
-  echo ".level= ${LOGGING_LEVEL}" >> "${HZ_HOME}/logging.properties"
+  sed -i "s/java.util.logging.ConsoleHandler.level = INFO/java.util.logging.ConsoleHandler.level = ${LOGGING_LEVEL}/g" logging.properties
+  sed -i "s/.level= INFO/.level= ${LOGGING_LEVEL}/g" logging.properties
 fi
 
 echo "########################################"


### PR DESCRIPTION
Changes:
- Add default `logging.properties` file
- Add property `LOGGING_LEVEL` to enable changing logging level while starting the container
- Add description on how to build custom Hazelcast Image for testing
- Add `apk add --no-cache nss` (unrelated, but needed because of the change in Alpine, read more [here](https://github.com/docker-library/openjdk/issues/289#issuecomment-473903764))

fix #108 