### PR TITLE
WIP Allow to define logging format and class via env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,24 @@ $ docker run -e LOGGING_LEVEL=FINEST hazelcast/hazelcast
 
 Available logging levels are (from highest to lowest): `SEVERE`, `WARNING`, `INFO`, `CONFIG`, `FINE`, `FINER`, and `FINEST`. The default logging level is `INFO`.
 
+### LOGGING_FORMAT
+The logging output format can be changed using `LOGGING_FORMAT` variable. For example:
+
+```
+$ docker run -e LOGGING_FORMAT="%4\$s: %5\$s [%1\$tc]%n" hazelcast/hazelcast
+```
+
+Note that if you use special characters, you should escape them, e.g. $ should be escaped to \\$
+
+### LOGGING_FORMATTER
+The logging formatter class can be changed using `LOGGING_FORMATTER` variable, for example, to have console output in xml format:
+
+```
+$ docker run -e LOGGING_FORMATTER="java.util.logging.XMLFormatter" hazelcast/hazelcast
+```
+
+By default, available formatters are: `java.util.logging.SimpleFormatter` and `java.util.logging.XMLFormatter`.
+
 Note that if you need some more custom logging configuration, you can configure the `logging.properties` file and build your own Hazelcast image.
 
 ### HZ_LICENSE_KEY (Hazelcast Enterprise Only)

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -24,6 +24,8 @@ ENV HZ_HOME="${HZ_HOME}" \
     PROMETHEUS_PORT="" \
     PROMETHEUS_CONFIG="${HZ_HOME}/jmx_agent_config.yaml" \
     LOGGING_LEVEL="" \
+    LOGGING_FORMATTER="" \
+    LOGGING_FORMAT="" \
     CLASSPATH="" \
     JAVA_OPTS=""
 

--- a/hazelcast-enterprise/start-hazelcast.sh
+++ b/hazelcast-enterprise/start-hazelcast.sh
@@ -39,6 +39,12 @@ if [ -n "${LOGGING_LEVEL}" ]; then
   sed -i "s/java.util.logging.ConsoleHandler.level = INFO/java.util.logging.ConsoleHandler.level = ${LOGGING_LEVEL}/g" logging.properties
   sed -i "s/.level= INFO/.level= ${LOGGING_LEVEL}/g" logging.properties
 fi
+if [ -n "${LOGGING_FORMATTER}" ]; then
+  sed -i -E "s/(java.util.logging.ConsoleHandler.formatter) = (.+)/\1 = ${LOGGING_FORMATTER}/g" logging.properties
+fi
+if [ -n "${LOGGING_FORMAT}" ]; then
+  sed -i -E "s/(# )*(java.util.logging.SimpleFormatter.format)=(.+)/${LOGGING_FORMATTER:-java.util.logging.SimpleFormatter}.format=${LOGGING_FORMAT}/g" logging.properties
+fi
 
 if [ -n "${HZ_LICENSE_KEY}" ]; then
   export JAVA_OPTS="${JAVA_OPTS} -Dhazelcast.enterprise.license.key=${HZ_LICENSE_KEY}"

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -21,6 +21,8 @@ ENV HZ_HOME="${HZ_HOME}" \
     PROMETHEUS_PORT="" \
     PROMETHEUS_CONFIG="${HZ_HOME}/jmx_agent_config.yaml" \
     LOGGING_LEVEL="" \
+    LOGGING_FORMATTER="" \
+    LOGGING_FORMAT="" \
     CLASSPATH="" \
     JAVA_OPTS=""
 

--- a/hazelcast-oss/start-hazelcast.sh
+++ b/hazelcast-oss/start-hazelcast.sh
@@ -39,6 +39,12 @@ if [ -n "${LOGGING_LEVEL}" ]; then
   sed -i "s/java.util.logging.ConsoleHandler.level = INFO/java.util.logging.ConsoleHandler.level = ${LOGGING_LEVEL}/g" logging.properties
   sed -i "s/.level= INFO/.level= ${LOGGING_LEVEL}/g" logging.properties
 fi
+if [ -n "${LOGGING_FORMATTER}" ]; then
+  sed -i -E "s/(java.util.logging.ConsoleHandler.formatter) = (.+)/\1 = ${LOGGING_FORMATTER}/g" logging.properties
+fi
+if [ -n "${LOGGING_FORMAT}" ]; then
+  sed -i -E "s/(# )*(java.util.logging.SimpleFormatter.format)=(.+)/${LOGGING_FORMATTER:-java.util.logging.SimpleFormatter}.format=${LOGGING_FORMAT}/g" logging.properties
+fi
 
 echo "########################################"
 echo "# JAVA_OPTS=${JAVA_OPTS}"


### PR DESCRIPTION
It is hard to override default logging output format without building new image.
In theory, it can be done by passing format string as system property to `JAVA_OPTS` variable,
but since the format often contains whitespaces and $ sign and `JAVA_OPTS` is passed through `eval` and at then end it is expanded in `exec` without double quotes, it is extremely hard to make it passing properly.