### PR TITLE
Make NLC images smaller #406

### DIFF
--- a/.github/workflows/ee-nlc-snapshot-push.yml
+++ b/.github/workflows/ee-nlc-snapshot-push.yml
@@ -36,7 +36,7 @@ jobs:
           ZIP_NAME=hazelcast-enterprise-${HZ_VERSION}-nlc.zip
           S3_NLC_ZIP_URL=${S3_NLC_URL}/snapshot/${ZIP_NAME}
 
-          HAZELCAST_ZIP_URL="$(aws s3 presign ${S3_NLC_ZIP_URL})"
+          HAZELCAST_ZIP_URL="$(aws s3 presign ${S3_NLC_ZIP_URL} --expires-in 600)"
           echo "HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL}" >> $GITHUB_ENV
 
       - name: Login to Docker Hub

--- a/.github/workflows/ee-nlc-snapshot-push.yml
+++ b/.github/workflows/ee-nlc-snapshot-push.yml
@@ -31,12 +31,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: 'us-east-1'
 
-      - name: Download NLC image from S3
+      - name: Get presigned NLC URL from S3
         run: |
           ZIP_NAME=hazelcast-enterprise-${HZ_VERSION}-nlc.zip
           S3_NLC_ZIP_URL=${S3_NLC_URL}/snapshot/${ZIP_NAME}
 
-          aws s3 cp ${S3_NLC_ZIP_URL} ./hazelcast-enterprise/hazelcast-enterprise-distribution.zip
+          HAZELCAST_ZIP_URL="$(aws s3 presign ${S3_NLC_ZIP_URL})"
+          echo "HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL}" >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         run: echo "${NLC_REPO_TOKEN}" | docker login -u ${NLC_REPO_USERNAME} ${NLC_REPOSITORY} --password-stdin
@@ -45,6 +46,7 @@ jobs:
         run: |
           docker build \
             --build-arg HZ_VERSION=${HZ_VERSION} \
+            --build-arg HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL} \
             --label hazelcast.ee.revision=${{ github.event.inputs.HZ_EE_REVISION }} \
             --tag ${NLC_IMAGE_NAME}:${HZ_VERSION} hazelcast-enterprise
 

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -37,9 +37,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: 'us-east-1'
 
-      - name: Download NLC zip from S3
-        run: aws s3 cp ${S3_NLC_ZIP_URL} ./hazelcast-enterprise/hazelcast-enterprise-distribution.zip
-          
+      - name: Get presigned NLC URL from S3
+        run: |
+          HAZELCAST_ZIP_URL="$(aws s3 presign ${S3_NLC_ZIP_URL})"
+          echo "HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL}" >> $GITHUB_ENV
+
       - name: Login to Docker Hub
         run: echo "${NLC_REPO_TOKEN}" | docker login -u ${NLC_REPO_USERNAME} ${NLC_REPOSITORY} --password-stdin
 
@@ -47,6 +49,7 @@ jobs:
         run: |
           docker build \
             --build-arg HZ_VERSION=${RELEASE_VERSION} \
+            --build-arg HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL} \
             --tag ${NLC_IMAGE_NAME}:${RELEASE_VERSION} hazelcast-enterprise
 
       - name: Push EE image

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Get presigned NLC URL from S3
         run: |
-          HAZELCAST_ZIP_URL="$(aws s3 presign ${S3_NLC_ZIP_URL})"
+          HAZELCAST_ZIP_URL="$(aws s3 presign ${S3_NLC_ZIP_URL} --expires-in 600)"
           echo "HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL}" >> $GITHUB_ENV
 
       - name: Login to Docker Hub

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -8,6 +8,7 @@ ARG HZ_VARIANT=""
 # Build constants
 ARG HZ_HOME="/opt/hazelcast"
 ARG USER_NAME="hazelcast"
+ARG HAZELCAST_ZIP_URL=""
 
 # Runtime variables
 ENV HZ_HOME="${HZ_HOME}" \
@@ -42,7 +43,7 @@ RUN echo "Installing new packages" \
         --disableplugin=subscription-manager install shadow-utils java-11-openjdk-headless zip tar \
     && if [[ ! -f ${HZ_HOME}/hazelcast-enterprise-distribution.zip ]]; then \
         HAZELCAST_ZIP_URL=$(${HZ_HOME}/get-hz-ee-dist-zip.sh); \
-        echo "Downloading Hazelcast${HZ_VARIANT} distribution zip from ${HAZELCAST_ZIP_URL}..."; \
+        echo "Downloading Hazelcast${HZ_VARIANT} distribution zip from ${HAZELCAST_ZIP_URL//\?*/?***********}..."; \
         curl -sf -L ${HAZELCAST_ZIP_URL} --output ${HZ_HOME}/hazelcast-enterprise-distribution.zip; \
     else \
            echo "Using local hazelcast-enterprise-distribution.zip"; \

--- a/hazelcast-enterprise/get-hz-ee-dist-zip.sh
+++ b/hazelcast-enterprise/get-hz-ee-dist-zip.sh
@@ -8,6 +8,9 @@
 # The slim is an artifact with a classifier, need to add `-` there
 if [[ -n "${HZ_VARIANT}" ]]; then SUFFIX="-${HZ_VARIANT}"; fi
 
+# Use predefined $HAZELCAST_ZIP_URL if set
+if [[ -n "${HAZELCAST_ZIP_URL}" ]]; then echo "$HAZELCAST_ZIP_URL"; exit; fi
+
 if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]
 then
     curl -O -fsSL https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/${HZ_VERSION}/maven-metadata.xml


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast-docker/issues/406
Use AWS S3 presigned URL to avoid downloading NLC zip files and adding them as a separate layer

### Tested locally:
```shell
HAZELCAST_ZIP_URL="$(aws s3 presign s3://<hazelcast-nlc-zip-distribution>.zip --expires-in 600)"
echo $HAZELCAST_ZIP_URL # to verify
docker buildx build --build-arg HZ_VERSION=5.1.1 --build-arg HAZELCAST_ZIP_URL="$HAZELCAST_ZIP_URL" hazelcast-enterprise -t hazelcast-enterprise:test-nlc-AFTER
```
Comparison:
```
$ docker images | less               
REPOSITORY                                                              TAG                     IMAGE ID       CREATED         SIZE
hazelcast-enterprise                                                    test-nlc-AFTER          18a8f722b664   2 minutes ago   914MB
hazelcast-enterprise                                                    test-nlc-BEFORE         1a8381418d13   3 hours ago     1.42GB
```