### PR TITLE
Bump alpine from 3.16.1 to 3.16.2 in /hazelcast-oss [4.2.z]

### DIFF
--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 
 # Versions of Hazelcast and Hazelcast plugins
 ARG HZ_VERSION=4.2.5


### PR DESCRIPTION
Bumps alpine from 3.16.1 to 3.16.2.

---
updated-dependencies:
- dependency-name: alpine
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>