### PR TITLE
Bump missed Anchore action versions.

### DIFF
--- a/.github/workflows/latest_image_push.yml
+++ b/.github/workflows/latest_image_push.yml
@@ -37,9 +37,9 @@ jobs:
         with:
           image-name: hazelcast/hazelcast:latest
       - name: Scan Hazelcast image by Anchore
-        uses: anchore/scan-action@v1
+        uses: anchore/scan-action@v2.0.2
         with:
-          image-reference: hazelcast/hazelcast:latest
+          image: hazelcast/hazelcast:latest
       - name: Scan Hazelcast image by Snyk
         uses: snyk/actions/docker@master
         env:
@@ -52,9 +52,9 @@ jobs:
         with:
           image-name: hazelcast/hazelcast-enterprise:latest
       - name: Scan Hazelcast Enterprise image by Anchore
-        uses: anchore/scan-action@v1
+        uses: anchore/scan-action@v2.0.2
         with:
-          image-reference: hazelcast/hazelcast-enterprise:latest
+          image: hazelcast/hazelcast-enterprise:latest
       - name: Scan Hazelcast Enterprise image by Snyk
         uses: snyk/actions/docker@master
         env:

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -44,9 +44,9 @@ jobs:
         with:
           image-name: hazelcast/hazelcast:${{ env.RELEASE_VERSION }}
       - name: Scan Hazelcast image by Anchore
-        uses: anchore/scan-action@v1
+        uses: anchore/scan-action@v2.0.2
         with:
-          image-reference: hazelcast/hazelcast:${{ env.RELEASE_VERSION }}
+          image: hazelcast/hazelcast:${{ env.RELEASE_VERSION }}
       - name: Scan Hazelcast image by Snyk
         uses: snyk/actions/docker@master
         env:
@@ -59,9 +59,9 @@ jobs:
         with:
           image-name: hazelcast/hazelcast-enterprise:${{ env.RELEASE_VERSION }}
       - name: Scan Hazelcast Enterprise image by Anchore
-        uses: anchore/scan-action@v1
+        uses: anchore/scan-action@v2.0.2
         with:
-          image-reference: hazelcast/hazelcast-enterprise:${{ env.RELEASE_VERSION }}
+          image: hazelcast/hazelcast-enterprise:${{ env.RELEASE_VERSION }}
       - name: Scan Hazelcast Enterprise image by Snyk
         uses: snyk/actions/docker@master
         env:


### PR DESCRIPTION
Completes #189. 
I wasn't aware of the scans in push actions.

The builder fails due to the found vulnerabilities by the updated version: https://github.com/hazelcast/hazelcast-docker/runs/1412655442?check_suite_focus=true