### PR TITLE
[Backport] Add vulnerability scan workflow.

### DIFF
--- a/.github/containerscan/.snyk
+++ b/.github/containerscan/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.0
+
+patch: {}

--- a/.github/workflows/vulnerability_check.yaml
+++ b/.github/workflows/vulnerability_check.yaml
@@ -1,0 +1,57 @@
+name: 3.12.z Vulnerability Scan
+
+on:
+  push:
+    branches:
+      - 3.12.z
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Build OSS image
+        run: |
+          docker build -t hazelcast/oss:${{ github.sha }} hazelcast-oss
+      - name: Build EE image
+        run: |
+          docker build -t hazelcast/ee:${{ github.sha }} hazelcast-enterprise
+      - name: Scan OSS image by Azure (Trivy + Dockle)
+        uses: Azure/container-scan@v0
+        with:
+          image-name: hazelcast/oss:${{ github.sha }}
+
+      - name: Scan OSS image by Anchore
+        uses: anchore/scan-action@v1
+        with:
+          image-reference: hazelcast/oss:${{ github.sha }}
+          fail-build: true
+
+      - name: Scan OSS image by Snyk
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: hazelcast/oss:${{ github.sha }}
+          args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan
+
+      - name: Scan EE image by Azure (Trivy + Dockle)
+        uses: Azure/container-scan@v0
+        with:
+          image-name: hazelcast/ee:${{ github.sha }}
+
+      - name: Scan EE image by Anchore
+        uses: anchore/scan-action@v1
+        with:
+          image-reference: hazelcast/ee:${{ github.sha }}
+          fail-build: true
+
+      - name: Scan EE image by Snyk
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: hazelcast/ee:${{ github.sha }}
+          args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan


### PR DESCRIPTION
Adds vulnerability check for 3.12.z image over the commits on 3.12.z branch. `.snyk` file is also provided for further vulnerabilities to be ignored.

Backports #170, follow up: #183