### PR TITLE
Create dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/hazelcast-oss"
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      
+  - package-ecosystem: "docker"
+    directory: "/hazelcast-enterprise"
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
So that's it's easier to keep track of dependencies.

Related: https://github.com/hazelcast/hazelcast-docker/issues/195