### PR TITLE
Run all vulnerability scans on failure.

### DIFF
--- a/.github/workflows/backport_vulnerability_scan.yml
+++ b/.github/workflows/backport_vulnerability_scan.yml
@@ -25,17 +25,20 @@ jobs:
           docker build -t hazelcast/ee:${{ github.sha }} hazelcast-enterprise
 
       - name: Scan OSS image by Azure (Trivy + Dockle)
+        if: always()
         uses: Azure/container-scan@v0
         with:
           image-name: hazelcast/oss:${{ github.sha }}
 
       - name: Scan OSS image by Anchore
+        if: always()
         uses: anchore/scan-action@v2.0.2
         with:
           image: hazelcast/oss:${{ github.sha }}
           fail-build: true
 
       - name: Scan OSS image by Snyk
+        if: always()
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -44,17 +47,20 @@ jobs:
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan
 
       - name: Scan EE image by Azure (Trivy + Dockle)
+        if: always()
         uses: Azure/container-scan@v0
         with:
           image-name: hazelcast/ee:${{ github.sha }}
 
       - name: Scan EE image by Anchore
+        if: always()
         uses: anchore/scan-action@v2.0.2
         with:
           image: hazelcast/ee:${{ github.sha }}
           fail-build: true
 
       - name: Scan EE image by Snyk
+        if: always()
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/latest_image_push.yml
+++ b/.github/workflows/latest_image_push.yml
@@ -33,14 +33,18 @@ jobs:
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise
 
       - name: Scan Hazelcast image by Azure (Trivy + Dockle)
+        if: always()
         uses: Azure/container-scan@v0
         with:
           image-name: hazelcast/hazelcast:latest
       - name: Scan Hazelcast image by Anchore
+        if: always()
         uses: anchore/scan-action@v2.0.2
         with:
           image: hazelcast/hazelcast:latest
+          fail-build: true
       - name: Scan Hazelcast image by Snyk
+        if: always()
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -48,14 +52,18 @@ jobs:
           image: hazelcast/hazelcast:latest
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan
       - name: Scan Hazelcast Enterprise image by Azure (Trivy + Dockle)
+        if: always()
         uses: Azure/container-scan@v0
         with:
           image-name: hazelcast/hazelcast-enterprise:latest
       - name: Scan Hazelcast Enterprise image by Anchore
+        if: always()
         uses: anchore/scan-action@v2.0.2
         with:
           image: hazelcast/hazelcast-enterprise:latest
+          fail-build: true
       - name: Scan Hazelcast Enterprise image by Snyk
+        if: always()
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -40,14 +40,18 @@ jobs:
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise
 
       - name: Scan Hazelcast image by Azure (Trivy + Dockle)
+        if: always()
         uses: Azure/container-scan@v0
         with:
           image-name: hazelcast/hazelcast:${{ env.RELEASE_VERSION }}
       - name: Scan Hazelcast image by Anchore
+        if: always()
         uses: anchore/scan-action@v2.0.2
         with:
           image: hazelcast/hazelcast:${{ env.RELEASE_VERSION }}
+          fail-build: true
       - name: Scan Hazelcast image by Snyk
+        if: always()
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -55,14 +59,18 @@ jobs:
           image: hazelcast/hazelcast:${{ env.RELEASE_VERSION }}
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan
       - name: Scan Hazelcast Enterprise image by Azure (Trivy + Dockle)
+        if: always()
         uses: Azure/container-scan@v0
         with:
           image-name: hazelcast/hazelcast-enterprise:${{ env.RELEASE_VERSION }}
       - name: Scan Hazelcast Enterprise image by Anchore
+        if: always()
         uses: anchore/scan-action@v2.0.2
         with:
           image: hazelcast/hazelcast-enterprise:${{ env.RELEASE_VERSION }}
+          fail-build: true
       - name: Scan Hazelcast Enterprise image by Snyk
+        if: always()
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -1,8 +1,6 @@
 name: Vulnerability Scan
 
 on:
-  pull_request_target:
-    branches: master
   schedule:
     - cron: '0 2 * * *'
 
@@ -21,17 +19,20 @@ jobs:
           docker build -t hazelcast/ee:${{ github.sha }} hazelcast-enterprise
 
       - name: Scan OSS image by Azure (Trivy + Dockle)
+        if: always()
         uses: Azure/container-scan@v0
         with:
           image-name: hazelcast/oss:${{ github.sha }}
 
       - name: Scan OSS image by Anchore
+        if: always()
         uses: anchore/scan-action@v2.0.2
         with:
           image: hazelcast/oss:${{ github.sha }}
           fail-build: true
 
       - name: Scan OSS image by Snyk
+        if: always()
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -40,17 +41,20 @@ jobs:
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan
 
       - name: Scan EE image by Azure (Trivy + Dockle)
+        if: always()
         uses: Azure/container-scan@v0
         with:
           image-name: hazelcast/ee:${{ github.sha }}
 
       - name: Scan EE image by Anchore
+        if: always()
         uses: anchore/scan-action@v2.0.2
         with:
           image: hazelcast/ee:${{ github.sha }}
           fail-build: true
 
       - name: Scan EE image by Snyk
+        if: always()
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
- Allows all vulnerability scans to run in case of any of them fails.
- Removes pr builder because of the misleading results (see #182)

Current actions do not continue to run when one of the scans fail. Say an OS check fails, the action is aborted at that point and no EE (and probably no more OS) check is reported by the action. This often makes difficult to detect the cause and create a fix pr for all.