### PR TITLE
Improve Container Memory Limits support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,17 @@ docker run -v `pwd`:/keystore -e HZ_LICENSE_KEY=<your_license_key> \
     hazelcast/hazelcast-enterprise
 ```
 
-
 ## Customizing Hazelcast
+
+### Memory
+
+Hazelcast Docker image respects the container memory limits, so you can specify it with the `-m` parameter.
+
+```
+$ docker run -m 512M hazelcast/hazelcast:$HAZELCAST_VERSION
+```
+
+Note that by default Hazelcast uses up to 80% of the container memory limit, but you can configure it by adding `-XX:MaxRAMPercentage` to the `JAVA_OPTS` variable.
 
 ### Using Custom Hazelcast Configuration File
 

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -16,7 +16,7 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     HZ_LICENSE_KEY="" \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -14,7 +14,7 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     MANCENTER_URL="" \


### PR DESCRIPTION
Changes:
- Set the default heap size as 80% of the total container memory size (before it was the default value 25%, which is way too low)
- Document usage of the container memory limits