### PR TITLE
Add .gitattributes file to project [HZ-2901]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# linux line-endings
+*.sh        text eol=lf


### PR DESCRIPTION
So that on Windows the .sh script files are preserved with LF line endings 
Jira : https://hazelcast.atlassian.net/browse/HZ-2901

The original PR was created from the fork repository, but it does not compile. The PR needs to be created directly on the HZ repo