### PR TITLE
Add Jenkinsfile for the release automation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
             steps {
                 dir("./hazelcast-oss") {
                     script {
-                        sh "docker buildx build -t leszko/hazelcast:${HAZELCAST_DOCKER_TAG} --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x . --push"
+                        sh "docker buildx build -t hazelcast/hazelcast:${HAZELCAST_DOCKER_TAG} --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x . --push"
                     }
 
                 }
@@ -32,7 +32,7 @@ pipeline {
             steps {
                 dir("./hazelcast-enterprise") {
                     script {
-                        sh "docker buildx build -t leszko/hazelcast-enterprise:${HAZELCAST_DOCKER_TAG} --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x . --push"
+                        sh "docker buildx build -t hazelcast/hazelcast-enterprise:${HAZELCAST_DOCKER_TAG} --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x . --push"
                     }
 
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,42 @@
+pipeline {
+    agent {
+        node {
+            label 'multi-arch-docker-release'
+            customWorkspace "${JOB_NAME}/${BUILD_NUMBER}"
+        }
+    }
+
+    parameters {
+        string(name: 'HAZELCAST_DOCKER_TAG', description: 'Hazelcast Docker Tag')
+    }
+
+    stages {
+        stage('Log into Docker Hub') {
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'devopshazelcast-dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                    sh "docker login --username ${USERNAME} --password ${PASSWORD}"
+                }
+            }
+        }
+        stage('Build and push "hazelcast/hazelcast" image') {
+            steps {
+                dir("./hazelcast-oss") {
+                    script {
+                        sh "docker buildx build -t leszko/hazelcast:${HAZELCAST_DOCKER_TAG} --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x . --push"
+                    }
+
+                }
+            }
+        }
+        stage('Build and push "hazelcast/hazelcast-enterprise"') {
+            steps {
+                dir("./hazelcast-enterprise") {
+                    script {
+                        sh "docker buildx build -t leszko/hazelcast-enterprise:${HAZELCAST_DOCKER_TAG} --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x . --push"
+                    }
+
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Docker image release automation.

Before the images were built by the Docker Hub automation, but it does not support multi-arch builds, so we need to automate it ourselves.

- I've already turned-off [Docker Hub Automation](https://hub.docker.com/repository/docker/hazelcast/hazelcast/builds) (so the images won't be built after every tag pushed to the repository)
- @lazerion @hasancelik could I ask you to add a trigger for the [hazelcast-docker-release pipeline](http://jenkins.hazelcast.com/view/Plugin%20Release/job/hazelcast-docker-release/)? It should be triggered after you released a new version of Hazelcast and after you pushed a new tag to [hazelcast/hazelcast-docker](url) repository. The pipeline has one parameter `HAZELCAST_DOCKER_TAG` and it should be the Hazelcast version (like the tag name, but without `v` at the beginning), for example: `4.0.1`
- I'll add a similar pipeline for `hazelcast-openshift`, but we need first to solve the issue with publishing multi-arch images to Red Hat Registry, so no changes there for now
- I'll extend this `Jenkinsfile` with tests and failure mail notifications in a separate PR. For now, I'd like to have exactly what we had with the use of Docker Hub automation