### PR TITLE
Checkout default MC version in RHEL build job to check tags [5.2.1]

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -56,7 +56,6 @@ jobs:
           repository: hazelcast/management-center-openshift
           path: management-center-openshift
           fetch-depth: 0
-          ref: v${{ env.HZ_VERSION }}
 
       - name: Set Hazelcast Enterprise RHEL repository and password
         working-directory: management-center-openshift


### PR DESCRIPTION
We don't need to checkout MC with the same same version as HZ. We need MC repo only to check git tags and find the matching version in `Set Management Center Version to be used in the tests` step