### PR TITLE
Add TLS support to Hazelcast Enterprise image

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $ docker run -e HZ_LICENSE_KEY=<your_license_key> hazelcast/hazelcast-enterprise
 
 ### TLS_ENABLED (Hazelcast Enterprise Only)
 
-The `TLS_ENABLED` environment variable can be used to enable TLS for the communication. The key material folder should be mounted and properly referenced by using `JAVA_OPTS` variable
+The `TLS_ENABLED` environment variable can be used to enable TLS for the communication. The key material folder should be mounted and properly referenced by using `JAVA_OPTS` variable.
 
 ```bash
 # generate a sample key material to the current folder (self-signed certificate)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,24 @@ The license key for Hazelcast Enterprise can be defined using the `HZ_LICENSE_KE
 $ docker run -e HZ_LICENSE_KEY=<your_license_key> hazelcast/hazelcast-enterprise
 ```
 
+### TLS_ENABLED (Hazelcast Enterprise Only)
+
+The `TLS_ENABLED` environment variable can be used to enable TLS for the communication. The key material folder should be mounted and properly referenced by using `JAVA_OPTS` variable
+
+```bash
+# generate a sample key material to the current folder (self-signed certificate)
+keytool -validity 365 -genkeypair -alias server -keyalg EC -keystore server.keystore -storepass 123456 -keypass 123456 -dname CN=localhost
+keytool -export -alias server -keystore server.keystore -storepass 123456 -file server.crt
+keytool -import -noprompt -alias server -keystore server.truststore -storepass 123456 -file server.crt
+
+# run Hazelcast Enterprise with TLS enabled
+docker run -v `pwd`:/keystore -e HZ_LICENSE_KEY=<your_license_key> \
+    -e TLS_ENABLED=true \
+    -e "JAVA_OPTS=-Djavax.net.ssl.keyStore=/keystore/server.keystore -Djavax.net.ssl.keyStorePassword=123456 -Djavax.net.ssl.trustStore=/keystore/server.truststore -Djavax.net.ssl.trustStorePassword=123456" \
+    hazelcast/hazelcast-enterprise
+```
+
+
 ## Customizing Hazelcast
 
 ### Using Custom Hazelcast Configuration File

--- a/hazelcast-enterprise/hazelcast.xml
+++ b/hazelcast-enterprise/hazelcast.xml
@@ -21,4 +21,7 @@
 
   <management-center enabled="${hazelcast.mancenter.enabled}">${hazelcast.mancenter.url}</management-center>
 
+  <network>
+    <ssl enabled="${hazelcast.tls.enabled}" />
+  </network>
 </hazelcast>

--- a/hazelcast-enterprise/start-hazelcast.sh
+++ b/hazelcast-enterprise/start-hazelcast.sh
@@ -48,6 +48,8 @@ else
   set -u 
 fi
 
+export JAVA_OPTS="${JAVA_OPTS} -Dhazelcast.tls.enabled=${TLS_ENABLED:-false}"
+
 echo "########################################"
 echo "# JAVA_OPTS=${JAVA_OPTS}"
 echo "# CLASSPATH=${CLASSPATH}"


### PR DESCRIPTION
This PR allows using TLS without a need to build a custom image.

The change is related to #117 and hazelcast/management-center-docker#15.