### PR TITLE
Corrected classpath environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ $ docker run -e JAVA_OPTS="-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcas
 Hazelcast has several extension points i.e MapStore API where you can provide your own implementation to add specific functionality into Hazelcast Cluster. If you have custom jars or files to put into classpath of docker container, you can simply use `CLASSPATH` environment variable and pass it via `docker run` command. Please see the following example:
 
 ```
-$ docker run -e CLASSPATH="/opt/hazelcast/CLASSPATH_EXT/" -v PATH_TO_LOCAL_CONFIG_FOLDER:/opt/hazelcast/CLASSPATH_EXT hazelcast/hazelcast
+$ docker run -e CLASSPATH="/opt/hazelcast/CLASSPATH_EXT/*" -v PATH_TO_LOCAL_CONFIG_FOLDER:/opt/hazelcast/CLASSPATH_EXT hazelcast/hazelcast
 ```
 
 ### Extending Hazelcast Base Image


### PR DESCRIPTION
The environment variable needs a * after it to get all the files that come from the CLASSPATH_EXT directory.