### PR TITLE
Ignore CVE-2023-33265 in HZ 3 connector [4.2.z]

### DIFF
--- a/.github/containerscan/.trivyignore
+++ b/.github/containerscan/.trivyignore
@@ -1,10 +1,13 @@
 # Add ignored CVEs in new lines below
 
-#See https://github.com/hazelcast/hazelcast/issues/20807 and https://issues.apache.org/jira/browse/HADOOP-18197
+# See https://github.com/hazelcast/hazelcast/issues/20807 and https://issues.apache.org/jira/browse/HADOOP-18197
 CVE-2022-3171
 
-#See https://github.com/hazelcast/hazelcast/issues/20807 and https://issues.apache.org/jira/browse/HADOOP-18197
+# See https://github.com/hazelcast/hazelcast/issues/20807 and https://issues.apache.org/jira/browse/HADOOP-18197
 CVE-2021-22570
 
-#See https://github.com/hazelcast/hazelcast/issues/24981
+# See https://github.com/hazelcast/hazelcast/issues/24981
 CVE-2023-2976
+
+# This issue is reported due to HZ 3 connector which was removed in 5.4.0-SNAPSHOT. This fix was applied only for 5.x+ HZ versions
+CVE-2023-33265


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/622

This issue is reported due to HZ 3 connector which was removed in 5.4.0-SNAPSHOT. This fix was applied only for 5.x+ HZ versions