### PR TITLE
Ignore CVEs without upstream fixes

### DIFF
--- a/.github/containerscan/.trivyignore
+++ b/.github/containerscan/.trivyignore
@@ -5,3 +5,6 @@ CVE-2022-3171
 
 #See https://github.com/hazelcast/hazelcast/issues/20807 and https://issues.apache.org/jira/browse/HADOOP-18197
 CVE-2021-22570
+
+#See https://github.com/hazelcast/hazelcast/issues/24981
+CVE-2023-2976

--- a/.github/containerscan/.trivyignore
+++ b/.github/containerscan/.trivyignore
@@ -2,3 +2,6 @@
 
 #See https://github.com/hazelcast/hazelcast/issues/20807 and https://issues.apache.org/jira/browse/HADOOP-18197
 CVE-2022-3171
+
+#See https://github.com/hazelcast/hazelcast/issues/20807 and https://issues.apache.org/jira/browse/HADOOP-18197
+CVE-2021-22570


### PR DESCRIPTION
Ignore CVE-2021-22570 and CVE-2023-2976 as they have to be fixed in the upstream