### PR TITLE
Use local distribution package for OS if present HZ-1083

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,6 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 
-hazelcast/hazelcast-distribution.zip
+hazelcast-oss/hazelcast-distribution.zip
 hazelcast-enterprise/hazelcast-enterprise-distribution.zip
 

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -39,11 +39,13 @@ COPY *.jar get-hz-ee-dist-zip.sh hazelcast-*.zip ${HZ_HOME}/
 RUN echo "Installing new packages" \
     && microdnf -y --nodocs --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos \
         --disableplugin=subscription-manager install shadow-utils java-11-openjdk-headless zip tar \
-    && echo "Downloading Hazelcast${HZ_VARIANT} distribution zip..." \
     && if [[ ! -f ${HZ_HOME}/hazelcast-enterprise-distribution.zip ]]; then \
         HAZELCAST_ZIP_URL=$(${HZ_HOME}/get-hz-ee-dist-zip.sh); \
+        echo "Downloading Hazelcast${HZ_VARIANT} distribution zip from ${HAZELCAST_ZIP_URL}..."; \
         curl -sf -L ${HAZELCAST_ZIP_URL} --output ${HZ_HOME}/hazelcast-enterprise-distribution.zip; \
-       fi \
+    else \
+           echo "Using local hazelcast-enterprise-distribution.zip"; \
+    fi \
     && unzip -qq ${HZ_HOME}/hazelcast-enterprise-distribution.zip 'hazelcast-*/**' -d ${HZ_HOME}/tmp/ \
     && mv ${HZ_HOME}/tmp/*/* ${HZ_HOME}/ \
     && echo "Setting Pardot ID to 'docker'" \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -23,14 +23,18 @@ ENV HZ_HOME="${HZ_HOME}" \
 # Expose port
 EXPOSE 5701
 
-COPY *.jar get-hz-dist-zip.sh ${HZ_HOME}/
+COPY *.jar get-hz-dist-zip.sh hazelcast-*.zip ${HZ_HOME}/
 
 # Install
 RUN echo "Installing new APK packages" \
     && apk add --no-cache openjdk11-jre-headless bash curl libxml2-utils zip unzip \
-    && echo "Downloading Hazelcast${HZ_VARIANT} distribution zip..." \
-    && HAZELCAST_ZIP_URL=$(${HZ_HOME}/get-hz-dist-zip.sh) \
-    && curl -sf -L ${HAZELCAST_ZIP_URL} --output ${HZ_HOME}/hazelcast-distribution.zip \
+    && if [[ ! -f ${HZ_HOME}/hazelcast-distribution.zip ]]; then \
+       HAZELCAST_ZIP_URL=$(${HZ_HOME}/get-hz-dist-zip.sh); \
+       echo "Downloading Hazelcast${HZ_VARIANT} distribution zip from ${HAZELCAST_ZIP_URL}..."; \
+       curl -sf -L ${HAZELCAST_ZIP_URL} --output ${HZ_HOME}/hazelcast-distribution.zip; \
+    else \
+           echo "Using local hazelcast-distribution.zip"; \
+    fi \
     && unzip -qq ${HZ_HOME}/hazelcast-distribution.zip 'hazelcast-*/**' -d ${HZ_HOME}/tmp/ \
     && mv ${HZ_HOME}/tmp/*/* ${HZ_HOME}/ \
     && echo "Setting Pardot ID to 'docker'" \


### PR DESCRIPTION
Use local hazelcast-distribution.zip if present instead of downloading one from the repository. 

Needed for building custom docker images for Kuberntes-based integration tests