### PR TITLE
Bump alpine from 3.17.2 to 3.18.0 in /hazelcast-oss (#575) [5.1.z]

### DIFF
--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.18.0
 
 # Versions of Hazelcast
 ARG HZ_VERSION=5.1.7-SNAPSHOT


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/575