### PR TITLE
[HZ-432] Use config/hazelcast-docker.xml as the default configuration

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -18,6 +18,7 @@ ENV HZ_HOME="${HZ_HOME}" \
     LOGGING_LEVEL="" \
     CLASSPATH="" \
     JAVA_OPTS="" \
+    HAZELCAST_CONFIG=config/hazelcast-docker.xml \
     PATH=${HZ_HOME}/bin:$PATH
 
 LABEL name="Hazelcast IMDG Enterprise" \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -17,6 +17,7 @@ ENV HZ_HOME="${HZ_HOME}" \
     LOGGING_LEVEL="" \
     CLASSPATH="" \
     JAVA_OPTS="" \
+    HAZELCAST_CONFIG=config/hazelcast-docker.xml \
     PATH=${HZ_HOME}/bin:$PATH
 
 # Expose port


### PR DESCRIPTION
This PR is related to security requirements in https://hazelcast.atlassian.net/browse/HZ-432

Depends on the hazelcast/hazelcast#19252

The PR configures a new environment property that defines the path to Docker-default Hazelcast member configuration XML file.