### PR TITLE
use headless 11 JRE to get rid of lcms2 and giflib vuls

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -39,7 +39,7 @@ COPY *.xml *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Installing new APK packages" \
-    && apk add --no-cache openjdk11-jre bash curl zip \
+    && apk add --no-cache openjdk11-jre-headless bash curl zip \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -38,7 +38,7 @@ COPY *.xml *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Installing new APK packages" \
-    && apk add --no-cache openjdk11-jre bash curl zip \
+    && apk add --no-cache openjdk11-jre-headless bash curl zip \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \


### PR DESCRIPTION
JFrog Xray detects `lcms2` and `giflib` vulnerabilities at [3.12.11-1 ](https://github.com/hazelcast/hazelcast-docker/releases/tag/v3.12.11-1) version:

<img width="1197" alt="Screen Shot 2021-02-17 at 11 29 28" src="https://user-images.githubusercontent.com/6005622/108176721-68b5e300-7113-11eb-9210-c5249cf9381b.png">