### PR TITLE
Create GH release in job without build matrix [HZ-943] [5.0.z]

### DIFF
--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -61,16 +61,6 @@ jobs:
             ${TAGS} \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
 
-      - name: Update Docker Hub Description of OSS image
-        if: env.PUSH_LATEST == 'yes'
-        uses: peter-evans/dockerhub-description@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ${{ env.DOCKER_ORG }}/hazelcast
-          short-description: Hazelcast Docker Image
-          readme-filepath: ./README.md
-
       - name: Build/Push EE image
         run: |
           TAGS="--tag ${{ env.DOCKER_ORG }}/hazelcast-enterprise:${{ env.RELEASE_VERSION }}${{ matrix.suffix }}"
@@ -83,13 +73,27 @@ jobs:
             ${TAGS} \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise
 
-      - name: Update Docker Hub Description of EE image
+  post-push:
+    runs-on: ubuntu-latest
+    needs: push
+    steps:
+      - name: Update Docker Hub Description of OSS image
         if: env.PUSH_LATEST == 'yes'
-        uses: peter-evans/dockerhub-description@v2
+        uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ${{ env.DOCKER_ORG }}/hazelcast-enterprise
+          repository: hazelcast/hazelcast
+          short-description: Hazelcast Docker Image
+          readme-filepath: ./README.md
+
+      - name: Update Docker Hub Description of EE image
+        if: env.PUSH_LATEST == 'yes'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: hazelcast/hazelcast-enterprise
           short-description: Hazelcast Enterprise Docker Image
           readme-filepath: ./README.md
 


### PR DESCRIPTION
When we release docker images the build uses a build matrix, which runs
2 similar jobs - one for full image the other for slim image. Both try
to create the GH release and the second action fails because the release
has already been created, causing the whole workflow run to fail.

This commit moves the release creation (and update of readme, which
needs to be done only once) to a separate job in the workflow, without
the build matrix.

Backport of #351