### PR TITLE
Add vulnerability scanning

### DIFF
--- a/.github/workflows/latest_image_push.yml
+++ b/.github/workflows/latest_image_push.yml
@@ -31,3 +31,20 @@ jobs:
           docker buildx build --push \
             --tag hazelcast/hazelcast-enterprise:latest \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise
+
+      - name: Scan Hazelcast image by Azure (Trivy + Dockle)
+        uses: Azure/container-scan@v0
+        with:
+          image-name: hazelcast/hazelcast:latest
+      - name: Scan Hazelcast image by Anchore
+        uses: anchore/scan-action@v1
+        with:
+          image-reference: hazelcast/hazelcast:latest
+      - name: Scan Hazelcast Enterprise image by Azure (Trivy + Dockle)
+        uses: Azure/container-scan@v0
+        with:
+          image-name: hazelcast/hazelcast-enterprise:latest
+      - name: Scan Hazelcast Enterprise image by Anchore
+        uses: anchore/scan-action@v1
+        with:
+          image-reference: hazelcast/hazelcast-enterprise:latest

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -38,3 +38,20 @@ jobs:
           docker buildx build --push \
             --tag hazelcast/hazelcast-enterprise:${{ env.RELEASE_VERSION }} \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise
+
+      - name: Scan Hazelcast image by Azure (Trivy + Dockle)
+        uses: Azure/container-scan@v0
+        with:
+          image-name: hazelcast/hazelcast:${{ env.RELEASE_VERSION }}
+      - name: Scan Hazelcast image by Anchore
+        uses: anchore/scan-action@v1
+        with:
+          image-reference: hazelcast/hazelcast:${{ env.RELEASE_VERSION }}
+      - name: Scan Hazelcast Enterprise image by Azure (Trivy + Dockle)
+        uses: Azure/container-scan@v0
+        with:
+          image-name: hazelcast/hazelcast-enterprise:${{ env.RELEASE_VERSION }}
+      - name: Scan Hazelcast Enterprise image by Anchore
+        uses: anchore/scan-action@v1
+        with:
+          image-reference: hazelcast/hazelcast-enterprise:${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
Scanning Docker images by vulnerability scanners.

Sample output: https://github.com/leszko/hazelcast-docker/runs/939978581

Note that they just print the information and won't prevent the images from the building.

We need 2 separate scanners, because:
- Azure detects better for some Code Style issues
- Anchore detects the jars with vulnerabilities