### PR TITLE
[Backport] Add scheduled vulnerability check.

### DIFF
--- a/.github/workflows/backport_vulnerability_scan.yml
+++ b/.github/workflows/backport_vulnerability_scan.yml
@@ -1,4 +1,4 @@
-name: 3.12.z Vulnerability Scan
+name: Scheduled 3.12.z Vulnerability Scan
 
 # Since scheduled workflows run on the latest
 # commit on the default or base branch, this
@@ -7,9 +7,6 @@ name: 3.12.z Vulnerability Scan
 on:
   schedule:
     - cron: '0 2 * * *'
-  push: # TODO: remove
-    branches:
-      - '**'
 
 jobs:
   build:
@@ -44,7 +41,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: hazelcast/oss:${{ github.sha }}
-          args: --file=hazelcast-oss/Dockerfile
+          args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan
 
       - name: Scan EE image by Azure (Trivy + Dockle)
         uses: Azure/container-scan@v0
@@ -63,4 +60,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: hazelcast/ee:${{ github.sha }}
-          args: --file=hazelcast-enterprise/Dockerfile
+          args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/backport_vulnerability_scan.yml
+++ b/.github/workflows/backport_vulnerability_scan.yml
@@ -1,0 +1,66 @@
+name: 3.12.z Vulnerability Scan
+
+# Since scheduled workflows run on the latest
+# commit on the default or base branch, this
+# backport job is scheduled not on 3.12.z branch
+# but master.
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  push: # TODO: remove
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code at 3.12.z branch
+        uses: actions/checkout@v2
+        with:
+          ref: 3.12.z
+
+      - name: Build OSS image
+        run: |
+          docker build -t hazelcast/oss:${{ github.sha }} hazelcast-oss
+      - name: Build EE image
+        run: |
+          docker build -t hazelcast/ee:${{ github.sha }} hazelcast-enterprise
+
+      - name: Scan OSS image by Azure (Trivy + Dockle)
+        uses: Azure/container-scan@v0
+        with:
+          image-name: hazelcast/oss:${{ github.sha }}
+
+      - name: Scan OSS image by Anchore
+        uses: anchore/scan-action@v1
+        with:
+          image-reference: hazelcast/oss:${{ github.sha }}
+          fail-build: true
+
+      - name: Scan OSS image by Snyk
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: hazelcast/oss:${{ github.sha }}
+          args: --file=hazelcast-oss/Dockerfile
+
+      - name: Scan EE image by Azure (Trivy + Dockle)
+        uses: Azure/container-scan@v0
+        with:
+          image-name: hazelcast/ee:${{ github.sha }}
+
+      - name: Scan EE image by Anchore
+        uses: anchore/scan-action@v1
+        with:
+          image-reference: hazelcast/ee:${{ github.sha }}
+          fail-build: true
+
+      - name: Scan EE image by Snyk
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: hazelcast/ee:${{ github.sha }}
+          args: --file=hazelcast-enterprise/Dockerfile


### PR DESCRIPTION
Adds scheduled workflow for 3.12.z branch. Per [doc](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#schedule):
> Scheduled workflows run on the latest commit on the default or base branch

hence the flow is to be added to master. 

One drawback of this might be that any failure happening for this work will cause {:x:} to appear next to the latest master commit, although it's not related to.

Follows #184 up.