### PR TITLE
Add snapshot image release capability to branch 3.12.z 

### DIFF
--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -17,14 +17,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1.0.1
-
-      - name:  Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1.1.1
-        with:
-          version: v0.5.1
-
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -28,21 +28,16 @@ jobs:
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
-      - name: Build/Push EE image
+      - name: Build EE image
         run: |
-          docker buildx build --push \
+          docker build \
             --build-arg HZ_VERSION=${{ github.event.inputs.HZ_VERSION }} \
             --label hazelcast.ee.revision=${{ github.event.inputs.HZ_EE_REVISION }} \
-            --tag hazelcast/hazelcast-enterprise:latest-snapshot \
-            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise
+            --tag hazelcast/hazelcast-enterprise:${{ github.event.inputs.HZ_VERSION }} hazelcast-enterprise
 
-      - name: Trigger Helm Chart Snapshot Action
+      - name: Push EE image
         run: |
-          curl  -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GH_API_TOKEN }} " \
-            https://api.github.com/repos/hazelcast/charts/actions/workflows/push-hazelcast-enterprise-snapshot.yml/dispatches \
-            -d '{"ref":"master"}'
+          docker push hazelcast/hazelcast-enterprise:${{ github.event.inputs.HZ_VERSION }}
 
       - name: Scan Hazelcast Enterprise image by Azure (Trivy + Dockle)
         if: always()

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -43,13 +43,13 @@ jobs:
         if: always()
         uses: Azure/container-scan@v0
         with:
-          image-name: hazelcast/hazelcast-enterprise:latest-snapshot
+          image-name: hazelcast/hazelcast-enterprise:${{ github.event.inputs.HZ_VERSION }}
 
       - name: Scan Hazelcast Enterprise image by Anchore
         if: always()
         uses: anchore/scan-action@v2.0.4
         with:
-          image: hazelcast/hazelcast-enterprise:latest-snapshot
+          image: hazelcast/hazelcast-enterprise:${{ github.event.inputs.HZ_VERSION }}
           fail-build: true
 
       - name: Scan Hazelcast Enterprise image by Snyk
@@ -58,5 +58,5 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: hazelcast/hazelcast-enterprise:latest-snapshot
+          image: hazelcast/hazelcast-enterprise:${{ github.event.inputs.HZ_VERSION }}
           args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -1,0 +1,67 @@
+name: Build EE snapshot image
+
+on:
+  workflow_dispatch:
+    inputs:
+      HZ_VERSION:
+        description: 'Version of Hazelcast to build the image for'
+        required: true
+      HZ_EE_REVISION:
+        description: 'Commit id of Hazelcast Enterprise snapshot jar'
+        required: true
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1.0.1
+
+      - name:  Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.1.1
+        with:
+          version: v0.5.1
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build/Push EE image
+        run: |
+          docker buildx build --push \
+            --build-arg HZ_VERSION=${{ github.event.inputs.HZ_VERSION }} \
+            --label hazelcast.ee.revision=${{ github.event.inputs.HZ_EE_REVISION }} \
+            --tag hazelcast/hazelcast-enterprise:latest-snapshot \
+            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise
+
+      - name: Trigger Helm Chart Snapshot Action
+        run: |
+          curl  -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GH_API_TOKEN }} " \
+            https://api.github.com/repos/hazelcast/charts/actions/workflows/push-hazelcast-enterprise-snapshot.yml/dispatches \
+            -d '{"ref":"master"}'
+
+      - name: Scan Hazelcast Enterprise image by Azure (Trivy + Dockle)
+        if: always()
+        uses: Azure/container-scan@v0
+        with:
+          image-name: hazelcast/hazelcast-enterprise:latest-snapshot
+
+      - name: Scan Hazelcast Enterprise image by Anchore
+        if: always()
+        uses: anchore/scan-action@v2.0.4
+        with:
+          image: hazelcast/hazelcast-enterprise:latest-snapshot
+          fail-build: true
+
+      - name: Scan Hazelcast Enterprise image by Snyk
+        if: always()
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: hazelcast/hazelcast-enterprise:latest-snapshot
+          args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -28,21 +28,16 @@ jobs:
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
-      - name: Build/Push OSS image
+      - name: Build OSS image
         run: |
-          docker buildx build --push \
+          docker build \
             --build-arg HZ_VERSION=${{ github.event.inputs.HZ_VERSION }} \
             --label hazelcast.revision=${{ github.event.inputs.HZ_REVISION }} \
-            --tag hazelcast/hazelcast:latest-snapshot \
-            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
+            --tag hazelcast/hazelcast:${{ github.event.inputs.HZ_VERSION }} hazelcast-oss
 
-      - name: Trigger Helm Chart Snapshot Action
+      - name: Push OSS image
         run: |
-          curl  -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GH_API_TOKEN }} " \
-            https://api.github.com/repos/hazelcast/charts/actions/workflows/push-hazelcast-snapshot.yml/dispatches \
-            -d '{"ref":"master"}'
+          docker push hazelcast/hazelcast:${{ github.event.inputs.HZ_VERSION }}
 
       - name: Scan Hazelcast image by Azure (Trivy + Dockle)
         if: always()

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -17,14 +17,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1.0.1
-
-      - name:  Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1.1.1
-        with:
-          version: v0.5.1
-
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -1,0 +1,67 @@
+name: Build OSS snapshot image
+
+on:
+  workflow_dispatch:
+    inputs:
+      HZ_VERSION:
+        description: 'Version of Hazelcast to build the image for'
+        required: true
+      HZ_REVISION:
+        description: 'Commit id of Hazelcast snapshot jar'
+        required: true
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1.0.1
+
+      - name:  Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.1.1
+        with:
+          version: v0.5.1
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build/Push OSS image
+        run: |
+          docker buildx build --push \
+            --build-arg HZ_VERSION=${{ github.event.inputs.HZ_VERSION }} \
+            --label hazelcast.revision=${{ github.event.inputs.HZ_REVISION }} \
+            --tag hazelcast/hazelcast:latest-snapshot \
+            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
+
+      - name: Trigger Helm Chart Snapshot Action
+        run: |
+          curl  -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GH_API_TOKEN }} " \
+            https://api.github.com/repos/hazelcast/charts/actions/workflows/push-hazelcast-snapshot.yml/dispatches \
+            -d '{"ref":"master"}'
+
+      - name: Scan Hazelcast image by Azure (Trivy + Dockle)
+        if: always()
+        uses: Azure/container-scan@v0
+        with:
+          image-name: hazelcast/hazelcast:latest-snapshot
+
+      - name: Scan Hazelcast image by Anchore
+        if: always()
+        uses: anchore/scan-action@v2.0.4
+        with:
+          image: hazelcast/hazelcast:latest-snapshot
+          fail-build: true
+
+      - name: Scan Hazelcast image by Snyk
+        if: always()
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: hazelcast/hazelcast:latest-snapshot
+          args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -43,13 +43,13 @@ jobs:
         if: always()
         uses: Azure/container-scan@v0
         with:
-          image-name: hazelcast/hazelcast:latest-snapshot
+          image-name: hazelcast/hazelcast:${{ github.event.inputs.HZ_VERSION }} 
 
       - name: Scan Hazelcast image by Anchore
         if: always()
         uses: anchore/scan-action@v2.0.4
         with:
-          image: hazelcast/hazelcast:latest-snapshot
+          image: hazelcast/hazelcast:${{ github.event.inputs.HZ_VERSION }} 
           fail-build: true
 
       - name: Scan Hazelcast image by Snyk
@@ -58,5 +58,5 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: hazelcast/hazelcast:latest-snapshot
+          image: hazelcast/hazelcast:${{ github.event.inputs.HZ_VERSION }} 
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -43,7 +43,7 @@ RUN echo "Installing new APK packages" \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \
-    && HAZELCAST_ALL_URL=$(${HZ_HOME}/get-hz-all-url.sh) \
+    && HAZELCAST_ALL_URL=$(${HZ_HOME}/get-hz-ee-all-url.sh) \
     && for JAR_URL in ${HAZELCAST_ALL_URL} ${CACHE_API_URL} ${PROMETHEUS_AGENT_URL} ${EUREKA_PLUGIN_URLS}; do curl -sf -O -L ${JAR_URL} || exit $?; done \
     && mv jmx_prometheus_javaagent-*.jar jmx_prometheus_javaagent.jar \
     && echo "Setting Pardot ID to 'docker'" \

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -39,20 +39,21 @@ COPY *.xml *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Installing new APK packages" \
-    && apk add --no-cache openjdk11-jre-headless bash curl zip \
+    && apk add --no-cache openjdk11-jre-headless bash curl perl-xml-xpath zip \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \
+    && HAZELCAST_ALL_URL=$(${HZ_HOME}/get-hz-all-url.sh) \
     && for JAR_URL in ${HAZELCAST_ALL_URL} ${CACHE_API_URL} ${PROMETHEUS_AGENT_URL} ${EUREKA_PLUGIN_URLS}; do curl -sf -O -L ${JAR_URL} || exit $?; done \
     && mv jmx_prometheus_javaagent-*.jar jmx_prometheus_javaagent.jar \
     && echo "Setting Pardot ID to 'docker'" \
     && echo 'hazelcastDownloadId=docker' > "hazelcast-download.properties" \
-    && zip -f hazelcast-enterprise-all-${HZ_VERSION}.jar hazelcast-download.properties \
+    && zip -u hazelcast-enterprise-all-*.jar hazelcast-download.properties \
     && echo "Granting read permission to ${HZ_HOME}" \
     && chmod -R +r ${HZ_HOME} \
     && echo "Cleaning APK packages" \
-    && apk del zip \
-    && rm -rf /var/cache/apk/*
+    && apk del perl-xml-xpath curl zip \
+    && rm -rf /var/cache/apk/* ${HZ_HOME}/get-hz-all-url.sh
 
 WORKDIR ${HZ_HOME}
 

--- a/hazelcast-enterprise/get-hz-ee-all-url.sh
+++ b/hazelcast-enterprise/get-hz-ee-all-url.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This is a simple script imitating what maven does for snapshot versions. We are not using maven because currently Docker Buildx and QEMU on Github Actions
+# don't work with Java on architectures ppc64le and s390x. When the problem is fixed we will revert back to using maven.
+# If the version is snapshot, the script downloads the 'maven-metadata.xml' and parses it for the snapshot version. 'maven-metadata.xml' only holds the values for 
+# the latest snapshot version. Thus, the [1] in snapshotVersion[1] is arbitrary because all of elements in the list have same value. The list consists of 'jar', 'pom', 'sources' and 'javadoc'.
+if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]
+then
+    curl -O -fsSL "https://repository.hazelcast.com/artifactory/snapshot/com/hazelcast/hazelcast-enterprise-all/${HZ_VERSION}/maven-metadata.xml"
+    version=$(xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()" maven-metadata.xml)
+    url="https://repository.hazelcast.com/artifactory/snapshot/com/hazelcast/hazelcast-enterprise-all/${HZ_VERSION}/hazelcast-enterprise-all-${version}.jar"
+    rm maven-metadata.xml
+else
+    url="https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-all/${HZ_VERSION}/hazelcast-enterprise-all-${HZ_VERSION}.jar"
+fi
+
+echo $url

--- a/hazelcast-enterprise/get-hz-ee-all-url.sh
+++ b/hazelcast-enterprise/get-hz-ee-all-url.sh
@@ -6,10 +6,9 @@
 # the latest snapshot version. Thus, the [1] in snapshotVersion[1] is arbitrary because all of elements in the list have same value. The list consists of 'jar', 'pom', 'sources' and 'javadoc'.
 if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]
 then
-    curl -O -fsSL "https://repository.hazelcast.com/artifactory/snapshot/com/hazelcast/hazelcast-enterprise-all/${HZ_VERSION}/maven-metadata.xml"
-    version=$(xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()" maven-metadata.xml)
+    xml=$(curl  -fsSL "https://repository.hazelcast.com/artifactory/snapshot/com/hazelcast/hazelcast-enterprise-all/${HZ_VERSION}/maven-metadata.xml")
+    version=$(echo $xml | xpath -q -e '/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()' )
     url="https://repository.hazelcast.com/artifactory/snapshot/com/hazelcast/hazelcast-enterprise-all/${HZ_VERSION}/hazelcast-enterprise-all-${version}.jar"
-    rm maven-metadata.xml
 else
     url="https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-all/${HZ_VERSION}/hazelcast-enterprise-all-${HZ_VERSION}.jar"
 fi

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -38,20 +38,21 @@ COPY *.xml *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Installing new APK packages" \
-    && apk add --no-cache openjdk11-jre-headless bash curl zip \
+    && apk add --no-cache openjdk11-jre-headless bash curl perl-xml-xpath zip \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \
-    && for JAR_URL in ${HAZELCAST_ALL_URL} ${CACHE_API_URL} ${PROMETHEUS_AGENT_URL} ${EUREKA_PLUGIN_URLS}; do curl -sf -O -L ${JAR_URL} || exit $?; done \
+    && HAZELCAST_ALL_URL=$(${HZ_HOME}/get-hz-all-url.sh) \
+    && for JAR_URL in ${HAZELCAST_ALL_URL} ${CACHE_API_URL} ${PROMETHEUS_AGENT_URL} ${EUREKA_PLUGIN_URLS} ${LOG4J2_URLS}; do curl -sf -O -L ${JAR_URL} || exit $?; done \
     && mv jmx_prometheus_javaagent-*.jar jmx_prometheus_javaagent.jar \
     && echo "Setting Pardot ID to 'docker'" \
     && echo 'hazelcastDownloadId=docker' > "hazelcast-download.properties" \
-    && zip -f hazelcast-all-${HZ_VERSION}.jar hazelcast-download.properties \
+    && zip -u hazelcast-all-*.jar hazelcast-download.properties \
     && echo "Granting read permission to ${HZ_HOME}" \
     && chmod -R +r ${HZ_HOME} \
     && echo "Cleaning APK packages" \
-    && apk del zip \
-    && rm -rf /var/cache/apk/*
+    && apk del perl-xml-xpath curl zip \
+    && rm -rf /var/cache/apk/* ${HZ_HOME}/get-hz-all-url.sh
 
 WORKDIR ${HZ_HOME}
 

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -38,7 +38,7 @@ COPY *.xml *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Installing new APK packages" \
-    && apk add --no-cache openjdk11-jre-headless bash curl perl-xml-xpath zip \
+    && apk add --no-cache openjdk11-jre-headless bash curl libxml2-utils zip \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \
@@ -51,7 +51,7 @@ RUN echo "Installing new APK packages" \
     && echo "Granting read permission to ${HZ_HOME}" \
     && chmod -R +r ${HZ_HOME} \
     && echo "Cleaning APK packages" \
-    && apk del perl-xml-xpath curl zip \
+    && apk del libxml2-utils curl zip \
     && rm -rf /var/cache/apk/* ${HZ_HOME}/get-hz-all-url.sh
 
 WORKDIR ${HZ_HOME}

--- a/hazelcast-oss/get-hz-all-url.sh
+++ b/hazelcast-oss/get-hz-all-url.sh
@@ -6,9 +6,10 @@
 # the latest snapshot version. Thus, the [1] in snapshotVersion[1] is arbitrary because all of elements in the list have same value. The list consists of 'jar', 'pom', 'sources' and 'javadoc'.
 if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]
 then
-    xml=$(curl -fsSL https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-all/${HZ_VERSION}/maven-metadata.xml)
-    version=$(echo $xml | xpath -q -e '/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()' )
+    curl -O -fsSL "https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-all/${HZ_VERSION}/maven-metadata.xml"
+    version=$(xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()" maven-metadata.xml)
     url="https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-all/${HZ_VERSION}/hazelcast-all-${version}.jar"
+    rm maven-metadata.xml
 else
     url="https://repo1.maven.org/maven2/com/hazelcast/hazelcast-all/${HZ_VERSION}/hazelcast-all-${HZ_VERSION}.jar"
 fi

--- a/hazelcast-oss/get-hz-all-url.sh
+++ b/hazelcast-oss/get-hz-all-url.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This is a simple script imitating what maven does for snapshot versions. We are not using maven because currently Docker Buildx and QEMU on Github Actions
+# don't work with Java on architectures ppc64le and s390x. When the problem is fixed we will revert back to using maven.
+# If the version is snapshot, the script downloads the 'maven-metadata.xml' and parses it for the snapshot version. 'maven-metadata.xml' only holds the values for 
+# the latest snapshot version. Thus, the [1] in snapshotVersion[1] is arbitrary because all of elements in the list have same value. The list consists of 'jar', 'pom', 'sources' and 'javadoc'.
+if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]
+then
+    xml=$(curl -fsSL https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-all/${HZ_VERSION}/maven-metadata.xml)
+    version=$(echo $xml | xpath -q -e '/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()' )
+    url="https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-all/${HZ_VERSION}/hazelcast-all-${version}.jar"
+else
+    url="https://repo1.maven.org/maven2/com/hazelcast/hazelcast-all/${HZ_VERSION}/hazelcast-all-${HZ_VERSION}.jar"
+fi
+
+echo $url


### PR DESCRIPTION
With this PR when a new snapshot jar is created for versions 3.12.z, its Docker image will be pushed to Docker Hub with the following tag: `3.12.z-SNAPSHOT`. So, if the snapshot version is 3.12.15, the tag will be `3.12.15-SNAPSHOT`.


TODO
- [x] Create a Jenkins job for workflow triggers. 