### PR TITLE
Improve vulnerability scans [HZ-1090] [5.1.z]

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -3,6 +3,15 @@ general:
     # ubi-minimal marked as WONTFIX
     - CVE-2019-1010022
     - CVE-2019-5827
+    # https://github.com/hazelcast/hazelcast/blob/master/owasp-check-suppressions.xml#L228-L234
+    - CVE-2020-25644
+    # https://github.com/hazelcast/hazelcast/issues/21045
+    - CVE-2020-36518
+    # False positive - hazelcast-client-3.12.12.jar is not vulnerable
+    # See https://github.com/advisories/GHSA-v57x-gxfj-484q
+    - GHSA-v57x-gxfj-484q
+    # This was present only in 5.1-BETA-1, it was fixed in 5.1 and older versions were not affected
+    - CVE-2022-0265
   bestPracticeViolations:
     # HZ_LICENSE_KEY included as an env variable
     - CIS-DI-0010

--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -1,18 +1,16 @@
 name: Vulnerability Scan
 
 on:
-  schedule:
-    - cron: '0 2 * * *'
   push:
     branches:
-      - master
+      - 5.1.z
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build OSS image
         run: |
@@ -24,9 +22,11 @@ jobs:
       - name: Scan OSS image by Azure (Trivy + Dockle)
         if: always()
         uses: Azure/container-scan@v0
+        env:
+          TRIVY_IGNORE_UNFIXED: true
         with:
           image-name: hazelcast/oss:${{ github.sha }}
-          severity-threshold: MEDIUM
+          severity-threshold: HIGH
 
       - name: Scan OSS image by Snyk
         if: always()
@@ -35,14 +35,16 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: hazelcast/oss:${{ github.sha }}
-          args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan --severity-threshold=medium
+          args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
 
       - name: Scan EE image by Azure (Trivy + Dockle)
         if: always()
         uses: Azure/container-scan@v0
+        env:
+          TRIVY_IGNORE_UNFIXED: true
         with:
           image-name: hazelcast/ee:${{ github.sha }}
-          severity-threshold: MEDIUM
+          severity-threshold: HIGH
 
       - name: Scan EE image by Snyk
         if: always()
@@ -51,4 +53,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: hazelcast/ee:${{ github.sha }}
-          args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan --severity-threshold=medium
+          args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns


### PR DESCRIPTION
Mostly backport of #373 for the branch specific vulnerability scan.
Not updating the scheduled scans as they don't run from this branch.