### PR TITLE
Use openjdk15-jre as runtime

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -37,7 +37,9 @@ COPY *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Installing new APK packages" \
-    && apk add --no-cache openjdk11-jre bash curl \
+    && apk update \
+    && apk add --no-cache openjdk15-jre --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+    && apk add --no-cache bash curl \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -36,7 +36,9 @@ COPY *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Installing new APK packages" \
-    && apk add --no-cache openjdk11-jre bash curl \
+    && apk update \
+    && apk add --no-cache openjdk15-jre --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+    && apk add --no-cache bash curl \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \


### PR DESCRIPTION
Not sure if `--repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing` is acceptable for production-ready artifacts, but it looks like we'd need to wait a bit until it's promoted from _testing_ to _community_