### PR TITLE
Add revision of hazelcast into snapshot images as label

### DIFF
--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -6,6 +6,9 @@ on:
       HZ_VERSION:
         description: 'Version of Hazelcast to build the image for'
         required: true
+      HZ_EE_REVISION:
+        description: 'Commit id of Hazelcast Enterprise snapshot jar'
+        required: true
 
 jobs:
   push:
@@ -29,6 +32,7 @@ jobs:
         run: |
           docker buildx build --push \
             --build-arg HZ_VERSION=${{ github.event.inputs.HZ_VERSION }} \
+            --label hazelcast.ee.revision=${{ github.event.inputs.HZ_EE_REVISION }} \
             --tag hazelcast/hazelcast-enterprise:latest-snapshot \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise
 

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -6,6 +6,9 @@ on:
       HZ_VERSION:
         description: 'Version of Hazelcast to build the image for'
         required: true
+      HZ_REVISION:
+        description: 'Commit id of Hazelcast snapshot jar'
+        required: true
 
 jobs:
   push:
@@ -29,6 +32,7 @@ jobs:
         run: |
           docker buildx build --push \
             --build-arg HZ_VERSION=${{ github.event.inputs.HZ_VERSION }} \
+            --label hazelcast.revision=${{ github.event.inputs.HZ_REVISION }} \
             --tag hazelcast/hazelcast:latest-snapshot \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
 


### PR DESCRIPTION
fixes #222 

Current workflow steps:
1. Master deploy jobs pass their commit ids to docker snapshot release builds:

<img width="1402" alt="Screen Shot 2021-02-03 at 11 17 58" src="https://user-images.githubusercontent.com/6005622/106718172-b873b500-6611-11eb-9b1f-e7e4ab71d15c.png">

[Hazelcast-4.master-deploy](http://jenkins.hazelcast.com/job/Hazelcast-4.master-deploy/)
[Hazelcast-EE-4.master-deploy](http://jenkins.hazelcast.com/job/Hazelcast-EE-4.master-deploy/)

2. Docker snapshot release jobs trigger github actions via passing those commit ids:
```
curl  -X POST \
      -H "Accept: application/vnd.github.v3+json" \
      -H "Authorization: token ${GITHUB_TOKEN} "\
      https://api.github.com/repos/hazelcast/hazelcast-docker/actions/workflows/oss_latest_snapshot_push.yml/dispatches \
      -d '{"ref":"master", "inputs":{"HZ_VERSION":"'$HZ_VERSION'", "HZ_REVISION":"'$GIT_COMMIT'"}}'
```
[Hazelcast-docker-snapshot-release](http://jenkins.hazelcast.com/job/Hazelcast-docker-snapshot-release/)

```
curl  -X POST \
      -H "Accept: application/vnd.github.v3+json" \
      -H "Authorization: token ${GITHUB_TOKEN} "\
      https://api.github.com/repos/hazelcast/hazelcast-docker/actions/workflows/ee_latest_snapshot_push.yml/dispatches \
      -d '{"ref":"master", "inputs":{"HZ_VERSION":"'$HZ_VERSION'", "HZ_EE_REVISION":"'$GIT_COMMIT'"}}'
```
[Hazelcast-ee-docker-snapshot-release](http://jenkins.hazelcast.com/job/Hazelcast-ee-docker-snapshot-release/)