### PR TITLE
Always pull the new HZ image for RHEL tests

### DIFF
--- a/.github/scripts/values.yaml
+++ b/.github/scripts/values.yaml
@@ -1,6 +1,7 @@
 image:
   repository: SCAN_REPOSITORY
   tag: RELEASE_VERSION
+  pullPolicy: Always
   pullSecrets:
     - PULL_SECRET
 cluster:


### PR DESCRIPTION
It helps with re-running tests against previously broken docker image