### PR TITLE
Remove PR builder trigger.

### DIFF
--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -1,8 +1,6 @@
 name: Vulnerability Scan
 
 on:
-  pull_request:
-    branches: master
   schedule:
     - cron: '0 2 * * *'
 


### PR DESCRIPTION
Snyk authentication fails for PRs on `on: pull_request` action due to the missing token hence has no effect but blocks merging. The secret might be visible to fork PRs when `on: pull_request_target` is used instead (see https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target). 