### PR TITLE
Enable ignore-unfixed option for Trivy

### DIFF
--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -49,12 +49,12 @@ jobs:
             https://api.github.com/repos/hazelcast/charts/actions/workflows/push-hazelcast-enterprise-snapshot.yml/dispatches \
             -d '{"ref":"master"}'
 
-      - name: Scan Hazelcast Enterprise image by Azure (Trivy + Dockle)
-        if: always()
-        uses: Azure/container-scan@v0
+      - name: Scan OSS image by Trivy
+        uses: aquasecurity/trivy-action@master
         with:
-          image-name: hazelcast/hazelcast-enterprise:${{ github.event.inputs.HZ_VERSION }}
-          severity-threshold: MEDIUM
+          image-ref: 'hazelcast/hazelcast-enterprise:${{ github.event.inputs.HZ_VERSION }}'
+          ignore-unfixed: true
+          severity: 'MEDIUM,HIGH,CRITICAL'
 
       - name: Scan Hazelcast Enterprise image by Snyk
         if: always()

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -49,12 +49,12 @@ jobs:
             https://api.github.com/repos/hazelcast/charts/actions/workflows/push-hazelcast-snapshot.yml/dispatches \
             -d '{"ref":"master"}'
 
-      - name: Scan Hazelcast image by Azure (Trivy + Dockle)
-        if: always()
-        uses: Azure/container-scan@v0
+      - name: Scan OSS image by Trivy
+        uses: aquasecurity/trivy-action@master
         with:
-          image-name: hazelcast/hazelcast:${{ github.event.inputs.HZ_VERSION }}
-          severity-threshold: MEDIUM
+          image-ref: 'hazelcast/hazelcast:${{ github.event.inputs.HZ_VERSION }}'
+          ignore-unfixed: true
+          severity: 'MEDIUM,HIGH,CRITICAL'
 
       - name: Scan Hazelcast image by Snyk
         if: always()

--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -21,12 +21,12 @@ jobs:
         run: |
           docker build -t hazelcast/ee:${{ github.sha }} hazelcast-enterprise
 
-      - name: Scan OSS image by Azure (Trivy + Dockle)
-        if: always()
-        uses: Azure/container-scan@v0
+      - name: Scan OSS image by Trivy
+        uses: aquasecurity/trivy-action@master
         with:
-          image-name: hazelcast/oss:${{ github.sha }}
-          severity-threshold: MEDIUM
+          image-ref: 'hazelcast/oss:${{ github.sha }}'
+          ignore-unfixed: true
+          severity: 'MEDIUM,HIGH,CRITICAL'
 
       - name: Scan OSS image by Snyk
         if: always()
@@ -37,12 +37,12 @@ jobs:
           image: hazelcast/oss:${{ github.sha }}
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan --severity-threshold=medium
 
-      - name: Scan EE image by Azure (Trivy + Dockle)
-        if: always()
-        uses: Azure/container-scan@v0
+      - name: Scan EE image by Trivy
+        uses: aquasecurity/trivy-action@master
         with:
-          image-name: hazelcast/ee:${{ github.sha }}
-          severity-threshold: MEDIUM
+          image-ref: 'hazelcast/ee:${{ github.sha }}'
+          ignore-unfixed: true
+          severity: 'MEDIUM,HIGH,CRITICAL'
 
       - name: Scan EE image by Snyk
         if: always()


### PR DESCRIPTION
Additional changes:
- use official trivy Github Action

Trivy steps at EE workflows are currently failing after I changed severity level to medium(its default valut is high):
https://github.com/hazelcast/hazelcast-docker/runs/3241439215?check_suite_focus=true
Snyk steps are not failing because Snyk ignores unfixed(won't fix) ones as a default behaviour:
https://support.snyk.io/hc/en-us/articles/360000923498-How-can-I-ignore-a-vulnerability- 

@leszko I checked most of medium vulns are reported by Trivy were marked as `will not fix` by RedHat so checking them one by one every time then adding into whitelist.yaml to make our builds are green again is just time-consumer. If vulnerability can not be fixed, it can be invisible for us. WDYT?