### PR TITLE
Add curl to allow healthchecks

### DIFF
--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -38,7 +38,7 @@ RUN echo "Installing new APK packages" \
     && echo "Granting read permission to ${HZ_HOME}" \
     && chmod -R +r ${HZ_HOME} \
     && echo "Cleaning APK packages and redundant files/folders" \
-    && apk del libxml2-utils curl zip unzip \
+    && apk del libxml2-utils zip unzip \
     && rm -rf /var/cache/apk/* ${HZ_HOME}/get-hz-dist-zip.sh ${HZ_HOME}/hazelcast-distribution.zip ${HZ_HOME}/tmp
 
 COPY log4j2.properties jmx_agent_config.yaml ${HZ_HOME}/config/


### PR DESCRIPTION
This is an addition to hazelcast/hazelcast#19664 which should allow our Docker users to simply check if hazelcast is properly started. E.g. by calling

```bash
curl -f http://hazelcast-host:5701/hazelcast/health/ready
```