### PR TITLE
Enterprise snapshot release

### DIFF
--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -36,13 +36,13 @@ jobs:
         if: always()
         uses: Azure/container-scan@v0
         with:
-          image-name: hazelcast/hazelcast-enterprise:latest
+          image-name: hazelcast/hazelcast:latest-snapshot
 
       - name: Scan Hazelcast Enterprise image by Anchore
         if: always()
         uses: anchore/scan-action@2.0.3
         with:
-          image: hazelcast/hazelcast-enterprise:latest
+          image-name: hazelcast/hazelcast:latest-snapshot
           fail-build: true
 
       - name: Scan Hazelcast Enterprise image by Snyk
@@ -51,5 +51,5 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: hazelcast/hazelcast-enterprise:latest
+          image-name: hazelcast/hazelcast:latest-snapshot
           args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -36,13 +36,13 @@ jobs:
         if: always()
         uses: Azure/container-scan@v0
         with:
-          image-name: hazelcast/hazelcast:latest-snapshot
+          image-name: hazelcast/hazelcast-enterprise:latest-snapshot
 
       - name: Scan Hazelcast Enterprise image by Anchore
         if: always()
         uses: anchore/scan-action@2.0.3
         with:
-          image-name: hazelcast/hazelcast:latest-snapshot
+          image-name: hazelcast/hazelcast-enterprise:latest-snapshot
           fail-build: true
 
       - name: Scan Hazelcast Enterprise image by Snyk
@@ -51,5 +51,5 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image-name: hazelcast/hazelcast:latest-snapshot
+          image-name: hazelcast/hazelcast-enterprise:latest-snapshot
           args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -1,4 +1,4 @@
-name: Build OSS snapshot image
+name: Build EE snapshot image
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -1,4 +1,4 @@
-name: Build latest OS and EE image
+name: Build latest EE image
 
 on:
   workflow_dispatch:
@@ -25,41 +25,12 @@ jobs:
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
-      - name: Build/Push OSS image
-        run: |
-          docker buildx build --push \
-            --build-arg HZ_VERSION=${{ github.event.inputs.HZ_VERSION }} \
-            --tag hazelcast/hazelcast:latest-snapshot \
-            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss 
-
       - name: Build/Push EE image
         run: |
           docker buildx build --push \
             --build-arg HZ_VERSION=${{ github.event.inputs.HZ_VERSION }} \
             --tag hazelcast/hazelcast-enterprise:latest-snapshot \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise 
-
-      - name: Scan Hazelcast image by Azure (Trivy + Dockle)
-        if: always()
-        uses: Azure/container-scan@v0
-        with:
-          image-name: hazelcast/hazelcast:latest
-
-      - name: Scan Hazelcast image by Anchore
-        if: always()
-        uses: anchore/scan-action@2.0.3
-        with:
-          image: hazelcast/hazelcast:latest
-          fail-build: true
-
-      - name: Scan Hazelcast image by Snyk
-        if: always()
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: hazelcast/hazelcast:latest
-          args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan
 
       - name: Scan Hazelcast Enterprise image by Azure (Trivy + Dockle)
         if: always()

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -42,7 +42,7 @@ jobs:
         if: always()
         uses: anchore/scan-action@2.0.3
         with:
-          image-name: hazelcast/hazelcast-enterprise:latest-snapshot
+          image: hazelcast/hazelcast-enterprise:latest-snapshot
           fail-build: true
 
       - name: Scan Hazelcast Enterprise image by Snyk
@@ -51,5 +51,5 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image-name: hazelcast/hazelcast-enterprise:latest-snapshot
+          image: hazelcast/hazelcast-enterprise:latest-snapshot
           args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -1,4 +1,4 @@
-name: Build latest EE image
+name: Build OSS snapshot image
 
 on:
   workflow_dispatch:

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -42,7 +42,7 @@ jobs:
         if: always()
         uses: anchore/scan-action@2.0.3
         with:
-          image-name: hazelcast/hazelcast:latest-snapshot
+          image: hazelcast/hazelcast:latest-snapshot
           fail-build: true
 
       - name: Scan Hazelcast image by Snyk
@@ -51,5 +51,5 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image-name: hazelcast/hazelcast:latest-snapshot
+          image: hazelcast/hazelcast:latest-snapshot
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -36,13 +36,13 @@ jobs:
         if: always()
         uses: Azure/container-scan@v0
         with:
-          image-name: hazelcast/hazelcast:latest
+          image-name: hazelcast/hazelcast:latest-snapshot
 
       - name: Scan Hazelcast image by Anchore
         if: always()
         uses: anchore/scan-action@2.0.3
         with:
-          image: hazelcast/hazelcast:latest
+          image-name: hazelcast/hazelcast:latest-snapshot
           fail-build: true
 
       - name: Scan Hazelcast image by Snyk
@@ -51,5 +51,5 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: hazelcast/hazelcast:latest
+          image-name: hazelcast/hazelcast:latest-snapshot
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -1,4 +1,4 @@
-name: Build latest OSS image
+name: Build OSS snapshot image
 
 on:
   workflow_dispatch:

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -1,0 +1,55 @@
+name: Build latest OSS image
+
+on:
+  workflow_dispatch:
+    inputs:
+      HZ_VERSION:
+        description: 'Version of Hazelcast to build the image for'
+        required: true
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1.0.1
+
+      - name:  Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.1.1
+        with:
+          version: v0.5.1
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build/Push OSS image
+        run: |
+          docker buildx build --push \
+            --build-arg HZ_VERSION=${{ github.event.inputs.HZ_VERSION }} \
+            --tag hazelcast/hazelcast:latest-snapshot \
+            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss 
+
+      - name: Scan Hazelcast image by Azure (Trivy + Dockle)
+        if: always()
+        uses: Azure/container-scan@v0
+        with:
+          image-name: hazelcast/hazelcast:latest
+
+      - name: Scan Hazelcast image by Anchore
+        if: always()
+        uses: anchore/scan-action@2.0.3
+        with:
+          image: hazelcast/hazelcast:latest
+          fail-build: true
+
+      - name: Scan Hazelcast image by Snyk
+        if: always()
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: hazelcast/hazelcast:latest
+          args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -49,7 +49,6 @@ RUN echo "Installing new packages" \
     && mkdir -p "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \
     && HAZELCAST_ALL_URL=$(${HZ_HOME}/get-hz-ee-all-url.sh) \
-    && echo $HAZELCAST_ALL_URL \
     && for JAR_URL in ${HAZELCAST_ALL_URL} ${CACHE_API_URL} ${PROMETHEUS_AGENT_URL} ${LOG4J2_URLS}; do curl -sf -O -L ${JAR_URL} || exit $?; done \
     && mv jmx_prometheus_javaagent-*.jar jmx_prometheus_javaagent.jar \
     && echo "Granting read permission to ${HZ_HOME}" \

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -48,6 +48,8 @@ RUN echo "Installing new packages" \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir -p "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \
+    && HAZELCAST_ALL_URL=$(${HZ_HOME}/get-hz-ee-all-url.sh) \
+    && echo $HAZELCAST_ALL_URL \
     && for JAR_URL in ${HAZELCAST_ALL_URL} ${CACHE_API_URL} ${PROMETHEUS_AGENT_URL} ${LOG4J2_URLS}; do curl -sf -O -L ${JAR_URL} || exit $?; done \
     && mv jmx_prometheus_javaagent-*.jar jmx_prometheus_javaagent.jar \
     && echo "Granting read permission to ${HZ_HOME}" \
@@ -55,7 +57,8 @@ RUN echo "Installing new packages" \
     && echo "Setting Pardot ID to 'docker'" \
     && echo 'hazelcastDownloadId=docker' > "${HZ_HOME}/hazelcast-download.properties" \
     && echo "Removed cached package data" \
-    && microdnf -y clean all
+    && microdnf -y clean all \
+    && rm ${HZ_HOME}/get-hz-ee-all-url.sh
 
 RUN echo "Adding non-root user" \
     && groupadd --system hazelcast \

--- a/hazelcast-enterprise/get-hz-ee-all-url.sh
+++ b/hazelcast-enterprise/get-hz-ee-all-url.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This is a simple script imitating what maven does for snapshot versions. We are not using maven because currently Docker Buildx and QEMU on Github Actions
+# don't work with Java on architectures ppc64le and s390x. When the problem is fixed we will revert back to using maven.
+# If the version is snapshot, the script downloads the 'maven-metadata.xml' and parses it for the snapshot version. 'maven-metadata.xml' only holds the values for 
+# the latest snapshot version. Thus, the [1] in snapshotVersion[1] is arbitrary because all of elements in the list have same value. The list consists of 'jar', 'pom', 'sources' and 'javadoc'.
+if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]
+then
+    curl -O -fsSL "https://repository.hazelcast.com/artifactory/snapshot/com/hazelcast/hazelcast-enterprise-all/${HZ_VERSION}/maven-metadata.xml"
+    version=$(xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()" maven-metadata.xml)
+    url="https://repository.hazelcast.com/artifactory/snapshot/com/hazelcast/hazelcast-enterprise-all/${HZ_VERSION}/hazelcast-enterprise-all-${version}.jar"
+    rm maven-metadata.xml
+else
+    url="https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-all/${HZ_VERSION}/hazelcast-enterprise-all-${HZ_VERSION}.jar"
+fi
+
+echo $url


### PR DESCRIPTION
This PR is a continuation of the [oss snapshot release](https://github.com/hazelcast/hazelcast-docker/pull/218).

Enterprise Dockerfile is updated so that it can also install `hazelcast-enterprise-all` snapshot jars. Similar to the `oss snapshot release`, a new script named `get-hz-ee-all-url.sh` is added to find the installation URL for `hazelcast-enterprise-all` jar depending on `HZ_VERSION`.

The `latest_snapshot_push.yml` is split into two different workflows named `oss_latest_snapshot_push.yml` and  `ee_latest_snapshot_push.yml`. They will be triggered by the following Jenkins jobs respectively: [Hazelcast-docker-snapshot-release ](http://jenkins.hazelcast.com/view/Hazelcast%20Enterprise/job/Hazelcast-docker-snapshot-release/) and  [Hazelcast-ee-docker-snapshot-release](http://jenkins.hazelcast.com/job/Hazelcast-ee-docker-snapshot-release/).

I have created following images for test purposes: [hazelcast-enterprise:latest-snapshot](https://hub.docker.com/layers/mtypey/hazelcast-enterprise/latest-snapshot/images/sha256-46efaee7262ad9947aec3bf3ff948c4b91b30dc898fbde7e34723334330fe260?context=repo) and [hazelcast:latest-snapshot](https://hub.docker.com/layers/mtypey/hazelcast/latest-snapshot/images/sha256-3ca3e74696584f45adae324b98b822a9c935c1bf47d38f1677c7bae8ce742553?context=repo)