### PR TITLE
Add .gitattributes file to project [HZ-2901]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# linux line-endings
+*.sh        text eol=lf


### PR DESCRIPTION
So that on Windows the .sh script files are preserved with LF line endings [HZ-2901]

[HZ-2901]: https://hazelcast.atlassian.net/browse/HZ-2901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ