### PR TITLE
Add snapshot image release capability to branch 4.0.z

### DIFF
--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -1,4 +1,4 @@
-name: Build EE snapshot image
+name: Build EE 4.0.z snapshot image
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -1,0 +1,72 @@
+name: Build EE snapshot image
+
+on:
+  workflow_dispatch:
+    inputs:
+      HZ_VERSION:
+        description: 'Version of Hazelcast to build the image for'
+        required: true
+      HZ_EE_REVISION:
+        description: 'Commit id of Hazelcast Enterprise snapshot jar'
+        required: true
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1.0.1
+
+      - name:  Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.1.1
+        with:
+          version: v0.5.1
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build/Push EE image
+        run: |
+          TAGS="--tag hazelcast/hazelcast-enterprise:${{ github.event.inputs.HZ_VERSION }}"
+          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            TAGS="${TAGS} --tag hazelcast/hazelcast-enterprise:latest-snapshot"
+          fi
+          docker buildx build --push \
+            --build-arg HZ_VERSION=${{ github.event.inputs.HZ_VERSION }} \
+            --label hazelcast.ee.revision=${{ github.event.inputs.HZ_EE_REVISION }} \
+            $TAGS \
+            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise
+
+      - name: Trigger Helm Chart Snapshot Action
+        if: github.ref == 'refs/heads/master'
+        run: |
+          curl  -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GH_API_TOKEN }} " \
+            https://api.github.com/repos/hazelcast/charts/actions/workflows/push-hazelcast-enterprise-snapshot.yml/dispatches \
+            -d '{"ref":"master"}'
+
+      - name: Scan Hazelcast Enterprise image by Azure (Trivy + Dockle)
+        if: always()
+        uses: Azure/container-scan@v0
+        with:
+          image-name: hazelcast/hazelcast-enterprise:${{ github.event.inputs.HZ_VERSION }}
+
+      - name: Scan Hazelcast Enterprise image by Anchore
+        if: always()
+        uses: anchore/scan-action@v2.0.4
+        with:
+          image: hazelcast/hazelcast-enterprise:${{ github.event.inputs.HZ_VERSION }}
+          fail-build: true
+
+      - name: Scan Hazelcast Enterprise image by Snyk
+        if: always()
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: hazelcast/hazelcast-enterprise:${{ github.event.inputs.HZ_VERSION }}
+          args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -1,0 +1,72 @@
+name: Build OSS snapshot image
+
+on:
+  workflow_dispatch:
+    inputs:
+      HZ_VERSION:
+        description: 'Version of Hazelcast to build the image for'
+        required: true
+      HZ_REVISION:
+        description: 'Commit id of Hazelcast snapshot jar'
+        required: true
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1.0.1
+
+      - name:  Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.1.1
+        with:
+          version: v0.5.1
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build/Push OSS image
+        run: |
+          TAGS="--tag hazelcast/hazelcast:${{ github.event.inputs.HZ_VERSION }}"
+          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            TAGS="${TAGS} --tag hazelcast/hazelcast:latest-snapshot"
+          fi
+          docker buildx build --push \
+            --build-arg HZ_VERSION=${{ github.event.inputs.HZ_VERSION }} \
+            --label hazelcast.revision=${{ github.event.inputs.HZ_REVISION }} \
+            $TAGS \
+            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
+
+      - name: Trigger Helm Chart Snapshot Action
+        if: github.ref == 'refs/heads/master'
+        run: |
+          curl  -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GH_API_TOKEN }} " \
+            https://api.github.com/repos/hazelcast/charts/actions/workflows/push-hazelcast-snapshot.yml/dispatches \
+            -d '{"ref":"master"}'
+
+      - name: Scan Hazelcast image by Azure (Trivy + Dockle)
+        if: always()
+        uses: Azure/container-scan@v0
+        with:
+          image-name: hazelcast/hazelcast:${{ github.event.inputs.HZ_VERSION }}
+
+      - name: Scan Hazelcast image by Anchore
+        if: always()
+        uses: anchore/scan-action@v2.0.4
+        with:
+          image: hazelcast/hazelcast:${{ github.event.inputs.HZ_VERSION }}
+          fail-build: true
+
+      - name: Scan Hazelcast image by Snyk
+        if: always()
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: hazelcast/hazelcast:${{ github.event.inputs.HZ_VERSION }}
+          args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -1,4 +1,4 @@
-name: Build OSS snapshot image
+name: Build OSS 4.0.z snapshot image
 
 on:
   workflow_dispatch:

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -48,6 +48,7 @@ RUN echo "Installing new packages" \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir -p "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \
+    && HAZELCAST_ALL_URL=$(${HZ_HOME}/get-hz-ee-all-url.sh) \
     && for JAR_URL in ${HAZELCAST_ALL_URL} ${CACHE_API_URL} ${PROMETHEUS_AGENT_URL} ${LOG4J2_URLS}; do curl -sf -O -L ${JAR_URL} || exit $?; done \
     && mv jmx_prometheus_javaagent-*.jar jmx_prometheus_javaagent.jar \
     && echo "Setting Pardot ID to 'docker'" \
@@ -57,7 +58,8 @@ RUN echo "Installing new packages" \
     && chmod -R +r ${HZ_HOME} \
     && echo "Removing cached package data and unnecessary tools" \
     && microdnf remove zip unzip \
-    && microdnf -y clean all
+    && microdnf -y clean all \
+    && rm ${HZ_HOME}/get-hz-ee-all-url.sh
 
 RUN echo "Adding non-root user" \
     && groupadd --system hazelcast \

--- a/hazelcast-enterprise/get-hz-ee-all-url.sh
+++ b/hazelcast-enterprise/get-hz-ee-all-url.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This is a simple script imitating what maven does for snapshot versions. We are not using maven because currently Docker Buildx and QEMU on Github Actions
+# don't work with Java on architectures ppc64le and s390x. When the problem is fixed we will revert back to using maven.
+# If the version is snapshot, the script downloads the 'maven-metadata.xml' and parses it for the snapshot version. 'maven-metadata.xml' only holds the values for 
+# the latest snapshot version. Thus, the [1] in snapshotVersion[1] is arbitrary because all of elements in the list have same value. The list consists of 'jar', 'pom', 'sources' and 'javadoc'.
+if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]
+then
+    curl -O -fsSL "https://repository.hazelcast.com/artifactory/snapshot/com/hazelcast/hazelcast-enterprise-all/${HZ_VERSION}/maven-metadata.xml"
+    version=$(xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()" maven-metadata.xml)
+    url="https://repository.hazelcast.com/artifactory/snapshot/com/hazelcast/hazelcast-enterprise-all/${HZ_VERSION}/hazelcast-enterprise-all-${version}.jar"
+    rm maven-metadata.xml
+else
+    url="https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-all/${HZ_VERSION}/hazelcast-enterprise-all-${HZ_VERSION}.jar"
+fi
+
+echo $url

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -36,10 +36,11 @@ COPY *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Installing new APK packages" \
-    && apk add --no-cache openjdk11-jre-headless bash curl zip \
+    && apk add --no-cache openjdk11-jre-headless bash curl perl-xml-xpath zip \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \
+    && HAZELCAST_ALL_URL=$(${HZ_HOME}/get-hz-all-url.sh) \
     && for JAR_URL in ${HAZELCAST_ALL_URL} ${CACHE_API_URL} ${PROMETHEUS_AGENT_URL} ${EUREKA_PLUGIN_URLS} ${LOG4J2_URLS}; do curl -sf -O -L ${JAR_URL} || exit $?; done \
     && mv jmx_prometheus_javaagent-*.jar jmx_prometheus_javaagent.jar \
     && echo "Setting Pardot ID to 'docker'" \
@@ -48,8 +49,8 @@ RUN echo "Installing new APK packages" \
     && echo "Granting read permission to ${HZ_HOME}" \
     && chmod -R +r ${HZ_HOME} \
     && echo "Cleaning APK packages" \
-    && apk del curl zip \
-    && rm -rf /var/cache/apk/*
+    && apk del perl-xml-xpath curl zip \
+    && rm -rf /var/cache/apk/* ${HZ_HOME}/get-hz-all-url.sh
 
 WORKDIR ${HZ_HOME}
 

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -36,7 +36,7 @@ COPY *.sh *.yaml *.jar *.properties ${HZ_HOME}/
 
 # Install
 RUN echo "Installing new APK packages" \
-    && apk add --no-cache openjdk11-jre-headless bash curl perl-xml-xpath zip \
+    && apk add --no-cache openjdk11-jre-headless bash curl libxml2-utils zip \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \
@@ -49,7 +49,7 @@ RUN echo "Installing new APK packages" \
     && echo "Granting read permission to ${HZ_HOME}" \
     && chmod -R +r ${HZ_HOME} \
     && echo "Cleaning APK packages" \
-    && apk del perl-xml-xpath curl zip \
+    && apk del libxml2-utils curl zip \
     && rm -rf /var/cache/apk/* ${HZ_HOME}/get-hz-all-url.sh
 
 WORKDIR ${HZ_HOME}

--- a/hazelcast-oss/get-hz-all-url.sh
+++ b/hazelcast-oss/get-hz-all-url.sh
@@ -6,9 +6,10 @@
 # the latest snapshot version. Thus, the [1] in snapshotVersion[1] is arbitrary because all of elements in the list have same value. The list consists of 'jar', 'pom', 'sources' and 'javadoc'.
 if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]
 then
-    xml=$(curl -fsSL https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-all/${HZ_VERSION}/maven-metadata.xml)
-    version=$(echo $xml | xpath -q -e '/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()' )
+    curl -O -fsSL "https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-all/${HZ_VERSION}/maven-metadata.xml"
+    version=$(xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()" maven-metadata.xml)
     url="https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-all/${HZ_VERSION}/hazelcast-all-${version}.jar"
+    rm maven-metadata.xml
 else
     url="https://repo1.maven.org/maven2/com/hazelcast/hazelcast-all/${HZ_VERSION}/hazelcast-all-${HZ_VERSION}.jar"
 fi

--- a/hazelcast-oss/get-hz-all-url.sh
+++ b/hazelcast-oss/get-hz-all-url.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This is a simple script imitating what maven does for snapshot versions. We are not using maven because currently Docker Buildx and QEMU on Github Actions
+# don't work with Java on architectures ppc64le and s390x. When the problem is fixed we will revert back to using maven.
+# If the version is snapshot, the script downloads the 'maven-metadata.xml' and parses it for the snapshot version. 'maven-metadata.xml' only holds the values for 
+# the latest snapshot version. Thus, the [1] in snapshotVersion[1] is arbitrary because all of elements in the list have same value. The list consists of 'jar', 'pom', 'sources' and 'javadoc'.
+if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]
+then
+    xml=$(curl -fsSL https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-all/${HZ_VERSION}/maven-metadata.xml)
+    version=$(echo $xml | xpath -q -e '/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()' )
+    url="https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-all/${HZ_VERSION}/hazelcast-all-${version}.jar"
+else
+    url="https://repo1.maven.org/maven2/com/hazelcast/hazelcast-all/${HZ_VERSION}/hazelcast-all-${HZ_VERSION}.jar"
+fi
+
+echo $url


### PR DESCRIPTION
With this PR when a new snapshot jar is created for versions 4.0.z, its Docker image will be pushed to Docker Hub with the following tag: `4.0.z-SNAPSHOT`. So, If the snapshot version is 4.0.5, the tag will `4.0.5-SNAPSHOT`.


TODO
- [ ] Create a Jenkins job for workflow triggers. 