### PR TITLE
Bump alpine from 3.17.1 to 3.17.2 in /hazelcast-oss (#546) [4.2.z]

### DIFF
--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.1
+FROM alpine:3.17.2
 
 # Versions of Hazelcast and Hazelcast plugins
 ARG HZ_VERSION=4.2.7


### PR DESCRIPTION
(cherry picked from commit 7655a386a2051b83089f6383f96c423b2f40d9e1)