### PR TITLE
Change Docker Buildx and QEMU setup actions to official ones

### DIFF
--- a/.github/workflows/latest_image_push.yml
+++ b/.github/workflows/latest_image_push.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v1.0.1
 
       - name:  Set up Docker Buildx
         uses: docker/setup-buildx-action@v1.1.1

--- a/.github/workflows/latest_image_push.yml
+++ b/.github/workflows/latest_image_push.yml
@@ -12,12 +12,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v3.3.1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name:  Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.1.1
         with:
-          buildx-version: v0.4.1
-          qemu-version: 4.2.0-7
+          version: v0.5.1
 
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -20,12 +20,14 @@ jobs:
         run: |
           echo ${{ env.RELEASE_VERSION }}
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v3.3.1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1.0.1
+
+      - name:  Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.1.1
         with:
-          buildx-version: v0.4.1
-          qemu-version: 4.2.0-7
+          version: v0.5.1
+
 
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin


### PR DESCRIPTION
There are official Github Actions for setting up QEMU and Docker Buildx. This PR removes the old action and adds the new ones into the workflows.

