### PR TITLE
Manually create release 5.3.6 branch from v5.3.5 [HZ-3673][5.3.6]

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -1,7 +1,7 @@
 FROM redhat/ubi8-minimal:8.7
 
 # Versions of Hazelcast
-ARG HZ_VERSION=5.3.5
+ARG HZ_VERSION=5.3.6-SNAPSHOT
 # Variant - empty for full, "slim" for slim
 ARG HZ_VARIANT=""
 

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18.0
 
 # Versions of Hazelcast
-ARG HZ_VERSION=5.3.5
+ARG HZ_VERSION=5.3.6-SNAPSHOT
 # Variant - empty for full, "slim" for slim
 ARG HZ_VARIANT=""
 


### PR DESCRIPTION
Manually create release branch 5.3.6 from v5.3.5 and update version to 5.3.6-SNAPSHOT

Fixes: [HZ-3673]

[HZ-3673]: https://hazelcast.atlassian.net/browse/HZ-3673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ