### PR TITLE
Remove temporarily s390x OSS build due to missing openjdk package (#434) [5.1.z]

### DIFF
--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -48,4 +48,4 @@ jobs:
             --build-arg HZ_VARIANT=${{ matrix.variant }} \
             --label hazelcast.revision=${{ github.event.inputs.HZ_REVISION }} \
             $TAGS \
-            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
+            --platform=linux/arm64,linux/amd64,linux/ppc64le hazelcast-oss

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -84,7 +84,7 @@ jobs:
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
             --build-arg HZ_VARIANT=${{ matrix.variant }} \
             ${TAGS} \
-            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-oss
+            --platform=linux/arm64,linux/amd64,linux/ppc64le hazelcast-oss
 
       - name: Build/Push EE image
         run: |


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/434