### PR TITLE
Fix issue with Java 11

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -21,7 +21,7 @@ ARG EUREKA_PLUGIN_URLS='https://repo1.maven.org/maven2/com/hazelcast/hazelcast-e
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     HZ_LICENSE_KEY="" \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -21,7 +21,7 @@ ARG EUREKA_PLUGIN_URLS='https://repo1.maven.org/maven2/com/hazelcast/hazelcast-e
 # Runtime constants / variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -Djava.util.logging.config.file=${HZ_HOME}/logging.properties -XX:MaxRAMPercentage=80.0 --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     MANCENTER_URL="" \


### PR DESCRIPTION
Reported by the community:

```
Jan 06, 2021 1:55:49 PM com.hazelcast.internal.management.ManagementCenterService
INFO: [192.168.1.39]:5701 [dev] [3.12.11] Hazelcast will connect to Hazelcast Management Center on address:
http://hz-hazelcast-mancenter.hazelcast.svc.cluster.local:8080/hazelcast-mancenter
Jan 06, 2021 1:55:49 PM com.hazelcast.core.LifecycleService
INFO: [192.168.1.39]:5701 [dev] [3.12.11] [192.168.1.39]:5701 is STARTED
Jan 06, 2021 1:55:49 PM com.hazelcast.internal.management.ManagementCenterService
WARNING: [192.168.1.39]:5701 [dev] [3.12.11] Hazelcast Management Center Service will be shutdown due to exception.
java.lang.ExceptionInInitializerError
	at com.hazelcast.memory.DefaultMemoryStats.getTotalPhysical(DefaultMemoryStats.java:32)
	at com.hazelcast.monitor.impl.LocalMemoryStatsImpl.<init>(LocalMemoryStatsImpl.java:71)
	at com.hazelcast.internal.management.TimedMemberStateFactory.getMemoryStats(TimedMemberStateFactory.java:157)
	at com.hazelcast.internal.management.TimedMemberStateFactory.createMemberState(TimedMemberStateFactory.java:196)
	at com.hazelcast.internal.management.TimedMemberStateFactory.createTimedMemberState(TimedMemberStateFactory.java:130)
	at com.hazelcast.internal.management.ManagementCenterService$PrepareStateThread.run(ManagementCenterService.java:440)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make public long com.sun.management.internal.OperatingSystemImpl.getTotalPhysicalMemorySize() accessible: module jdk.management does not "opens com.sun.management.internal" to unnamed module @3abbfa04
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:340)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:280)
	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:198)
	at java.base/java.lang.reflect.Method.setAccessible(Method.java:192)
	at com.hazelcast.util.OperatingSystemMXBeanSupport.readLongAttribute(OperatingSystemMXBeanSupport.java:72)
	at com.hazelcast.memory.MemoryStatsSupport.<clinit>(MemoryStatsSupport.java:26)
	... 6 more
Jan 06, 2021 1:55:49 PM com.hazelcast.internal.management.ManagementCenterService
INFO: [192.168.1.39]:5701 [dev] [3.12.11] Shutting down Hazelcast Management Center Service
```