### PR TITLE
Update oss base image to alpine 3.16.1 [4.1.z]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hasancelik @pivovarit 
+* @hazelcast/platform

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.16.1
 
 # Versions of Hazelcast and Hazelcast plugins
 ARG HZ_VERSION=4.1.9


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/416