### PR TITLE
Do not push multiple tags for DEVEL versions [4.2.z]

### DIFF
--- a/.github/scripts/get-tags-to-push.sh
+++ b/.github/scripts/get-tags-to-push.sh
@@ -2,7 +2,7 @@
 
 function find_last_matching_version() {
   FILTER=$1
-  git tag | grep -v BETA | grep '^v' | cut -c2- | grep "^$FILTER" | tail -n 1
+  git tag | grep -v BETA | grep -v DEVEL | grep '^v' | cut -c2- | grep "^$FILTER" | tail -n 1
 }
 
 function get_latest_version() {
@@ -16,7 +16,7 @@ function verlte() {
 function get_tags_to_push() {
   VERSION_TO_RELEASE=$1
 
-  if [[ "$VERSION_TO_RELEASE" =~ .*BETA.* ]]; then
+  if [[ "$VERSION_TO_RELEASE" =~ .*BETA.*|.*DEVEL.* ]]; then
     echo "$VERSION_TO_RELEASE"
     return
   fi

--- a/.github/scripts/get-tags-to-push_tests.sh
+++ b/.github/scripts/get-tags-to-push_tests.sh
@@ -42,6 +42,7 @@ assert_tags_to_push "5.1.99" "5.1.99 5.1"
 assert_tags_to_push "4.99.0" "4.99.0 4.99 4"
 assert_tags_to_push "99.0.0" "99.0.0 99.0 99 latest"
 assert_tags_to_push "5.3.0-BETA-1" "5.3.0-BETA-1"
+assert_tags_to_push "5.4.0-DEVEL-9" "5.4.0-DEVEL-9"
 assert_tags_to_push "5.99.0-BETA-1" "5.99.0-BETA-1"
 assert_tags_to_push "99.0.0-BETA-1" "99.0.0-BETA-1"
 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/674

It also breaks automatic rebuilds of the `latest` tag