### PR TITLE
Use unique project name for each RHEL workflow re-run

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Deploy Hazelcast Cluster
         run: |
           WORKDIR=$(pwd)/.github/scripts
-          PROJECT=hz-ee-test-${{ github.run_id }}
+          PROJECT=hztest-${{ github.run_id }}-${{ github.run_attempt }}
           .github/scripts/smoke-test.sh \
                         "$WORKDIR" \
                         "$PROJECT"  \
@@ -134,7 +134,7 @@ jobs:
 
       - name: Validate Cluster Size
         run: |
-          PROJECT=hz-ee-test-${{ github.run_id }}
+          PROJECT=hztest-${{ github.run_id }}-${{ github.run_attempt }}
           HZ_NAME=$PROJECT
           NAME=hazelcast-enterprise
 
@@ -153,7 +153,7 @@ jobs:
       - name: Clean up After Test
         if: always()
         run: |
-          PROJECT=hz-ee-test-${{ github.run_id }}
+          PROJECT=hztest-${{ github.run_id }}-${{ github.run_attempt }}
           .github/scripts/clean-up.sh $PROJECT
 
       - name: Publish the Hazelcast Enterprise image


### PR DESCRIPTION
For quick re-runs we can hit the error the OC project still exists (deletion of the projects is only scheduled). It's safer to use unique project for reach re-run of the build

Prefix of the `PROJECT` variable was shortened since the variable is used for K8s labels which have limit of 63 characters.