### PR TITLE
Update logging configuration after changes in distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ Note that if you need some more custom logging configuration, you can specify a 
 $ docker run -v <config-file-path>:/opt/hazelcast/config/log4j2.properties hazelcast/hazelcast
 ```
 
+### LOGGING_CONFIG
+
+_since version 5.1_
+
+The logging configuration can be changed using the `LOGGING_CONFIG` variable, for example you can mount your own Log4j2 configuration file and set the path using this variable.
+The default value is set to `/opt/hazelcast/config/log4j2.properties`.
+A relative or an absolute path can be provided.
+
+We also provide `log4j2-json.properties` file in the image. This is using the Log4j2 [log4j-layout-template-json](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html) module. To use it you can do the following:
+
+```
+$ docker run -e LOGGING_CONFIG=log4j2-json.properties hazelcast/hazelcast
+```
+
+See the [Log4j2 manual](https://logging.apache.org/log4j/2.x/manual/) for reference.
+
 ## Customizing Hazelcast
 
 ### Memory

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -55,7 +55,7 @@ RUN echo "Installing new packages" \
     && microdnf -y clean all \
     && rm -rf ${HZ_HOME}/get-hz-ee-dist-zip.sh ${HZ_HOME}/hazelcast-enterprise-distribution.zip ${HZ_HOME}/tmp
 
-COPY log4j2.properties jmx_agent_config.yaml ${HZ_HOME}/config/
+COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml ${HZ_HOME}/config/
 
 RUN echo "Adding non-root user" \
     && groupadd --system hazelcast \

--- a/hazelcast-enterprise/log4j2-json.properties
+++ b/hazelcast-enterprise/log4j2-json.properties
@@ -1,0 +1,9 @@
+# Logging Configuration with JsonLayout template
+
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=JsonTemplateLayout
+appender.console.layout.eventTemplateUri=${env:LOGGING_JSON_TEMPLATE:-classpath:JsonLayout.json}
+
+rootLogger.level=${env:LOGGING_LEVEL:-INFO}
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/hazelcast-enterprise/log4j2.properties
+++ b/hazelcast-enterprise/log4j2.properties
@@ -4,6 +4,7 @@ appender.console.type=Console
 appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=${env:LOGGING_PATTERN}
+appender.console.layout.alwaysWriteExceptions=false
 
-rootLogger.level=${env:LOGGING_LEVEL}
+rootLogger.level=${env:LOGGING_LEVEL:-INFO}
 rootLogger.appenderRef.stdout.ref=STDOUT

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -41,7 +41,7 @@ RUN echo "Installing new APK packages" \
     && apk del libxml2-utils zip unzip \
     && rm -rf /var/cache/apk/* ${HZ_HOME}/get-hz-dist-zip.sh ${HZ_HOME}/hazelcast-distribution.zip ${HZ_HOME}/tmp
 
-COPY log4j2.properties jmx_agent_config.yaml ${HZ_HOME}/config/
+COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml ${HZ_HOME}/config/
 
 WORKDIR ${HZ_HOME}
 

--- a/hazelcast-oss/log4j2-json.properties
+++ b/hazelcast-oss/log4j2-json.properties
@@ -1,0 +1,9 @@
+# Logging Configuration with JsonLayout template
+
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=JsonTemplateLayout
+appender.console.layout.eventTemplateUri=${env:LOGGING_JSON_TEMPLATE:-classpath:JsonLayout.json}
+
+rootLogger.level=${env:LOGGING_LEVEL:-INFO}
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/hazelcast-oss/log4j2.properties
+++ b/hazelcast-oss/log4j2.properties
@@ -4,6 +4,7 @@ appender.console.type=Console
 appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=${env:LOGGING_PATTERN}
+appender.console.layout.alwaysWriteExceptions=false
 
-rootLogger.level=${env:LOGGING_LEVEL}
+rootLogger.level=${env:LOGGING_LEVEL:-INFO}
 rootLogger.appenderRef.stdout.ref=STDOUT


### PR DESCRIPTION
In the Docker image, we use a specific config file without the rolling file
appender (only log to console). The changes in the main distribution
need to be applied to these config files as well.

Set default value for LOGGING_LEVEL in log4j2 properties.

In https://github.com/hazelcast/hazelcast/pull/20528 we removed setting
the default value in the scripts and moved it to the log4j2 config file.
