### PR TITLE
Fix typo in HZ_MC_VERSION

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -53,7 +53,7 @@ jobs:
           FILTERED_TAGS=$(git tag --list "${HZ_EE_MAJOR_VERSION}*" |  grep -E -v '.*(BETA|-).*' )
           LATEST_TAG=$(echo -en "${FILTERED_TAGS}" | sort | tail -n 1)
           echo $LATEST_TAG
-          echo "HZ_MC_VERSION=${LATEST_TAG:11}" >> $GITHUB_ENV
+          echo "HZ_MC_VERSION=${LATEST_TAG:1}" >> $GITHUB_ENV
 
       - name: Checkout Code
         uses: actions/checkout@v2


### PR DESCRIPTION
The `LATEST_TAG` in MC version step is in the form of `vx.y.z`. However when creating `HZ_MC_VERSION`, we are creating the substring from 11th character as follows: `HZ_MC_VERSION=${LATEST_TAG:11}` instead of the first one. This PR fixes that typo.