### PR TITLE
Use unique project name for each RHEL workflow re-run [5.1.5]

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Deploy Hazelcast Cluster
         run: |
           WORKDIR=$(pwd)/.github/scripts
-          PROJECT=hz-ee-test-${{ github.run_id }}
+          PROJECT=hz-ee-test-${{ github.run_id }}-${{ github.run_attempt }}
           .github/scripts/smoke-test.sh \
                         "$WORKDIR" \
                         "$PROJECT"  \


### PR DESCRIPTION
oc delete $PROJECT only schedule the deletion so immediate re-runs can fail with:
```
Error from server (AlreadyExists): project.project.openshift.io "hz-ee-test-3462598144" already exists
```

Details: https://cookbook.openshift.org/projects-and-user-collaboration/why-when-i-try-to-create-a-new-project-does-it-keep-failing.html