### PR TITLE
Remove MAX_HEAP_SIZE and MIN_HEAP_SIZE variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,6 @@ Read more about the Management Center image [here](https://github.com/hazelcast/
 
 ## Hazelcast Defined Environment Variables
 
-### MAX_HEAP_SIZE
-
-You can give environment variables to the Hazelcast member within your Docker command. Currently, we support the variables  `MIN_HEAP_SIZE` and `MAX_HEAP_SIZE` inside our start script. An example command is as follows:
-
-```
-$ docker run -e MIN_HEAP_SIZE="1g" hazelcast/hazelcast
-```
-
 ### JAVA_OPTS
 
 As shown below, you can use `JAVA_OPTS` environment variable if you need to pass multiple VM arguments to your Hazelcast member.

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -17,8 +17,6 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
     JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties" \
-    MIN_HEAP_SIZE="" \
-    MAX_HEAP_SIZE="" \
     HZ_LICENSE_KEY="" \
     MANCENTER_URL="" \
     PROMETHEUS_PORT="" \

--- a/hazelcast-enterprise/start-hazelcast.sh
+++ b/hazelcast-enterprise/start-hazelcast.sh
@@ -17,14 +17,6 @@ else
   export JAVA_OPTS="${JAVA_OPTS_DEFAULT}"
 fi
 
-if [ -n "${MIN_HEAP_SIZE}" ]; then
-  export JAVA_OPTS="-Xms${MIN_HEAP_SIZE} ${JAVA_OPTS}"
-fi
-
-if [ -n "${MAX_HEAP_SIZE}" ]; then
-  export JAVA_OPTS="-Xmx${MAX_HEAP_SIZE} ${JAVA_OPTS}"
-fi
-
 if [ -n "${MANCENTER_URL}" ]; then
   export JAVA_OPTS="-Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL} ${JAVA_OPTS}"
 else

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -15,8 +15,6 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
     JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties" \
-    MIN_HEAP_SIZE="" \
-    MAX_HEAP_SIZE="" \
     MANCENTER_URL="" \
     PROMETHEUS_PORT="" \
     PROMETHEUS_CONFIG="${HZ_HOME}/jmx_agent_config.yaml" \

--- a/hazelcast-oss/start-hazelcast.sh
+++ b/hazelcast-oss/start-hazelcast.sh
@@ -17,14 +17,6 @@ else
   export JAVA_OPTS="${JAVA_OPTS_DEFAULT}"
 fi
 
-if [ -n "${MIN_HEAP_SIZE}" ]; then
-  export JAVA_OPTS="-Xms${MIN_HEAP_SIZE} ${JAVA_OPTS}"
-fi
-
-if [ -n "${MAX_HEAP_SIZE}" ]; then
-  export JAVA_OPTS="-Xmx${MAX_HEAP_SIZE} ${JAVA_OPTS}"
-fi
-
 if [ -n "${MANCENTER_URL}" ]; then
   export JAVA_OPTS="-Dhazelcast.mancenter.enabled=true -Dhazelcast.mancenter.url=${MANCENTER_URL} ${JAVA_OPTS}"
 else


### PR DESCRIPTION
fix #113 

Since this change is non-backward compatible, I'd merge it together with the `4.0` release.