### PR TITLE
Separate push jobs from security scans

### DIFF
--- a/.github/workflows/latest_image_push.yml
+++ b/.github/workflows/latest_image_push.yml
@@ -2,10 +2,11 @@ name: Build latest OS and EE image
 
 on:
   push:
-    branches: master
+    branches:
+      - master
 
 jobs:
-  build:
+  push:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -31,7 +32,10 @@ jobs:
           docker buildx build --push \
             --tag hazelcast/hazelcast-enterprise:latest \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise
-
+  scan:
+    runs-on: ubuntu-latest
+    needs: push
+    steps:
       - name: Scan Hazelcast image by Azure (Trivy + Dockle)
         if: always()
         uses: Azure/container-scan@v0
@@ -70,3 +74,4 @@ jobs:
         with:
           image: hazelcast/hazelcast-enterprise:latest
           args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan
+

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -8,7 +8,7 @@ on:
       - "v4.*"
 
 jobs:
-  build:
+  push:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -40,7 +40,10 @@ jobs:
           docker buildx build --push \
             --tag hazelcast/hazelcast-enterprise:${{ env.RELEASE_VERSION }} \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise
-
+  scan:
+    runs-on: ubuntu-latest
+    needs: push
+    steps:
       - name: Scan Hazelcast image by Azure (Trivy + Dockle)
         if: always()
         uses: Azure/container-scan@v0


### PR DESCRIPTION
Image pushing and image scanning should be separate to not misguide people into thinking that push failed if it's just a scan

<img width="580" alt="image" src="https://user-images.githubusercontent.com/2182533/102342419-7cb95900-3f99-11eb-9332-1e53229c7eec.png">
