### PR TITLE
Upgrade openssl version.

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -42,9 +42,7 @@ COPY *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Installing new APK packages" \
-    && apk add --no-cache openjdk11-jre bash apr curl procps nss \
-    && echo "Installing old OpenSSL 1.0 from Alpine 3.8" \
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.8/main/ openssl=1.0.2u-r0 \
+    && apk add --no-cache openjdk11-jre bash apr curl procps nss openssl \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \


### PR DESCRIPTION
Upgrades openssl version to 1.1.1g-r0 as suggested by the vulnerability [check](https://github.com/hazelcast/hazelcast-docker/runs/1209332122). (default version at alpine:3.11 pkg [repo](https://pkgs.alpinelinux.org/package/v3.11/main/x86_64/openssl))

I see the discussions made here at #126. But I didn't see any problem with the given example in README:
```
docker run -v `pwd`:/keystore -e HZ_LICENSE_KEY=<your_license_key> \
    -e TLS_ENABLED=true \
    -e "JAVA_OPTS=-Djavax.net.ssl.keyStore=/keystore/server.keystore -Djavax.net.ssl.keyStorePassword=123456 -Djavax.net.ssl.trustStore=/keystore/server.truststore -Djavax.net.ssl.trustStorePassword=123456" \
    hazelcast/hazelcast-enterprise
```

as members form a cluster succesfully. Is there another way to reproduce the case you reported in the PR @leszko?