### PR TITLE
[CN-174] Get Management Center version from management-center-openshift repository

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -15,17 +15,31 @@ jobs:
     env:
       SCAN_REGISTRY: "scan.connect.redhat.com"
       TIMEOUT_IN_MINS: 120
-      HZ_MC_VERSION: 4.2020.12-2
       HZ_ENTERPRISE_LICENSE: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
       OCP_LOGIN_USERNAME: ${{ secrets.OCP_LOGIN_USERNAME }}
       OCP_LOGIN_PASSWORD: ${{ secrets.OCP_LOGIN_PASSWORD }}
       OCP_CLUSTER_URL: ${{ secrets.OCP_CLUSTER_URL }}
       HZ_EE_RHEL_REPO_PASSWORD: ${{ secrets.HZ_EE_RHEL_REPO_PASSWORD }}
       HZ_EE_RHEL_REPOSITORY: ${{ secrets.HZ_EE_RHEL_REPOSITORY }}
-      RHEL_API_KEY:  ${{ secrets.RHEL_API_KEY }}
+      RHEL_API_KEY: ${{ secrets.RHEL_API_KEY }}
 
     runs-on: ubuntu-latest
-    steps: 
+    steps:
+      - name: Checkout to Management Center Openshift
+        uses: actions/checkout@v2
+        with:
+          repository: hazelcast/management-center-openshift
+          path: management-center-openshift
+          fetch-depth: 0
+
+      - name: Set Management Center Version to be used in the tests
+        working-directory: management-center-openshift
+        run: |
+          FILTERED_TAGS=$(git tag --list "v*" |  grep -E -v '.*(BETA|-).*' )
+          LATEST_TAG=$((IFS=$'\n' && echo "${FILTERED_TAGS[*]}") | sort | tail -n 1)
+          echo $LATEST_TAG
+          echo "HZ_MC_VERSION=${LATEST_TAG:11}" >> $GITHUB_ENV
+
       - name: Checkout Code
         uses: actions/checkout@v2
         with:
@@ -37,19 +51,16 @@ jobs:
           echo "RHEL_IMAGE=${HZ_EE_RHEL_REPOSITORY}:${RELEASE_VERSION}" >> $GITHUB_ENV
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
 
-          
       - name: Build the Hazelcast Enterprise image
         run: |
           docker build \
                 --build-arg HZ_VERSION=${RELEASE_VERSION} \
                 --tag ${RHEL_IMAGE} hazelcast-enterprise
 
-
       - name: Log in to Red Hat Scan Registry and Push the Image
         run: |
           docker login ${SCAN_REGISTRY} -u unused -p ${HZ_EE_RHEL_REPO_PASSWORD}
           docker push ${RHEL_IMAGE}
-
 
       - name: Wait for Scan to Complete
         run: |
@@ -58,8 +69,7 @@ jobs:
           source .github/scripts/publish-rhel.sh
 
           wait_for_container_scan "$PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
-        
-          
+
       - name: Deploy Hazelcast Cluster
         run: |
           WORKDIR=$(pwd)/${NAME}
@@ -76,18 +86,17 @@ jobs:
                         "$CLUSTER_SIZE" \
                         "$HZ_ENTERPRISE_LICENSE" \
                         "$HZ_MC_VERSION"
-      
+
         env:
           CLUSTER_SIZE: 3
           NAME: hazelcast-enterprise
-
 
       - name: Validate Cluster Size
         run: |
           PROJECT=hz-ee-test-${{ github.run_id }}
           HZ_NAME=$PROJECT
           NAME=hazelcast-enterprise
-          
+
           source .github/scripts/cluster-verification.sh
 
           wait_for_last_member_initialization $CLUSTER_SIZE
@@ -101,13 +110,11 @@ jobs:
           CLUSTER_SIZE: 3
           NAME: hazelcast-enterprise
 
-
       - name: Clean up After Test
         if: always()
         run: |
           PROJECT=hz-ee-test-${{ github.run_id }}
           .github/scripts/clean-up.sh $PROJECT
-
 
       - name: Publish the Hazelcast-Enterprise-Operator image
         run: |


### PR DESCRIPTION
The Red Hat tag publish workflow will now get the latest MC version released in the Red Hat Catalogue from the [management-center-openshift](https://github.com/hazelcast/management-center-openshift) repository.