### PR TITLE
Bump Anchore action version.

### DIFF
--- a/.github/workflows/backport_vulnerability_scan.yml
+++ b/.github/workflows/backport_vulnerability_scan.yml
@@ -30,9 +30,9 @@ jobs:
           image-name: hazelcast/oss:${{ github.sha }}
 
       - name: Scan OSS image by Anchore
-        uses: anchore/scan-action@v1
+        uses: anchore/scan-action@v2.0.2
         with:
-          image-reference: hazelcast/oss:${{ github.sha }}
+          image: hazelcast/oss:${{ github.sha }}
           fail-build: true
 
       - name: Scan OSS image by Snyk
@@ -49,9 +49,9 @@ jobs:
           image-name: hazelcast/ee:${{ github.sha }}
 
       - name: Scan EE image by Anchore
-        uses: anchore/scan-action@v1
+        uses: anchore/scan-action@v2.0.2
         with:
-          image-reference: hazelcast/ee:${{ github.sha }}
+          image: hazelcast/ee:${{ github.sha }}
           fail-build: true
 
       - name: Scan EE image by Snyk

--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -26,9 +26,9 @@ jobs:
           image-name: hazelcast/oss:${{ github.sha }}
 
       - name: Scan OSS image by Anchore
-        uses: anchore/scan-action@v1
+        uses: anchore/scan-action@v2.0.2
         with:
-          image-reference: hazelcast/oss:${{ github.sha }}
+          image: hazelcast/oss:${{ github.sha }}
           fail-build: true
 
       - name: Scan OSS image by Snyk
@@ -45,9 +45,9 @@ jobs:
           image-name: hazelcast/ee:${{ github.sha }}
 
       - name: Scan EE image by Anchore
-        uses: anchore/scan-action@v1
+        uses: anchore/scan-action@v2.0.2
         with:
-          image-reference: hazelcast/ee:${{ github.sha }}
+          image: hazelcast/ee:${{ github.sha }}
           fail-build: true
 
       - name: Scan EE image by Snyk


### PR DESCRIPTION
The current version seems quite old and just started to fail due to deprecated GHA properties:
https://github.com/hazelcast/hazelcast-docker/actions/runs/367236703
This is also why the build for this commit (6c838e9) fails.