### PR TITLE
Ignore vulnerabilities from libssl 1.0

### DIFF
--- a/.github/containerscan/.snyk
+++ b/.github/containerscan/.snyk
@@ -1,0 +1,43 @@
+version: v1.5.0
+ignore:
+  SNYK-ALPINE311-OPENSSL-544606:
+    - '*':
+        reason: "netty-tcnative requires libssl 1.0"
+        expires: 2021-01-15T00:00:00.000Z
+
+  SNYK-ALPINE311-OPENSSL-544707:
+    - '*':
+        reason: "netty-tcnative requires libssl 1.0"
+        expires: 2021-01-15T00:00:00.000Z
+
+  SNYK-ALPINE311-OPENSSL-544851:
+    - '*':
+        reason: "netty-tcnative requires libssl 1.0"
+        expires: 2021-01-15T00:00:00.000Z
+        
+  SNYK-ALPINE311-OPENSSL-544897:
+    - '*':
+        reason: "netty-tcnative requires libssl 1.0"
+        expires: 2021-01-15T00:00:00.000Z
+
+  SNYK-ALPINE311-OPENSSL-544988:
+    - '*':
+        reason: "netty-tcnative requires libssl 1.0"
+        expires: 2021-01-15T00:00:00.000Z
+
+  SNYK-ALPINE311-OPENSSL-545412:
+    - '*':
+        reason: "netty-tcnative requires libssl 1.0"
+        expires: 2021-01-15T00:00:00.000Z
+
+  SNYK-ALPINE311-OPENSSL-545889:
+    - '*':
+        reason: "netty-tcnative requires libssl 1.0"
+        expires: 2021-01-15T00:00:00.000Z
+
+  SNYK-ALPINE311-OPENSSL-587980:
+    - '*':
+        reason: "netty-tcnative requires libssl 1.0"
+        expires: 2021-01-15T00:00:00.000Z
+
+patch: {}

--- a/.github/workflows/latest_image_push.yml
+++ b/.github/workflows/latest_image_push.yml
@@ -46,7 +46,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: hazelcast/hazelcast:latest
-          args: --file=hazelcast-oss/Dockerfile
+          args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan
       - name: Scan Hazelcast Enterprise image by Azure (Trivy + Dockle)
         uses: Azure/container-scan@v0
         with:
@@ -61,4 +61,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: hazelcast/hazelcast-enterprise:latest
-          args: --file=hazelcast-enterprise/Dockerfile
+          args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -53,7 +53,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: hazelcast/hazelcast:${{ env.RELEASE_VERSION }}
-          args: --file=hazelcast-oss/Dockerfile
+          args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan
       - name: Scan Hazelcast Enterprise image by Azure (Trivy + Dockle)
         uses: Azure/container-scan@v0
         with:
@@ -68,4 +68,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: hazelcast/hazelcast-enterprise:${{ env.RELEASE_VERSION }}
-          args: --file=hazelcast-enterprise/Dockerfile
+          args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -1,8 +1,6 @@
 name: Vulnerability Scan
 
 on:
-  pull_request:
-    branches: master
   schedule:
     - cron: '0 2 * * *'
 
@@ -37,7 +35,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: hazelcast/oss:${{ github.sha }}
-          args: --file=hazelcast-oss/Dockerfile
+          args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan
 
       - name: Scan EE image by Azure (Trivy + Dockle)
         uses: Azure/container-scan@v0
@@ -56,4 +54,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: hazelcast/ee:${{ github.sha }}
-          args: --file=hazelcast-enterprise/Dockerfile
+          args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -1,6 +1,8 @@
 name: Vulnerability Scan
 
 on:
+  pull_request_target:
+    branches: master
   schedule:
     - cron: '0 2 * * *'
 


### PR DESCRIPTION
**- Ignores libssl vulnerabilities for Snyk check for 3 months.** 
After this expires, we can try to upgrade openssl version if the latest is compatible or else extend the time period. See #171, #126.

**- Fixes PR builder** 
Uses `on: pull_request_target` to fix authentication problem caused by the missing secrets on fork builds.

~~**- Removes PR builder** 
Snyk authentication fails for PRs on `on: pull_request` action due to the missing token hence has no effect but blocks merging. The secret might be visible to fork PRs when `on: pull_request_target` is used instead (see [doc](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target)).~~