### PR TITLE
Fix UBI repository ids [4.2.z]

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -42,7 +42,7 @@ COPY licenses /licenses
 
 # Install
 RUN echo "Installing new packages" \
-    && microdnf -y --nodocs --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos \
+    && microdnf -y --nodocs --disablerepo=* --enablerepo=ubi-8-appstream-rpms --enablerepo=ubi-8-baseos-rpms \
         --disableplugin=subscription-manager install shadow-utils java-11-openjdk-headless zip tar \
     && echo "Downloading Hazelcast and related JARs" \
     && mkdir -p "${HZ_HOME}/lib" \


### PR DESCRIPTION
This page https://access.redhat.com/articles/4238681 lists the repositories with the `-rpms` suffix.

Not sure if this changed recently or if there is some other change causing the previous value not to work.