### PR TITLE
Fix trivy scanning [5.1.z]

### DIFF
--- a/.github/containerscan/trivy.yaml
+++ b/.github/containerscan/trivy.yaml
@@ -1,6 +1,9 @@
 dependency-tree: true
 exit-code: 1
 ignorefile: .github/containerscan/.trivyignore
+severity:
+  - CRITICAL
+  - HIGH
 vulnerability:
   ignore-unfixed: true
 debug: true

--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -6,7 +6,9 @@ on:
       - 5.1.z
 
 jobs:
-  build:
+  scan-oss:
+    env:
+      DOCKLE_HOST: "unix:///var/run/docker.sock"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -15,17 +17,13 @@ jobs:
       - name: Build OSS image
         run: |
           docker build -t hazelcast/oss:${{ github.sha }} hazelcast-oss
-      - name: Build EE image
-        run: |
-          docker build -t hazelcast/ee:${{ github.sha }} hazelcast-enterprise
 
       - name: Scan OSS image by Trivy
         if: always()
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.11.2
         with:
           image-ref: hazelcast/oss:${{ github.sha }}
           trivy-config: .github/containerscan/trivy.yaml
-          severity: 'CRITICAL,HIGH'
 
       - name: Scan OSS image by Dockle
         if: always()
@@ -45,13 +43,24 @@ jobs:
           image: hazelcast/oss:${{ github.sha }}
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
 
+  scan-ee:
+    env:
+      DOCKLE_HOST: "unix:///var/run/docker.sock"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Build EE image
+        run: |
+          docker build -t hazelcast/ee:${{ github.sha }} hazelcast-enterprise
+
       - name: Scan EE image by Trivy
         if: always()
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.11.2
         with:
           image-ref: hazelcast/ee:${{ github.sha }}
           trivy-config: .github/containerscan/trivy.yaml
-          severity: 'CRITICAL,HIGH'
 
       - name: Scan EE image by Dockle
         if: always()


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/596

There was a bug in trivy-action that was fixed, so we need to revert our workaround: https://github.com/aquasecurity/trivy-action/issues/238

Also due to potential instability decided to pin the action version 

Also made image scanning parallel