### PR TITLE
Correcting log4j2.properties localtion

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Available logging levels are (from highest to lowest): `OFF`, `FATAL`, `ERROR`, 
 Note that if you need some more custom logging configuration, you can specify a configuration file.
 
 ```
-$ docker run -v <config-file-path>:/opt/hazelcast/log4j2.properties hazelcast/hazelcast
+$ docker run -v <config-file-path>:/opt/hazelcast/config/log4j2.properties hazelcast/hazelcast
 ```
 
 ## Customizing Hazelcast


### PR DESCRIPTION
The actual location of the configuration file is `/opt/hazelcast/config` as show during startup logs

```
Starting Hazelcast
+ exec /usr/bin/java --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED 
--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED 
--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED 
--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED 
-Dhazelcast.logging.type=log4j2 -Dlog4j.configurationFile=file:/opt/hazelcast/config/log4j2.properties 
-Dhazelcast.config=/opt/hazelcast/config/hazelcast-docker.xml -Djet.custom.lib.dir=/opt/hazelcast/custom-lib 
-Djava.net.preferIPv4Stack=true -XX:MaxRAMPercentage=80.0 -XX:MaxGCPauseMillis=5 
-cp '/opt/hazelcast/*:/opt/hazelcast/lib/*:/opt/hazelcast/lib:/opt/hazelcast/lib/*:/opt/hazelcast/bin/user-lib:/opt/hazelcast/bin/user-lib/*' com.hazelcast.core.server.HazelcastMemberStarter
```