### PR TITLE
Ignore vulnerabilities from libssl 1.0

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,4 +1,8 @@
 general:
+  vulnerabilities:
+    # netty-tcnative still requires libssl 1.0
+    - CVE-2019-1543
+    - CVE-2020-1967
   bestPracticeViolations:
     # HZ_LICENSE_KEY included as an env variable
     - CIS-DI-0010


### PR DESCRIPTION
Adds the CVEs below to Azure checkers allowlist:
* CVE-2019-1543
* CVE-2020-1967

Note that these are previously reported ones by Snyk and already added to the ignore list of Snyk:

* https://snyk.io/vuln/SNYK-ALPINE311-OPENSSL-544988
* https://snyk.io/vuln/SNYK-ALPINE311-OPENSSL-587980

https://github.com/hazelcast/hazelcast-docker/blob/e2e50fb17867d23d1f9e250f829315a91c124bbb/.github/containerscan/.snyk#L23-L41


