### PR TITLE
Add preflight scan for RHEL docker images [HZ-1209]

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -102,6 +102,19 @@ jobs:
           docker login ${SCAN_REGISTRY} -u unused -p ${HZ_EE_RHEL_REPO_PASSWORD}
           docker push ${RHEL_IMAGE}
 
+      - name: Install preflight tool
+        run: |
+          PREFLIGHT_VERSION=$(curl -s https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/releases/latest | grep 'tag_name' | cut -d\" -f4)
+          wget https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/${PREFLIGHT_VERSION}/preflight-linux-amd64
+          chmod +x preflight-linux-amd64
+
+      - name: Run preflight scan
+        run: |
+          PROJECT_ID=$( echo ${HZ_EE_RHEL_REPOSITORY} | grep -m 1 -Po "/\K.+(?=/)" )
+          ./preflight-linux-amd64 check container ${RHEL_IMAGE} \
+          --submit --pyxis-api-token=${RHEL_API_KEY} \
+          --certification-project-id=$PROJECT_ID
+
       - name: Wait for Scan to Complete
         run: |
           PROJECT_ID=$( echo ${HZ_EE_RHEL_REPOSITORY} | grep -m 1 -Po "/\K.+(?=/)" )

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -113,7 +113,8 @@ jobs:
           PROJECT_ID=$( echo ${HZ_EE_RHEL_REPOSITORY} | grep -m 1 -Po "/\K.+(?=/)" )
           ./preflight-linux-amd64 check container ${RHEL_IMAGE} \
           --submit --pyxis-api-token=${RHEL_API_KEY} \
-          --certification-project-id=$PROJECT_ID
+          --certification-project-id=$PROJECT_ID \
+          --docker-config ~/.docker/config.json
 
       - name: Wait for Scan to Complete
         run: |

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -43,7 +43,7 @@ RUN echo "Installing new packages" \
         --disableplugin=subscription-manager install shadow-utils java-11-openjdk-headless zip tar \
     && if [[ ! -f ${HZ_HOME}/hazelcast-enterprise-distribution.zip ]]; then \
         HAZELCAST_ZIP_URL=$(${HZ_HOME}/get-hz-ee-dist-zip.sh); \
-        echo "Downloading Hazelcast${HZ_VARIANT} distribution zip from ${HAZELCAST_ZIP_URL//\?*/?***********}..."; \
+        echo "Downloading Hazelcast${HZ_VARIANT} distribution zip from ${HAZELCAST_ZIP_URL%\?*}..."; \
         curl -sf -L ${HAZELCAST_ZIP_URL} --output ${HZ_HOME}/hazelcast-enterprise-distribution.zip; \
     else \
            echo "Using local hazelcast-enterprise-distribution.zip"; \

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -43,7 +43,7 @@ RUN echo "Installing new packages" \
         --disableplugin=subscription-manager install shadow-utils java-11-openjdk-headless zip tar \
     && if [[ ! -f ${HZ_HOME}/hazelcast-enterprise-distribution.zip ]]; then \
         HAZELCAST_ZIP_URL=$(${HZ_HOME}/get-hz-ee-dist-zip.sh); \
-        echo "Downloading Hazelcast${HZ_VARIANT} distribution zip from ${HAZELCAST_ZIP_URL%\?*}..."; \
+        echo "Downloading Hazelcast${HZ_VARIANT} distribution zip from $(echo $HAZELCAST_ZIP_URL | sed "s/?.*//g")..."; \
         curl -sf -L ${HAZELCAST_ZIP_URL} --output ${HZ_HOME}/hazelcast-enterprise-distribution.zip; \
     else \
            echo "Using local hazelcast-enterprise-distribution.zip"; \


### PR DESCRIPTION
The Redhat process for doing container certifications has changed on April 25th. The new process uses a `preflight` tool on a local system. 

A new step running `preflight` tool has been added to the workflow publishing docker images on Redhat Catalog.

Related to https://hazelcast.atlassian.net/browse/HZ-1209

More info here: https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_software_certification_workflow_guide/proc_running-the-certification-test-suite_openshift-sw-cert-workflow-complete-pre-certification-checklist-for-containers

## Testing
A new `5.1.1-1` HZ EE release was performed with success: https://catalog.redhat.com/software/containers/hazelcast/hazelcast-enterprise-5-rhel8/615ffdc404fd1c67039dbcc8