### PR TITLE
Use UTF-8 as the in-container encoding

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -18,7 +18,7 @@ ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH="" \
     JAVA_OPTS="" \
     HAZELCAST_CONFIG=config/hazelcast-docker.xml \
-    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8 \
     PATH=${HZ_HOME}/bin:$PATH
 
 LABEL name="Hazelcast IMDG Enterprise" \

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -18,6 +18,7 @@ ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH="" \
     JAVA_OPTS="" \
     HAZELCAST_CONFIG=config/hazelcast-docker.xml \
+    LC_ALL=C.UTF-8 \
     PATH=${HZ_HOME}/bin:$PATH
 
 LABEL name="Hazelcast IMDG Enterprise" \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -17,6 +17,7 @@ ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH="" \
     JAVA_OPTS="" \
     HAZELCAST_CONFIG=config/hazelcast-docker.xml \
+    LANG=C.UTF-8 \
     PATH=${HZ_HOME}/bin:$PATH
 
 # Expose port


### PR DESCRIPTION
Fixes hazelcast/hazelcast-enterprise#4787

This change sets the hazelcast-enterprise container's encoding to UTF-8 (instead of the ANSI).
It allows displaying correct emoji characters in the log for instance.

Another option could be forcing the system property `file.encoding=UTF-8` (as a `java` argument). 