### PR TITLE
Update docker tags for minor and major versions (#554) [5.2.z]

### DIFF
--- a/.github/scripts/assert.sh/LICENSE
+++ b/.github/scripts/assert.sh/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Márk Török
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.github/scripts/assert.sh/assert.sh
+++ b/.github/scripts/assert.sh/assert.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+
+#####################################################################
+##
+## title: Assert Extension
+##
+## description:
+## Assert extension of shell (bash, ...)
+##   with the common assert functions
+## Function list based on:
+##   http://junit.sourceforge.net/javadoc/org/junit/Assert.html
+## Log methods : inspired by
+##	- https://natelandau.com/bash-scripting-utilities/
+## author: Mark Torok
+##
+## date: 07. Dec. 2016
+##
+## license: MIT
+##
+#####################################################################
+
+if command -v tput &>/dev/null && tty -s; then
+  RED=$(tput setaf 1)
+  GREEN=$(tput setaf 2)
+  MAGENTA=$(tput setaf 5)
+  NORMAL=$(tput sgr0)
+  BOLD=$(tput bold)
+else
+  RED=$(echo -en "\e[31m")
+  GREEN=$(echo -en "\e[32m")
+  MAGENTA=$(echo -en "\e[35m")
+  NORMAL=$(echo -en "\e[00m")
+  BOLD=$(echo -en "\e[01m")
+fi
+
+log_header() {
+  printf "\n${BOLD}${MAGENTA}==========  %s  ==========${NORMAL}\n" "$@" >&2
+}
+
+log_success() {
+  printf "${GREEN}✔ %s${NORMAL}\n" "$@" >&2
+}
+
+log_failure() {
+  printf "${RED}✖ %s${NORMAL}\n" "$@" >&2
+}
+
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="${3-}"
+
+  if [ "$expected" == "$actual" ]; then
+    log_success "$expected == $actual :: $msg" || true
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$expected == $actual :: $msg" || true
+    return 1
+  fi
+}
+
+assert_not_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="${3-}"
+
+  if [ ! "$expected" == "$actual" ]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$expected != $actual :: $msg" || true
+    return 1
+  fi
+}
+
+assert_true() {
+  local actual="$1"
+  local msg="${2-}"
+
+  assert_eq true "$actual" "$msg"
+  return "$?"
+}
+
+assert_false() {
+  local actual="$1"
+  local msg="${2-}"
+
+  assert_eq false "$actual" "$msg"
+  return "$?"
+}
+
+assert_array_eq() {
+
+  declare -a expected=("${!1-}")
+  # echo "AAE ${expected[@]}"
+
+  declare -a actual=("${!2}")
+  # echo "AAE ${actual[@]}"
+
+  local msg="${3-}"
+
+  local return_code=0
+  if [ ! "${#expected[@]}" == "${#actual[@]}" ]; then
+    return_code=1
+  fi
+
+  local i
+  for (( i=1; i < ${#expected[@]} + 1; i+=1 )); do
+    if [ ! "${expected[$i-1]}" == "${actual[$i-1]}" ]; then
+      return_code=1
+      break
+    fi
+  done
+
+  if [ "$return_code" == 1 ]; then
+    [ "${#msg}" -gt 0 ] && log_failure "(${expected[*]}) != (${actual[*]}) :: $msg" || true
+  fi
+
+  return "$return_code"
+}
+
+assert_array_not_eq() {
+
+  declare -a expected=("${!1-}")
+  declare -a actual=("${!2}")
+
+  local msg="${3-}"
+
+  local return_code=1
+  if [ ! "${#expected[@]}" == "${#actual[@]}" ]; then
+    return_code=0
+  fi
+
+  local i
+  for (( i=1; i < ${#expected[@]} + 1; i+=1 )); do
+    if [ ! "${expected[$i-1]}" == "${actual[$i-1]}" ]; then
+      return_code=0
+      break
+    fi
+  done
+
+  if [ "$return_code" == 1 ]; then
+    [ "${#msg}" -gt 0 ] && log_failure "(${expected[*]}) == (${actual[*]}) :: $msg" || true
+  fi
+
+  return "$return_code"
+}
+
+assert_empty() {
+  local actual=$1
+  local msg="${2-}"
+
+  assert_eq "" "$actual" "$msg"
+  return "$?"
+}
+
+assert_not_empty() {
+  local actual=$1
+  local msg="${2-}"
+
+  assert_not_eq "" "$actual" "$msg"
+  return "$?"
+}
+
+assert_contain() {
+  local haystack="$1"
+  local needle="${2-}"
+  local msg="${3-}"
+
+  if [ -z "${needle:+x}" ]; then
+    return 0;
+  fi
+
+  if [ -z "${haystack##*$needle*}" ]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$haystack doesn't contain $needle :: $msg" || true
+    return 1
+  fi
+}
+
+assert_not_contain() {
+  local haystack="$1"
+  local needle="${2-}"
+  local msg="${3-}"
+
+  if [ -z "${needle:+x}" ]; then
+    return 0;
+  fi
+
+  if [ "${haystack##*$needle*}" ]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$haystack contains $needle :: $msg" || true
+    return 1
+  fi
+}
+
+assert_gt() {
+  local first="$1"
+  local second="$2"
+  local msg="${3-}"
+
+  if [[ "$first" -gt  "$second" ]]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$first > $second :: $msg" || true
+    return 1
+  fi
+}
+
+assert_ge() {
+  local first="$1"
+  local second="$2"
+  local msg="${3-}"
+
+  if [[ "$first" -ge  "$second" ]]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$first >= $second :: $msg" || true
+    return 1
+  fi
+}
+
+assert_lt() {
+  local first="$1"
+  local second="$2"
+  local msg="${3-}"
+
+  if [[ "$first" -lt  "$second" ]]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$first < $second :: $msg" || true
+    return 1
+  fi
+}
+
+assert_le() {
+  local first="$1"
+  local second="$2"
+  local msg="${3-}"
+
+  if [[ "$first" -le  "$second" ]]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$first <= $second :: $msg" || true
+    return 1
+  fi
+}

--- a/.github/scripts/get-tags-to-push.sh
+++ b/.github/scripts/get-tags-to-push.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+function find_last_matching_version() {
+  FILTER=$1
+  git tag | grep -v BETA | grep '^v' | cut -c2- | grep "^$FILTER" | tail -n 1
+}
+
+function get_latest_version() {
+  find_last_matching_version ""
+}
+
+function verlte() {
+  [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
+}
+
+function get_tags_to_push() {
+  VERSION_TO_RELEASE=$1
+
+  if [[ "$VERSION_TO_RELEASE" =~ .*BETA.* ]]; then
+    echo "$VERSION_TO_RELEASE"
+    return
+  fi
+
+  MINOR_VERSION_TO_RELEASE=${VERSION_TO_RELEASE%.*}
+  MAJOR_VERSION_TO_RELEASE=${MINOR_VERSION_TO_RELEASE%.*}
+
+  LATEST_FOR_MINOR=$(find_last_matching_version $MINOR_VERSION_TO_RELEASE)
+  LATEST_FOR_MAJOR=$(find_last_matching_version $MAJOR_VERSION_TO_RELEASE)
+  LATEST=$(get_latest_version)
+
+  TAGS_TO_PUSH+=($VERSION_TO_RELEASE)
+
+  if verlte "$LATEST_FOR_MINOR" "$VERSION_TO_RELEASE"; then
+    TAGS_TO_PUSH+=($MINOR_VERSION_TO_RELEASE)
+  fi
+
+  if verlte "$LATEST_FOR_MAJOR" "$VERSION_TO_RELEASE"; then
+    TAGS_TO_PUSH+=($MAJOR_VERSION_TO_RELEASE)
+  fi
+
+  if verlte "$LATEST" "$VERSION_TO_RELEASE"; then
+    TAGS_TO_PUSH+=(latest)
+  fi
+
+  echo "${TAGS_TO_PUSH[@]}"
+}

--- a/.github/scripts/get-tags-to-push_tests.sh
+++ b/.github/scripts/get-tags-to-push_tests.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+function findScriptDir() {
+  CURRENT=$PWD
+
+  DIR=$(dirname "$0")
+  cd "$DIR" || exit
+  TARGET_FILE=$(basename "$0")
+
+  # Iterate down a (possible) chain of symlinks
+  while [ -L "$TARGET_FILE" ]
+  do
+      TARGET_FILE=$(readlink "$TARGET_FILE")
+      DIR=$(dirname "$TARGET_FILE")
+      cd "$DIR" || exit
+      TARGET_FILE=$(basename "$TARGET_FILE")
+  done
+
+  SCRIPT_DIR=$(pwd -P)
+  # Restore current directory
+  cd "$CURRENT" || exit
+}
+
+findScriptDir
+
+. "$SCRIPT_DIR"/assert.sh/assert.sh
+. "$SCRIPT_DIR"/get-tags-to-push.sh
+
+TESTS_RESULT=0
+
+function assert_tags_to_push {
+  local VERSION_TO_RELEASE=$1
+  local EXPECTED_TAGS_TO_PUSH=$2
+  local ACTUAL_TAGS_TO_PUSH=$(get_tags_to_push "$VERSION_TO_RELEASE")
+  assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "Tags to push for version $VERSION_TO_RELEASE should be equal to $EXPECTED_TAGS_TO_PUSH " || TESTS_RESULT=$?
+}
+
+log_header "Tests for get_tags_to_push"
+assert_tags_to_push "5.2.0" "5.2.0"
+assert_tags_to_push "5.2.1" "5.2.1"
+assert_tags_to_push "5.1.99" "5.1.99 5.1"
+assert_tags_to_push "4.99.0" "4.99.0 4.99 4"
+assert_tags_to_push "99.0.0" "99.0.0 99.0 99 latest"
+assert_tags_to_push "5.3.0-BETA-1" "5.3.0-BETA-1"
+assert_tags_to_push "5.99.0-BETA-1" "5.99.0-BETA-1"
+assert_tags_to_push "99.0.0-BETA-1" "99.0.0-BETA-1"
+
+assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/.github/scripts/test_scripts.sh
+++ b/.github/scripts/test_scripts.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function findScriptDir() {
+  CURRENT=$PWD
+
+  DIR=$(dirname "$0")
+  cd "$DIR" || exit
+  TARGET_FILE=$(basename "$0")
+
+  # Iterate down a (possible) chain of symlinks
+  while [ -L "$TARGET_FILE" ]
+  do
+      TARGET_FILE=$(readlink "$TARGET_FILE")
+      DIR=$(dirname "$TARGET_FILE")
+      cd "$DIR" || exit
+      TARGET_FILE=$(basename "$TARGET_FILE")
+  done
+
+  SCRIPT_DIR=$(pwd -P)
+  # Restore current directory
+  cd "$CURRENT" || exit
+}
+
+findScriptDir
+
+find "$SCRIPT_DIR" -name "*_tests.sh" -print0 | xargs -0 -n1 bash

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,9 +15,15 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v2
+
+      - name: Test scripts
+        run: |
+          ./.github/scripts/test_scripts.sh
 
       - name: Build OSS image
         run: |

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -87,27 +87,35 @@ jobs:
       - name: Build/Push OSS image
         if: env.EDITIONS == 'All' || env.EDITIONS == 'OSS'
         run: |
-          TAGS="--tag ${{ env.DOCKER_ORG }}/hazelcast:${{ env.RELEASE_VERSION }}${{ matrix.suffix }}"
-          if [[ "${{ env.PUSH_LATEST }}" == "yes" ]]; then
-            TAGS="${TAGS} --tag ${{ env.DOCKER_ORG }}/hazelcast:latest${{ matrix.suffix }}"
-          fi
+          . .github/scripts/get-tags-to-push.sh 
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }})
+          echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
+          TAGS_ARG=""
+          for tag in ${TAGS_TO_PUSH[@]}
+          do
+             TAGS_ARG="${TAGS_ARG} --tag ${{ env.DOCKER_ORG }}/hazelcast:${tag}${{ matrix.suffix }}"
+          done
           docker buildx build --push \
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
             --build-arg HZ_VARIANT=${{ matrix.variant }} \
-            ${TAGS} \
+            ${TAGS_ARG} \
             --platform=linux/arm64,linux/amd64,linux/ppc64le hazelcast-oss
 
       - name: Build/Push EE image
         if: env.EDITIONS == 'All' || env.EDITIONS == 'EE'
         run: |
-          TAGS="--tag ${{ env.DOCKER_ORG }}/hazelcast-enterprise:${{ env.RELEASE_VERSION }}${{ matrix.suffix }}"
-          if [[ "${{ env.PUSH_LATEST }}" == "yes" ]]; then
-            TAGS="${TAGS} --tag ${{ env.DOCKER_ORG }}/hazelcast-enterprise:latest${{ matrix.suffix }}"
-          fi
+          . .github/scripts/get-tags-to-push.sh 
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }})
+          echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
+          TAGS_ARG=""
+          for tag in ${TAGS_TO_PUSH[@]}
+          do
+             TAGS_ARG="${TAGS_ARG} --tag ${{ env.DOCKER_ORG }}/hazelcast-enterprise:${tag}${{ matrix.suffix }}"
+          done
           docker buildx build --push \
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
             --build-arg HZ_VARIANT=${{ matrix.variant }} \
-            ${TAGS} \
+            ${TAGS_ARG} \
             --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x hazelcast-enterprise
 
   post-push:


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/554

* Update docker tags for minor and major

* Simplify pushing latest tags

* Print pushed tags

(cherry picked from commit 46cdbf6b6ef01d61b699640a83d7940740612898)