### PR TITLE
Fix Dockerfile vulnerabilities

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,0 +1,4 @@
+general:
+  bestPracticeViolations:
+    # HZ_LICENSE_KEY included as an env variable
+    - CIS-DI-0010

--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -2,3 +2,5 @@ general:
   bestPracticeViolations:
     # HZ_LICENSE_KEY included as an env variable
     - CIS-DI-0010
+    # We don't sign Hazelcast Docker images
+    - CIS-DI-0005

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -39,10 +39,8 @@ EXPOSE 5701
 COPY *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
-RUN echo "Updating Alpine system" \
-    && apk upgrade --update-cache --available \
-    && echo "Installing new APK packages" \
-    && apk add openjdk11-jre bash apr curl procps nss \
+RUN echo "Installing new APK packages" \
+    && apk add --no-cache openjdk11-jre bash apr curl procps nss \
     && echo "Installing old OpenSSL 1.0 from Alpine 3.8" \
     && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.8/main/ openssl=1.0.2u-r0 \
     && echo "Downloading Hazelcast and related JARs" \
@@ -58,6 +56,9 @@ RUN echo "Updating Alpine system" \
     && rm -rf /var/cache/apk/*
 
 WORKDIR ${HZ_HOME}
+
+RUN addgroup -S hazelcast && adduser -S hazelcast -G hazelcast
+USER hazelcast
 
 # Start Hazelcast server
 CMD ["/opt/hazelcast/start-hazelcast.sh"]

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -33,10 +33,8 @@ EXPOSE 5701
 COPY *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
-RUN echo "Updating Alpine system" \
-    && apk upgrade --update-cache --available \
-    && echo "Installing new APK packages" \
-    && apk add openjdk11-jre bash curl procps nss \
+RUN echo "Installing new APK packages" \
+    && apk add --no-cache openjdk11-jre bash curl procps nss \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \
@@ -50,6 +48,9 @@ RUN echo "Updating Alpine system" \
     && rm -rf /var/cache/apk/*
 
 WORKDIR ${HZ_HOME}
+
+RUN addgroup -S hazelcast && adduser -S hazelcast -G hazelcast
+USER hazelcast
 
 # Start Hazelcast server
 CMD ["/opt/hazelcast/start-hazelcast.sh"]


### PR DESCRIPTION
Fix vulnerabilities:
- [DKL-DI-0003](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0003): Avoid apt-get/apk/dist-upgrade
- [DKL-DI-0004](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0004): Use apk add with --no-cache
- [CIS-DI-0001](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#cis-di-0001): Create a user for the container

Whitelist vulnerabilities:
- [CIS-DI-0005](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#cis-di-0005): We don't want to use `docker trust` for now
- [CIS-DI-0010](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#cis-di-0010): We still want to have `HZ_ENTERPRISE_KEY` as an env variable for the sake of simplicity and backward-compatibility

Still to fix:
- [CIS-DI-0006](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#cis-di-0006): Healthcheck, I think we'll introduce it after [hazelcast/hazelcast/pull/17348](https://github.com/hazelcast/hazelcast/pull/17348), I don't want to introduce `hazeclast.yaml` enabling HEALTH REST endpoints, just to satisfy this comment