### PR TITLE
Rebuild NLC docker image when base system has changed

### DIFF
--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -95,5 +95,6 @@ jobs:
           echo "Rebuilding ${{ matrix.version }} EE image"
           gh workflow run tag_image_push.yml --ref v${{ matrix.version }} -f HZ_VERSION=${{ matrix.version }} -f EDITIONS=EE
           gh workflow run tag_image_push_rhel.yml --ref v${{ matrix.version }} -f HZ_VERSION=${{ matrix.version }}
+          gh workflow run ee-nlc-tag-push.yml --ref v${{ matrix.version }} -f HZ_VERSION=${{ matrix.version }}
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Automatically rebuilds NLC release images whenever a base system has changed

Blocked by https://github.com/hazelcast/hazelcast-docker/pull/654 and its backports