### PR TITLE
Always cleanup OpenShift test env even when helm release not present

### DIFF
--- a/.github/scripts/clean-up.sh
+++ b/.github/scripts/clean-up.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-set -e
-set -o pipefail
-
 PROJECT=$1
 helm uninstall ${PROJECT} --timeout 30s
 oc delete project ${PROJECT}


### PR DESCRIPTION
Forward port of https://github.com/hazelcast/hazelcast-docker/pull/480