### PR TITLE
Deploy Github Actions for latest and tag based images

### DIFF
--- a/.github/workflows/latest_image_push.yml
+++ b/.github/workflows/latest_image_push.yml
@@ -15,8 +15,8 @@ jobs:
         id: buildx
         uses: crazy-max/ghaction-docker-buildx@v1
         with:
-          buildx-version: latest
-          qemu-version: latest
+          buildx-version: v0.4.1
+          qemu-version: 4.2.0-7
 
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin

--- a/.github/workflows/latest_image_push.yml
+++ b/.github/workflows/latest_image_push.yml
@@ -1,0 +1,33 @@
+name: Build latest OS and EE image
+
+on:
+  push:
+    branches: enhancement/github-actions
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          buildx-version: latest
+          qemu-version: latest
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build/Push OSS image
+        run: |
+          docker buildx build --push \
+            --tag hasancelik/hazelcast:latest \
+            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
+      - name: Build/Push EE image
+        run: |
+          docker buildx build --push \
+            --tag hasancelik/hazelcast-enterprise:latest \
+            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise

--- a/.github/workflows/latest_image_push.yml
+++ b/.github/workflows/latest_image_push.yml
@@ -2,7 +2,7 @@ name: Build latest OS and EE image
 
 on:
   push:
-    branches: enhancement/github-actions
+    branches: master
 
 jobs:
   build:
@@ -24,10 +24,10 @@ jobs:
       - name: Build/Push OSS image
         run: |
           docker buildx build --push \
-            --tag hasancelik/hazelcast:latest \
+            --tag hazelcast/hazelcast:latest \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
       - name: Build/Push EE image
         run: |
           docker buildx build --push \
-            --tag hasancelik/hazelcast-enterprise:latest \
+            --tag hazelcast/hazelcast-enterprise:latest \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -32,10 +32,10 @@ jobs:
       - name: Build/Push OSS image
         run: |
           docker buildx build --push \
-            --tag hasancelik/hazelcast:${{ env.RELEASE_VERSION }} \
+            --tag hazelcast/hazelcast:${{ env.RELEASE_VERSION }} \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
       - name: Build/Push EE image
         run: |
           docker buildx build --push \
-            --tag hasancelik/hazelcast-enterprise:${{ env.RELEASE_VERSION }} \
+            --tag hazelcast/hazelcast-enterprise:${{ env.RELEASE_VERSION }} \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -16,15 +16,14 @@ jobs:
         run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF:11}
       - name: Print Release Version
         run: |
-          echo $RELEASE_VERSION
           echo ${{ env.RELEASE_VERSION }}
 
       - name: Set up Docker Buildx
         id: buildx
         uses: crazy-max/ghaction-docker-buildx@v1
         with:
-          buildx-version: latest
-          qemu-version: latest
+          buildx-version: v0.4.1
+          qemu-version: 4.2.0-7
 
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -1,0 +1,41 @@
+name: Build OS and EE image
+
+on:
+  create:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set Release Version
+        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF:11}
+      - name: Print Release Version
+        run: |
+          echo $RELEASE_VERSION
+          echo ${{ env.RELEASE_VERSION }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          buildx-version: latest
+          qemu-version: latest
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build/Push OSS image
+        run: |
+          docker buildx build --push \
+            --tag hasancelik/hazelcast:${{ env.RELEASE_VERSION }} \
+            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
+      - name: Build/Push EE image
+        run: |
+          docker buildx build --push \
+            --tag hasancelik/hazelcast-enterprise:${{ env.RELEASE_VERSION }} \
+            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise


### PR DESCRIPTION
You can check tags and build logs that are created by my test setup:
https://hub.docker.com/r/hasancelik/hazelcast/tags
https://github.com/hasancelik/hazelcast-docker/runs/695486717?check_suite_focus=true
https://github.com/hasancelik/hazelcast-docker/runs/695514272?check_suite_focus=true

Github Actions does not provide multi-arch environments for now but probably this feature will be addressed at a certain point. When they start to support it, we can convert [our existing Travis CI based PR](https://github.com/hazelcast/hazelcast-docker/blob/master/.travis.yml) builder to Github Actions:
https://github.community/t5/GitHub-Actions/Testing-against-multiple-architectures/td-p/40265