### PR TITLE
Ignore scanning env variables in dockle due to false positives [4.2.z]

### DIFF
--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -33,6 +33,8 @@ jobs:
           format: 'list'
           exit-code: '1'
           exit-level: 'warn'
+          # too many false positives, we don't use credentials in Dockerfile
+          ignore: 'CIS-DI-0010'
 
       - name: Scan OSS image by Snyk
         if: always()
@@ -70,6 +72,8 @@ jobs:
           format: 'list'
           exit-code: '1'
           exit-level: 'warn'
+          # too many false positives, we don't use credentials in Dockerfile
+          ignore: 'CIS-DI-0010'
 
       - name: Scan EE image by Snyk
         if: always()


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/627

The scan reports `HZ_HOME,HZ_VERSION,CLASSPATH_DEFAULT,HAZELCAST_ZIP_URL,JAVA_OPTS_DEFAULT,hazelcastDownloadId` and suspicious env variables, they're all false positives. Also we don't use any credentials in our Dockerfiles

Fixes: https://hazelcast.atlassian.net/browse/HZ-2977