### PR TITLE
Fix trivy scanning [4.2.z]

### DIFF
--- a/.github/containerscan/trivy.yaml
+++ b/.github/containerscan/trivy.yaml
@@ -6,3 +6,4 @@ severity:
   - HIGH
 vulnerability:
   ignore-unfixed: true
+debug: true

--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -6,7 +6,7 @@ on:
       - 4.2.z
 
 jobs:
-  build:
+  scan-oss:
     env:
       DOCKLE_HOST: "unix:///var/run/docker.sock"
     runs-on: ubuntu-latest
@@ -17,13 +17,10 @@ jobs:
       - name: Build OSS image
         run: |
           docker build -t hazelcast/oss:${{ github.sha }} hazelcast-oss
-      - name: Build EE image
-        run: |
-          docker build -t hazelcast/ee:${{ github.sha }} hazelcast-enterprise
 
       - name: Scan OSS image by Trivy
         if: always()
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.11.2
         with:
           image-ref: hazelcast/oss:${{ github.sha }}
           trivy-config: .github/containerscan/trivy.yaml
@@ -46,9 +43,21 @@ jobs:
           image: hazelcast/oss:${{ github.sha }}
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
 
+  scan-ee:
+    env:
+      DOCKLE_HOST: "unix:///var/run/docker.sock"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Build EE image
+        run: |
+          docker build -t hazelcast/ee:${{ github.sha }} hazelcast-enterprise
+
       - name: Scan EE image by Trivy
         if: always()
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.11.2
         with:
           image-ref: hazelcast/ee:${{ github.sha }}
           trivy-config: .github/containerscan/trivy.yaml


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/596

There was a bug in trivy-action that was fixed, so we need to revert our workaround: https://github.com/aquasecurity/trivy-action/issues/238

Also due to potential instability decided to pin the action version 

Also made image scanning parallel