### PR TITLE
Use shorter project name to avoid too long k8s labels

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Deploy Hazelcast Cluster
         run: |
           WORKDIR=$(pwd)/.github/scripts
-          PROJECT=hz-ee-test-${{ github.run_id }}-${{ github.run_attempt }}
+          PROJECT=hztest-${{ github.run_id }}-${{ github.run_attempt }}
           .github/scripts/smoke-test.sh \
                         "$WORKDIR" \
                         "$PROJECT"  \
@@ -134,7 +134,7 @@ jobs:
 
       - name: Validate Cluster Size
         run: |
-          PROJECT=hz-ee-test-${{ github.run_id }}-${{ github.run_attempt }}
+          PROJECT=hztest-${{ github.run_id }}-${{ github.run_attempt }}
           HZ_NAME=$PROJECT
           NAME=hazelcast-enterprise
 
@@ -158,7 +158,7 @@ jobs:
       - name: Clean up After Test
         if: always()
         run: |
-          PROJECT=hz-ee-test-${{ github.run_id }}-${{ github.run_attempt }}
+          PROJECT=hztest-${{ github.run_id }}-${{ github.run_attempt }}
           .github/scripts/clean-up.sh $PROJECT
 
       - name: Publish the Hazelcast Enterprise image


### PR DESCRIPTION
MC pods wasn't created due to error:
```
Invalid value: "hz-ee-test-3463507195-2-hazelcast-enterprise-mancenter-7b4b9ccff9": must be no more than 63 characters
```

Found with `kubectl get events -n $NAMESPACE -w` command ❤️ 