### PR TITLE
Update 5.3.z SNAPSHOT version to 5.3.6 [5.3.z] 

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -1,7 +1,7 @@
 FROM redhat/ubi8-minimal:8.7
 
 # Versions of Hazelcast
-ARG HZ_VERSION=5.3.4-SNAPSHOT
+ARG HZ_VERSION=5.3.6-SNAPSHOT
 # Variant - empty for full, "slim" for slim
 ARG HZ_VARIANT=""
 

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18.0
 
 # Versions of Hazelcast
-ARG HZ_VERSION=5.3.4-SNAPSHOT
+ARG HZ_VERSION=5.3.6-SNAPSHOT
 # Variant - empty for full, "slim" for slim
 ARG HZ_VARIANT=""
 


### PR DESCRIPTION
We have skipped 5.3.3 and 5.3.4 and released 5.3.5 instead. This change will ensure next release (5.3.6) is properly created from 5.3.z

Fixes: [[HZ-3546]](https://hazelcast.atlassian.net/browse/HZ-3546)

[HZ-3546]: https://hazelcast.atlassian.net/browse/HZ-3546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ