### PR TITLE
Add option to build specific images: OSS or EE only

### DIFF
--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -14,6 +14,15 @@ on:
       RELEASE_VERSION:
         description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         required: false
+      EDITIONS:
+        description: 'Editions to build'
+        required: true
+        default: 'All'
+        type: choice
+        options:
+          - All
+          - OSS
+          - EE
 
 jobs:
   push:
@@ -29,6 +38,7 @@ jobs:
       DOCKER_ORG: hazelcast
       HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
+      EDITIONS: ${{ github.event.inputs.EDITIONS || 'All' }}
     steps:
       - name: Set HZ version as environment variable
         run: |
@@ -75,6 +85,7 @@ jobs:
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Build/Push OSS image
+        if: env.EDITIONS == 'All' || env.EDITIONS == 'OSS'
         run: |
           . .github/scripts/get-tags-to-push.sh 
           TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }})
@@ -91,6 +102,7 @@ jobs:
             --platform=linux/arm64,linux/amd64,linux/ppc64le hazelcast-oss
 
       - name: Build/Push EE image
+        if: env.EDITIONS == 'All' || env.EDITIONS == 'EE'
         run: |
           . .github/scripts/get-tags-to-push.sh 
           TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }})
@@ -109,9 +121,11 @@ jobs:
   post-push:
     runs-on: ubuntu-latest
     needs: push
+    env:
+      EDITIONS: ${{ github.event.inputs.EDITIONS || 'All' }}
     steps:
       - name: Update Docker Hub Description of OSS image
-        if: env.PUSH_LATEST == 'yes'
+        if: env.PUSH_LATEST == 'yes' && (env.EDITIONS == 'All' || env.EDITIONS == 'OSS' )
         uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -121,7 +135,7 @@ jobs:
           readme-filepath: ./README.md
 
       - name: Update Docker Hub Description of EE image
-        if: env.PUSH_LATEST == 'yes'
+        if: env.PUSH_LATEST == 'yes' && (env.EDITIONS == 'All' || env.EDITIONS == 'EE' )
         uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -134,3 +148,4 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true


### PR DESCRIPTION
We need it for rebuilding docker images when a base image has changed . Without out we would rebuild EE images even if only OSS base image has changed 

Tested by building 5.2.3 OSS: https://github.com/hazelcast/hazelcast-docker/actions/runs/4730569479/jobs/8394457914

<img width="394" alt="image" src="https://user-images.githubusercontent.com/1242724/232729089-b055671e-54ec-4204-a94f-4477729289a3.png">


<img width="998" alt="image" src="https://user-images.githubusercontent.com/1242724/232728948-89ab92ad-8401-42c9-9b6a-9288bf906b7e.png">

