### PR TITLE
Remove hazlecast-kubernetes dependency

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -1,10 +1,9 @@
 FROM alpine:3.8
 
 # Versions of Hazelcast and Hazelcast plugins
-ARG HZ_VERSION=3.11.2
+ARG HZ_VERSION=3.12
 ARG CACHE_API_VERSION=1.1.0
-ARG HZ_KUBE_VERSION=1.3.1
-ARG HZ_EUREKA_VERSION=1.0.2
+ARG HZ_EUREKA_VERSION=1.1.1
 ARG JMX_PROMETHEUS_AGENT_VERSION=0.11.0
 ARG NETTY_VERSION=4.1.32.Final
 ARG NETTY_TCNATIVE_VERSION=2.0.20.Final
@@ -48,7 +47,6 @@ RUN echo "Updating Alpine system" \
          -L "https://repo1.maven.org/maven2/javax/cache/cache-api/${CACHE_API_VERSION}/${CACHE_API_JAR}" \
     && echo "Installing Hazelcast plugins" \
     && mvn -f dependency-copy.xml \
-           -Dhazelcast-kubernetes-version=${HZ_KUBE_VERSION} \
            -Dhazelcast-eureka-version=${HZ_EUREKA_VERSION} \
            -Dnetty.version=${NETTY_VERSION} \
            -Dnetty-tcnative.version=${NETTY_TCNATIVE_VERSION} \

--- a/hazelcast-enterprise/dependency-copy.xml
+++ b/hazelcast-enterprise/dependency-copy.xml
@@ -10,17 +10,6 @@
   <dependencies>
     <dependency>
       <groupId>com.hazelcast</groupId>
-      <artifactId>hazelcast-kubernetes</artifactId>
-      <version>${hazelcast-kubernetes-version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.hazelcast</groupId>
-          <artifactId>hazelcast</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast-eureka-one</artifactId>
       <version>${hazelcast-eureka-version}</version>
       <exclusions>

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,10 +1,9 @@
 FROM alpine:3.8
 
 # Versions of Hazelcast and Hazelcast plugins
-ARG HZ_VERSION=3.11.2
+ARG HZ_VERSION=3.12
 ARG CACHE_API_VERSION=1.1.0
-ARG HZ_KUBE_VERSION=1.3.1
-ARG HZ_EUREKA_VERSION=1.0.2
+ARG HZ_EUREKA_VERSION=1.1.1
 ARG JMX_PROMETHEUS_AGENT_VERSION=0.11.0
 
 # Build constants
@@ -45,7 +44,6 @@ RUN echo "Updating Alpine system" \
          -L "https://repo1.maven.org/maven2/javax/cache/cache-api/${CACHE_API_VERSION}/${CACHE_API_JAR}" \
     && echo "Installing Hazelcast plugins" \
     && mvn -f dependency-copy.xml \
-           -Dhazelcast-kubernetes-version=${HZ_KUBE_VERSION} \
            -Dhazelcast-eureka-version=${HZ_EUREKA_VERSION} \
            dependency:copy-dependencies \
     && echo "Maven clean-up" \

--- a/hazelcast-oss/dependency-copy.xml
+++ b/hazelcast-oss/dependency-copy.xml
@@ -10,17 +10,6 @@
   <dependencies>
     <dependency>
       <groupId>com.hazelcast</groupId>
-      <artifactId>hazelcast-kubernetes</artifactId>
-      <version>${hazelcast-kubernetes-version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.hazelcast</groupId>
-          <artifactId>hazelcast</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast-eureka-one</artifactId>
       <version>${hazelcast-eureka-version}</version>
       <exclusions>


### PR DESCRIPTION
`hazelcast-kubernetes` is included in `hazelcast-all` up from 3.12. We need to remove it from the image not to double the same (or even worse the same with the different version) JAR.

I asked @Holmistr to merge it after the 3.12 release, so it's inlcuded in the 3.12 Docker image.