### PR TITLE
Fix trivy scanning [5.3.z]

### DIFF
--- a/.github/containerscan/trivy.yaml
+++ b/.github/containerscan/trivy.yaml
@@ -1,6 +1,9 @@
 dependency-tree: true
 exit-code: 1
 ignorefile: .github/containerscan/.trivyignore
+severity:
+  - CRITICAL
+  - HIGH
 vulnerability:
   ignore-unfixed: true
 debug: true

--- a/.github/scripts/version.functions.sh
+++ b/.github/scripts/version.functions.sh
@@ -7,11 +7,11 @@ function get_supported_versions() {
 
 function get_minor_versions() {
   local MINIMAL_VERSION=$1
-  get_supported_versions "$MINIMAL_VERSION" | cut -c1,2,3 | uniq
+  get_supported_versions "$MINIMAL_VERSION" | cut -d'-' -f1 |  cut  -d'.' -f1,2 | uniq
 }
 
 function get_latest_patch_version() {
-  local MINOR_VERSION=${1:0:3}
+  local MINOR_VERSION=$(echo "$1" | cut  -d'-' -f1 |  cut  -d'.' -f1,2)
   get_supported_versions "" | grep "$MINOR_VERSION" | tail -n 1
 }
 

--- a/.github/scripts/version.functions_tests.sh
+++ b/.github/scripts/version.functions_tests.sh
@@ -74,6 +74,7 @@ assert_latest_patch_version "4.1" "4.1.10"
 assert_latest_patch_version "3.9" "3.9.4"
 
 log_header "Tests for get_minor_versions"
+assert_minor_versions_contain "3.12" "3.12"
 assert_minor_versions_contain "4.2" "4.2"
 assert_minor_versions_contain "4.2" "5.0"
 assert_minor_versions_contain "4.2" "5.1"

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -16,7 +16,7 @@ on:
                 type: string
 
 jobs:
-  build:
+  scan-oss:
     env:
       DOCKLE_HOST: "unix:///var/run/docker.sock"
     runs-on: ubuntu-latest
@@ -29,17 +29,13 @@ jobs:
       - name: Build OSS image
         run: |
             docker build -t hazelcast/oss:${{ github.sha }} hazelcast-oss
-      - name: Build EE image
-        run: |
-            docker build -t hazelcast/ee:${{ github.sha }} hazelcast-enterprise
 
       - name: Scan OSS image by Trivy
         if: always()
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.11.2
         with:
           image-ref: hazelcast/oss:${{ github.sha }}
           trivy-config: .github/containerscan/trivy.yaml
-          severity: 'CRITICAL,HIGH'
 
       - name: Scan OSS image by Dockle
         if: always()
@@ -59,13 +55,26 @@ jobs:
           image: hazelcast/oss:${{ github.sha }}
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
 
+  scan-ee:
+    env:
+      DOCKLE_HOST: "unix:///var/run/docker.sock"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code at ${{ inputs.ref }} branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Build EE image
+        run: |
+          docker build -t hazelcast/ee:${{ github.sha }} hazelcast-enterprise
+
       - name: Scan EE image by Trivy
         if: always()
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.11.2
         with:
           image-ref: hazelcast/ee:${{ github.sha }}
           trivy-config: .github/containerscan/trivy.yaml
-          severity: 'CRITICAL,HIGH'
 
       - name: Scan EE image by Dockle
         if: always()


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/596

There was a bug in trivy-action that was fixed, so we need to revert our workaround: https://github.com/aquasecurity/trivy-action/issues/238

Also due to potential instability decided to pin the action version 

Also made image scanning parallel