### PR TITLE
Bump alpine from 3.16.2 to 3.17.0 in /hazelcast-oss (#520) [5.2.z]

### DIFF
--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.2
+FROM alpine:3.17.0
 
 # Versions of Hazelcast
 ARG HZ_VERSION=5.2.2-SNAPSHOT


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/520

Bumps alpine from 3.16.2 to 3.17.0.

---
updated-dependencies:
- dependency-name: alpine dependency-type: direct:production update-type: version-update:semver-minor ...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit 9094cbb6128f8d5151a7cb5c2847b7b1cf7703ce)