### PR TITLE
[forward-port] [4.0.z] use headless 11 JRE to get rid of lcms2 and giflib vuls

### DIFF
--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -36,7 +36,7 @@ COPY *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Installing new APK packages" \
-    && apk add --no-cache openjdk11-jre bash curl zip \
+    && apk add --no-cache openjdk11-jre-headless bash curl zip \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \


### PR DESCRIPTION
forward-port of #238