### PR TITLE
Remove lib/* from CLASSPATH

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -11,7 +11,7 @@ ARG USER_NAME="hazelcast"
 
 # Runtime variables
 ENV HZ_HOME="${HZ_HOME}" \
-    CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
+    CLASSPATH_DEFAULT="${HZ_HOME}/*" \
     JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -XX:MaxRAMPercentage=80.0 -XX:MaxGCPauseMillis=5" \
     PROMETHEUS_PORT="" \
     PROMETHEUS_CONFIG="${HZ_HOME}/config/jmx_agent_config.yaml" \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -10,7 +10,7 @@ ARG HZ_HOME="/opt/hazelcast"
 
 # Runtime variables
 ENV HZ_HOME="${HZ_HOME}" \
-    CLASSPATH_DEFAULT="${HZ_HOME}/*:${HZ_HOME}/lib/*" \
+    CLASSPATH_DEFAULT="${HZ_HOME}/*" \
     JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -XX:MaxRAMPercentage=80.0 -XX:MaxGCPauseMillis=5" \
     PROMETHEUS_PORT="" \
     PROMETHEUS_CONFIG="${HZ_HOME}/config/jmx_agent_config.yaml" \


### PR DESCRIPTION
This is already added by the `hz-start` script.
Adding this to CLASSPATH results in the lib/* directory present 2x on
the final classpath.

Accidentally it is put before the default classpath, causing a change in
the loading order. Incorrect hazelcast-download.properties is loaded and
phone home reports as 'maven'.

Fixed #290