### PR TITLE
Use alpine:3 as a base image for OSS image

### DIFF
--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.0
+FROM alpine:3
 
 # Versions of Hazelcast
 ARG HZ_VERSION=5.4.0-SNAPSHOT


### PR DESCRIPTION
To avoid manual updates, automatic rebuilds of our docker images should keep them up-to-date and save us manual work