### PR TITLE
Add option for a custom release of HZ OSS image

### DIFF
--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -6,6 +6,14 @@ on:
       - "!*"
     tags:
       - "v5.*"
+  workflow_dispatch:
+    inputs:
+      HZ_VERSION:
+        description: 'Version of Hazelcast to build the image for, e.g. 5.1.1, 5.0.1, 4.2.3'
+        required: true
+      RELEASE_VERSION:
+        description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
+        required: false
 
 jobs:
   push:
@@ -19,14 +27,31 @@ jobs:
            suffix: ''
     env:
       DOCKER_ORG: hazelcast
+      HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
+      RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
     steps:
+      - name: Set HZ version as environment variable
+        run: |
+          if [ -z "${{ env.HZ_VERSION }}" ]; then
+             HZ_VERSION=${GITHUB_REF:11}
+          else
+             HZ_VERSION=${{ env.HZ_VERSION }}
+          fi
+          echo "HZ_VERSION=${HZ_VERSION}" >> $GITHUB_ENV
+
+      - name: Set Release version as environment variable
+        run: |
+          if [ -z "${{ env.RELEASE_VERSION }}" ]; then
+             RELEASE_VERSION=${{ env.HZ_VERSION }}
+          else
+             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+          fi
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Set Release Version
-        run: echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
 
       - name: Check if latest tag should be pushed
         run: |
@@ -56,7 +81,7 @@ jobs:
             TAGS="${TAGS} --tag ${{ env.DOCKER_ORG }}/hazelcast:latest${{ matrix.suffix }}"
           fi
           docker buildx build --push \
-            --build-arg HZ_VERSION=${{ env.RELEASE_VERSION }} \
+            --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
             --build-arg HZ_VARIANT=${{ matrix.variant }} \
             ${TAGS} \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
@@ -68,7 +93,7 @@ jobs:
             TAGS="${TAGS} --tag ${{ env.DOCKER_ORG }}/hazelcast-enterprise:latest${{ matrix.suffix }}"
           fi
           docker buildx build --push \
-            --build-arg HZ_VERSION=${{ env.RELEASE_VERSION }} \
+            --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
             --build-arg HZ_VARIANT=${{ matrix.variant }} \
             ${TAGS} \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise


### PR DESCRIPTION
Adds a manual trigger for releasing the HZ OSS image with a custom release version

OSS backport of https://github.com/hazelcast/hazelcast-docker/pull/401