### PR TITLE
Upgrade to Java 11

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.11
 
 # Versions of Hazelcast and Hazelcast plugins
 ARG HZ_VERSION=3.12.5
@@ -16,7 +16,7 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     HZ_LICENSE_KEY="" \
@@ -36,7 +36,7 @@ COPY *.xml *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 RUN echo "Updating Alpine system" \
     && apk upgrade --update-cache --available \
     && echo "Installing new APK packages" \
-    && apk add openjdk8-jre maven bash apr openssl curl procps nss \
+    && apk add openjdk11-jre maven bash apr openssl curl procps nss \
     && echo "Installing Hazelcast" \
     && cd "${HZ_HOME}" \
     && mkdir lib \

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -16,7 +16,7 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 -XX:+UseParallelGC --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 -XX:+UseParallelGC --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     HZ_LICENSE_KEY="" \

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -16,7 +16,7 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 -XX:+UseParallelGC --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 -XX:+UseParallelGC --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     HZ_LICENSE_KEY="" \

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -16,7 +16,7 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 -XX:+UseParallelGC --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     HZ_LICENSE_KEY="" \

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -5,8 +5,8 @@ ARG HZ_VERSION=3.12.5
 ARG CACHE_API_VERSION=1.1.0
 ARG HZ_EUREKA_VERSION=1.1.1
 ARG JMX_PROMETHEUS_AGENT_VERSION=0.11.0
-ARG NETTY_VERSION=4.1.32.Final
-ARG NETTY_TCNATIVE_VERSION=2.0.20.Final
+ARG NETTY_VERSION=4.1.44.Final
+ARG NETTY_TCNATIVE_VERSION=2.0.28.Final
 
 # Build constants
 ARG HZ_HOME="/opt/hazelcast"
@@ -16,7 +16,7 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     HZ_LICENSE_KEY="" \
@@ -36,7 +36,9 @@ COPY *.xml *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 RUN echo "Updating Alpine system" \
     && apk upgrade --update-cache --available \
     && echo "Installing new APK packages" \
-    && apk add openjdk11-jre maven bash apr openssl curl procps nss \
+    && apk add openjdk11-jre maven bash apr curl procps nss \
+    && echo "Installing old OpenSSL 1.0 from Alpine 3.8" \
+    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.8/main/ openssl=1.0.2u-r0 \
     && echo "Installing Hazelcast" \
     && cd "${HZ_HOME}" \
     && mkdir lib \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -14,7 +14,7 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 -XX:+UseParallelGC --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     MANCENTER_URL="" \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -14,7 +14,7 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 -XX:+UseParallelGC --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 -XX:+UseParallelGC --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     MANCENTER_URL="" \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.11
 
 # Versions of Hazelcast and Hazelcast plugins
 ARG HZ_VERSION=3.12.5
@@ -14,7 +14,7 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     MANCENTER_URL="" \
@@ -33,7 +33,7 @@ COPY *.xml *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 RUN echo "Updating Alpine system" \
     && apk upgrade --update-cache --available \
     && echo "Installing new APK packages" \
-    && apk add openjdk8-jre maven bash curl procps nss \
+    && apk add openjdk11-jre maven bash curl procps nss \
     && echo "Installing Hazelcast" \
     && cd "${HZ_HOME}" \
     && mkdir lib \


### PR DESCRIPTION
Update to Java 11 and Alpine 3.11.

Comparison of image sizes

|                    | Java 8 (current) | Java 11 (this PR) |
|--------------|------------------|-------------------|
| hazelcast    |   78.97 MB         | 91.33 MB                        |
| hazelcast-enterprise |  85.28 MB  | 97.85 MB |

**Pros** of moving to Java 11:
- Keeping image up to date
- Using new features from Java 11 (like better GC, faster TLS)

**Cons** of moving to Java 11:
- (slightly) bigger docker images
- Non-backwards-compatibility in terms of Java internals
- (Alpine Linux version related) Netty-tcnative is compiled against the old (1.0.0) version of `libssl` which is not included in Alpine 3.9 and newer. We would need to use a version from Alpine 3.8.

------------------------------------------------------

[**archived below**] Issues already solved thanks to @kwart

I try to upgrade Alpine version and Java version, but I have a problem with OpenSSL. It fails with the exception below. The issue is with Alpine upgrade. It's fails even if I just upgraded Alpine to `11` and kept Java 8.

@kwart you're an expert here, could you help?

```
Exception in thread "main" java.lang.UnsatisfiedLinkError: failed to load the required native library
        at io.netty.handler.ssl.OpenSsl.ensureAvailability(OpenSsl.java:474)
        at com.hazelcast.nio.ssl.OpenSSLEngineFactory.init(OpenSSLEngineFactory.java:76)
        at com.hazelcast.nio.ssl.AbstractTLSChannelInitializer.loadSSLEngineFactory(AbstractTLSChannelInitializer.java:47)
        at com.hazelcast.nio.ssl.AbstractTLSChannelInitializer.<init>(AbstractTLSChannelInitializer.java:25)
        at com.hazelcast.nio.ssl.UnifiedTLSChannelInitializer.<init>(UnifiedTLSChannelInitializer.java:51)
        at com.hazelcast.nio.EnterpriseChannelInitializerProvider.createUnifiedTlsChannelInitializer(EnterpriseChannelInitializerProvider.java:94)
        at com.hazelcast.nio.EnterpriseChannelInitializerProvider.<init>(EnterpriseChannelInitializerProvider.java:37)
        at com.hazelcast.instance.EnterpriseNodeExtension.createChannelInitializerProvider(EnterpriseNodeExtension.java:615)
        at com.hazelcast.instance.DefaultNodeContext.createNetworkingService(DefaultNodeContext.java:155)
        at com.hazelcast.instance.Node.<init>(Node.java:248)
        at com.hazelcast.instance.HazelcastInstanceImpl.createNode(HazelcastInstanceImpl.java:161)
        at com.hazelcast.instance.HazelcastInstanceImpl.<init>(HazelcastInstanceImpl.java:131)
        at com.hazelcast.instance.HazelcastInstanceFactory.constructHazelcastInstance(HazelcastInstanceFactory.java:228)
        at com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:207)
        at com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:157)
        at com.hazelcast.core.Hazelcast.newHazelcastInstance(Hazelcast.java:91)
        at com.hazelcast.core.server.StartServer.main(StartServer.java:46)
Caused by: java.lang.IllegalArgumentException: Failed to load any of the given libraries: [netty_tcnative_linux_x86_64, netty_tcnative_linux_x86_64_fedora, netty_tcnative_x86_64, netty_tcnative]
        at io.netty.util.internal.NativeLibraryLoader.loadFirstAvailable(NativeLibraryLoader.java:104)
        at io.netty.handler.ssl.OpenSsl.loadTcNative(OpenSsl.java:581)
        at io.netty.handler.ssl.OpenSsl.<clinit>(OpenSsl.java:133)
        ... 16 more
        Suppressed: java.lang.UnsatisfiedLinkError: could not load a native library: netty_tcnative_linux_x86_64
                at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:224)
                at io.netty.util.internal.NativeLibraryLoader.loadFirstAvailable(NativeLibraryLoader.java:96)
                ... 18 more
        Caused by: java.io.FileNotFoundException: META-INF/native/libnetty_tcnative_linux_x86_64.so
                at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:173)
                ... 19 more
                Suppressed: java.lang.UnsatisfiedLinkError: no netty_tcnative_linux_x86_64 in java.library.path: [/usr/lib/jvm/java-11-openjdk/lib/server, /usr/lib/jvm/java-11-openjdk/lib, /usr/lib/jvm/java-11-openjdk/../lib, /usr/java/packages/lib, /usr/lib64, /lib64, /lib, /usr/lib]
                        at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2660)
                        at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:829)
                        at java.base/java.lang.System.loadLibrary(System.java:1870)
                        at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:38)
                        at io.netty.util.internal.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:349)
                        at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:136)
                        ... 19 more
                        Suppressed: java.lang.UnsatisfiedLinkError: no netty_tcnative_linux_x86_64 in java.library.path: [/usr/lib/jvm/java-11-openjdk/lib/server, /usr/lib/jvm/java-11-openjdk/lib, /usr/lib/jvm/java-11-openjdk/../lib, /usr/java/packages/lib, /usr/lib64, /lib64, /lib, /usr/lib]
                                at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2660)
                                at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:829)
                                at java.base/java.lang.System.loadLibrary(System.java:1870)
                                at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:38)
                                at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
                                at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
                                at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
                                at java.base/java.lang.reflect.Method.invoke(Method.java:566)
                                at io.netty.util.internal.NativeLibraryLoader$1.run(NativeLibraryLoader.java:369)
                                at java.base/java.security.AccessController.doPrivileged(Native Method)
                                at io.netty.util.internal.NativeLibraryLoader.loadLibraryByHelper(NativeLibraryLoader.java:361)
                                at io.netty.util.internal.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:339)
                                ... 20 more
```