### PR TITLE
Bump redhat/ubi8-minimal from 8.5 to 8.6 in /hazelcast-enterprise [4.1.z]

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM redhat/ubi8-minimal:8.5
+FROM redhat/ubi8-minimal:8.6
 
 # Versions of Hazelcast and Hazelcast plugins
 ARG HZ_VERSION=4.1.9


### PR DESCRIPTION
Bumps redhat/ubi8-minimal from 8.5 to 8.6.

---
updated-dependencies:
- dependency-name: redhat/ubi8-minimal
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit 19fc40ed0e36161ccf7c5731cbdca15dbee25c06)