### PR TITLE
Fix repository URL [5.1.1]

### DIFF
--- a/hazelcast-enterprise/get-hz-ee-dist-zip.sh
+++ b/hazelcast-enterprise/get-hz-ee-dist-zip.sh
@@ -10,13 +10,13 @@ if [[ -n "${HZ_VARIANT}" ]]; then SUFFIX="-${HZ_VARIANT}"; fi
 
 if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]
 then
-    curl -O -fsSL https://repository.hazelcast.com/artifactory/snapshot/com/hazelcast/hazelcast-enterprise-distribution/${HZ_VERSION}/maven-metadata.xml
+    curl -O -fsSL https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/${HZ_VERSION}/maven-metadata.xml
     version=$(xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()" maven-metadata.xml)
 
-    url="https://repository.hazelcast.com/artifactory/snapshot/com/hazelcast/hazelcast-enterprise-distribution/${HZ_VERSION}/hazelcast-enterprise-distribution-${version}${SUFFIX}.zip"
+    url="https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/${HZ_VERSION}/hazelcast-enterprise-distribution-${version}${SUFFIX}.zip"
     rm maven-metadata.xml
 else
-    url="https://repository.hazelcast.com/artifactory/release/com/hazelcast/hazelcast-enterprise-distribution/${HZ_VERSION}/hazelcast-enterprise-distribution-${HZ_VERSION}${SUFFIX}.zip"
+    url="https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-distribution/${HZ_VERSION}/hazelcast-enterprise-distribution-${HZ_VERSION}${SUFFIX}.zip"
 fi
 
 echo $url


### PR DESCRIPTION
Previously URL with `artifactory` worked. With the introduction of
geolocation restriction we must use the URL without `artifactory` part.

Backport of #367