### PR TITLE
Add custom distribution zip to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 
+hazelcast/hazelcast-distribution.zip
+hazelcast-enterprise/hazelcast-enterprise-distribution.zip
+


### PR DESCRIPTION
This is useful when trying local build or when we use the docker
repository as submodule of the main repository.