### PR TITLE
Fix jar location for NLC stable release zip files

### DIFF
--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -43,8 +43,8 @@ jobs:
         run: |
           mkdir ./hazelcast-enterprise/tmp 
           aws s3 cp ${S3_NLC_ZIP_URL} ./${ZIP_NAME}
-          unzip -qq ./${ZIP_NAME} 'hazelcast-*/**' -d ./hazelcast-enterprise/tmp/ 
-          mv ./hazelcast-enterprise/tmp/*/lib/hazelcast-enterprise-all-*.jar ./hazelcast-enterprise/
+          unzip -qq ./${ZIP_NAME} "${RELEASE_VERSION}-nlc/hazelcast-enterprise-*/**" -d ./hazelcast-enterprise/tmp/ 
+          mv ./hazelcast-enterprise/tmp/${RELEASE_VERSION}-nlc/hazelcast-enterprise-*/hazelcast-enterprise-all-*.jar ./hazelcast-enterprise/
           
       - name: Login to Docker Hub
         run: echo "${NLC_REPO_TOKEN}" | docker login -u ${NLC_REPO_USERNAME} ${NLC_REPOSITORY} --password-stdin

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -47,7 +47,10 @@ RUN echo "Installing new packages" \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir -p "${HZ_HOME}/lib" \
     && cd "${HZ_HOME}/lib" \
-    && if [ -f ${HZ_HOME}/hazelcast-enterprise-all-*.jar ]; then HAZELCAST_ALL_URL=""; else HAZELCAST_ALL_URL=$( ${HZ_HOME}/get-hz-ee-all-url.sh ); fi \
+    && if [ -f ${HZ_HOME}/hazelcast-enterprise-all-*.jar ]; then \
+         HAZELCAST_ALL_URL=""; mv ${HZ_HOME}/hazelcast-enterprise-all-*.jar ./ ; \
+       else \
+         HAZELCAST_ALL_URL=$( ${HZ_HOME}/get-hz-ee-all-url.sh ); fi \
     && for JAR_URL in ${HAZELCAST_ALL_URL} ${CACHE_API_URL} ${PROMETHEUS_AGENT_URL} ${LOG4J2_URLS}; do curl -sf -O -L ${JAR_URL} || exit $?; done \
     && mv jmx_prometheus_javaagent-*.jar jmx_prometheus_javaagent.jar \
     && echo "Setting Pardot ID to 'docker'" \


### PR DESCRIPTION
Changes:

- For stable `v4` releases, the location of `hazelcast-all` jar in the NLC zip file is different from all other NLC releases, this PR fixes the problem.
- For NLC releases, the pardotID was not set correctly since jar location was under `${HZ_HOME}` instead of `${HZ_HOME}/lib`. The 