### PR TITLE
Run smoke tests against EE images and fix tzdata in EE [5.0.z]

### DIFF
--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -9,7 +9,7 @@ function test_docker_image() {
     local image=$1
     local container_name=$2
     echo "Starting container '$container_name' from image '$image'"
-    docker run -it --name "$container_name" -d -p5701:5701 "$image"
+    docker run -it --name "$container_name" -e HZ_LICENSEKEY -d -p5701:5701 "$image"
     local key="some-key"
     local expected="some-value"
     echo "Putting value '$expected' for key '$key'"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -5,8 +5,10 @@ on:
   pull_request:
 
 env:
-  test_container_name: hazelcast-oss-test
-  docker_log_file: docker-hazelcast-oss-test.log
+  test_container_name_oss: hazelcast-oss-test
+  test_container_name_ee: hazelcast-ee-test
+  docker_log_file_oss: docker-hazelcast-oss-test.log
+  docker_log_file_ee: docker-hazelcast-ee-test.log
 
 jobs:
   build-pr-oss:
@@ -32,16 +34,29 @@ jobs:
       - name: Run smoke test against OSS image
         timeout-minutes: 2
         run: |
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name }}
+          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }}
+
+      - name: Build Test EE image
+        run: |
+          docker buildx build --load --tag hazelcast-ee:test hazelcast-enterprise
+
+      - name: Run smoke test against EE image
+        timeout-minutes: 2
+        run: |
+          export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
+          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }}
 
       - name: Get docker logs
         if: ${{ always() }}
         run: |
-          docker logs ${{ env.test_container_name }} > ${{ env.docker_log_file }}
+          docker logs ${{ env.test_container_name_oss }} > ${{ env.docker_log_file_oss }}
+          docker logs ${{ env.test_container_name_ee }} > ${{ env.docker_log_file_ee }}
 
       - name: Store docker logs as artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.docker_log_file }}
-          path: ${{ env.docker_log_file }}
+          name: docker-logs
+          path: |
+            ${{ env.docker_log_file_oss }}
+            ${{ env.docker_log_file_ee }}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -23,6 +23,9 @@ on:
           - All
           - OSS
           - EE
+env:
+  test_container_name_oss: hazelcast-oss-test
+  test_container_name_ee: hazelcast-ee-test
 
 jobs:
   push:
@@ -48,6 +51,8 @@ jobs:
              HZ_VERSION=${{ env.HZ_VERSION }}
           fi
           echo "HZ_VERSION=${HZ_VERSION}" >> $GITHUB_ENV
+          echo "DOCKER_LOG_FILE_OSS=docker-hazelcast-oss-test${{ matrix.suffix }}.log" >> $GITHUB_ENV
+          echo "DOCKER_LOG_FILE_EE=docker-hazelcast-ee-test${{ matrix.suffix }}.log" >> $GITHUB_ENV
 
       - name: Set Release version as environment variable
         run: |
@@ -59,7 +64,7 @@ jobs:
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -74,17 +79,63 @@ jobs:
           echo ${{ env.PUSH_LATEST }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1.1.0
+        uses: docker/setup-qemu-action@v2.2.0
 
       - name:  Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1.6.0
+        uses: docker/setup-buildx-action@v2.2.1
         with:
           version: v0.5.1
 
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
-      - name: Build/Push OSS image
+      - name: Build Test OSS image
+        if: env.EDITIONS == 'All' || env.EDITIONS == 'OSS'
+        run: |
+          docker buildx build --load \
+            --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
+            --build-arg HZ_VARIANT=${{ matrix.variant }} \
+            --tag hazelcast-oss:test \
+            hazelcast-oss
+
+      - name: Run smoke test against OSS image
+        if: env.EDITIONS == 'All' || env.EDITIONS == 'OSS'
+        timeout-minutes: 2
+        run: |
+          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }}
+
+      - name: Build Test EE image
+        if: env.EDITIONS == 'All' || env.EDITIONS == 'EE'
+        run: |
+          docker buildx build --load \
+            --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
+            --build-arg HZ_VARIANT=${{ matrix.variant }} \
+            --tag hazelcast-ee:test \
+            hazelcast-enterprise
+
+      - name: Run smoke test against EE image
+        if: env.EDITIONS == 'All' || env.EDITIONS == 'EE'
+        timeout-minutes: 2
+        run: |
+          export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
+          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }}
+
+      - name: Get docker logs
+        if: ${{ always() }}
+        run: |
+          docker logs ${{ env.test_container_name_oss }} > ${{ env.DOCKER_LOG_FILE_OSS }} || true
+          docker logs ${{ env.test_container_name_ee }} > ${{ env.DOCKER_LOG_FILE_EE }} || true
+
+      - name: Store docker logs as artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: docker-logs
+          path: | 
+            ${{ env.DOCKER_LOG_FILE_OSS }}
+            ${{ env.DOCKER_LOG_FILE_EE }}
+
+      - name: Build and Push OSS image
         if: env.EDITIONS == 'All' || env.EDITIONS == 'OSS'
         run: |
           . .github/scripts/get-tags-to-push.sh 
@@ -145,6 +196,7 @@ jobs:
           readme-filepath: ./README.md
 
       - name: Create release
+        if: github.event_name == 'push'
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM redhat/ubi8-minimal:8.7
+FROM redhat/ubi8-minimal:8.8
 
 # Versions of Hazelcast
 ARG HZ_VERSION=5.0.6-SNAPSHOT
@@ -8,6 +8,7 @@ ARG HZ_VARIANT=""
 # Build constants
 ARG HZ_HOME="/opt/hazelcast"
 ARG USER_NAME="hazelcast"
+ARG HAZELCAST_ZIP_URL=""
 
 # Runtime variables
 ENV HZ_HOME="${HZ_HOME}" \
@@ -40,11 +41,13 @@ COPY *.jar get-hz-ee-dist-zip.sh hazelcast-*.zip ${HZ_HOME}/
 RUN echo "Installing new packages" \
     && microdnf update --nodocs \
     && microdnf -y --nodocs --disablerepo=* --enablerepo=ubi-8-appstream-rpms --enablerepo=ubi-8-baseos-rpms \
-        --disableplugin=subscription-manager install shadow-utils java-11-openjdk-headless zip tar \
-    && echo "Downloading Hazelcast${HZ_VARIANT} distribution zip..." \
+        --disableplugin=subscription-manager install shadow-utils java-11-openjdk-headless zip tar tzdata-java \
     && if [[ ! -f ${HZ_HOME}/hazelcast-enterprise-distribution.zip ]]; then \
         HAZELCAST_ZIP_URL=$(${HZ_HOME}/get-hz-ee-dist-zip.sh); \
+        echo "Downloading Hazelcast${HZ_VARIANT} distribution zip from $(echo $HAZELCAST_ZIP_URL | sed "s/?.*//g")..."; \
         curl -sf -L ${HAZELCAST_ZIP_URL} --output ${HZ_HOME}/hazelcast-enterprise-distribution.zip; \
+    else \
+           echo "Using local hazelcast-enterprise-distribution.zip"; \
        fi \
     && unzip -qq ${HZ_HOME}/hazelcast-enterprise-distribution.zip 'hazelcast-*/**' -d ${HZ_HOME}/tmp/ \
     && mv ${HZ_HOME}/tmp/*/* ${HZ_HOME}/ \


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/606

- Added smoke tests for EE builds 
- Added missing TZDATA for java (more details: https://bugzilla.redhat.com/show_bug.cgi?id=2224483)
- Manually run from a branch to fix EE 5.3.1 image: https://github.com/hazelcast/hazelcast-docker/actions/runs/5623878118
- Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/6265