### PR TITLE
Remove LOG_LEVEL_PATTERN variable from LOGGING_PATTERN [4.2.z]

### DIFF
--- a/hazelcast-enterprise/start-hazelcast.sh
+++ b/hazelcast-enterprise/start-hazelcast.sh
@@ -26,9 +26,9 @@ if [ -z "${LOGGING_LEVEL}" ]; then
 fi
 
 if [ "$(arch)" == "s390x" ]; then
-  export LOGGING_PATTERN="%d [%highlight{\${LOG_LEVEL_PATTERN:-%5p}}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=magenta}][%style{%t{1.}}{cyan}] [%style{%-10c}{blue}]: %m%n"
+  export LOGGING_PATTERN="%d [%highlight{%5p}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=magenta}][%style{%t{1.}}{cyan}] [%style{%-10c}{blue}]: %m%n"
 else
-  export LOGGING_PATTERN="%d [%highlight{\${LOG_LEVEL_PATTERN:-%5p}}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=magenta}] [%style{%t{1.}}{cyan}] [%style{%c{1.}}{blue}]: %m%n"
+  export LOGGING_PATTERN="%d [%highlight{%5p}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=magenta}] [%style{%t{1.}}{cyan}] [%style{%c{1.}}{blue}]: %m%n"
 fi
 
 # for 4.0.x backward compatibility

--- a/hazelcast-oss/start-hazelcast.sh
+++ b/hazelcast-oss/start-hazelcast.sh
@@ -26,9 +26,9 @@ if [ -z "${LOGGING_LEVEL}" ]; then
 fi
 
 if [ "$(arch)" == "s390x" ]; then
-  export LOGGING_PATTERN="%d [%highlight{\${LOG_LEVEL_PATTERN:-%5p}}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=magenta}][%style{%t{1.}}{cyan}] [%style{%-10c}{blue}]: %m%n"
+  export LOGGING_PATTERN="%d [%highlight{%5p}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=magenta}][%style{%t{1.}}{cyan}] [%style{%-10c}{blue}]: %m%n"
 else
-  export LOGGING_PATTERN="%d [%highlight{\${LOG_LEVEL_PATTERN:-%5p}}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=magenta}] [%style{%t{1.}}{cyan}] [%style{%c{1.}}{blue}]: %m%n"
+  export LOGGING_PATTERN="%d [%highlight{%5p}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=magenta}] [%style{%t{1.}}{cyan}] [%style{%c{1.}}{blue}]: %m%n"
 fi
 
 echo "########################################"


### PR DESCRIPTION
Since log4j 2.17.2 it seems it is not possible to use nested
placeholders. See https://github.com/apache/logging-log4j2/pull/732

This resulted in broken log line:
```
2022-04-22 12:43:25,651 [${LOG_LEVEL_PATTERN:- INFO}] [main] [c.h.c.LifecycleService]: [172.17.0.3]:5701 [dev] [4.2.4] [172.17.0.3]:5701 is STARTING
```

Changing only the LOG_LEVEL_PATTERN doesn't seem much useful and we
don't document it anywhere so it seems safe to remove.

Other option would be to use log4j 2.17.1, but it is only a matter of
time before we need to upgrade.