### PR TITLE
Create GH release in job without build matrix [HZ-943]

### DIFF
--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -75,8 +75,6 @@ jobs:
 
   post-push:
     runs-on: ubuntu-latest
-    env:
-      DOCKER_ORG: hazelcast
     needs: push
     steps:
       - name: Update Docker Hub Description of OSS image
@@ -85,7 +83,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ${{ env.DOCKER_ORG }}/hazelcast
+          repository: hazelcast/hazelcast
           short-description: Hazelcast Docker Image
           readme-filepath: ./README.md
 
@@ -95,7 +93,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ${{ env.DOCKER_ORG }}/hazelcast-enterprise
+          repository: hazelcast/hazelcast-enterprise
           short-description: Hazelcast Enterprise Docker Image
           readme-filepath: ./README.md
 


### PR DESCRIPTION
When we release docker images the build uses a build matrix, which runs
2 similar jobs - one for full image the other for slim image. Both try
to create the GH release and the second action fails because the release
has already been created, causing the whole workflow run to fail.

This commit moves the release creation (and update of readme, which
needs to be done only once) to a separate job in the workflow, without
the build matrix.