### PR TITLE
Remove temporarily s390x OSS build due to missing openjdk package (#434) [4.2.z]

### DIFF
--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -38,4 +38,4 @@ jobs:
             --build-arg HZ_VERSION=${{ github.event.inputs.HZ_VERSION }} \
             --label hazelcast.revision=${{ github.event.inputs.HZ_REVISION }} \
             $TAGS \
-            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
+            --platform=linux/arm64,linux/amd64,linux/ppc64le hazelcast-oss

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -49,7 +49,7 @@ jobs:
           docker buildx build --push \
             --build-arg HZ_VERSION=${{ env.RELEASE_VERSION }} \
             ${TAGS} \
-            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
+            --platform=linux/arm64,linux/amd64,linux/ppc64le hazelcast-oss
 
       - name: Update Docker Hub Description of OSS image
         if: env.PUSH_LATEST == 'yes'


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/434