### PR TITLE
Fix finding latest patch version. [5.3.6]

### DIFF
--- a/.github/scripts/version.functions.sh
+++ b/.github/scripts/version.functions.sh
@@ -12,7 +12,7 @@ function get_minor_versions() {
 
 function get_latest_patch_version() {
   local MINOR_VERSION=$(echo "$1" | cut  -d'-' -f1 |  cut  -d'.' -f1,2)
-  get_supported_versions "" | grep "$MINOR_VERSION" | tail -n 1
+  get_supported_versions "" | grep "^$MINOR_VERSION" | tail -n 1
 }
 
 function get_latest_patch_versions() {


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/666

'5.4.0-DEVEL-5' was recognized as the latest '4.0' patch version because it contains '4.0'. It resulted with build failures:

![image](https://github.com/hazelcast/hazelcast-docker/assets/1242724/5f6f17d8-dd49-4cc9-960c-dd92bb387923)

Within this fix we check if a tested version starts with a given minor version

This is required for https://hazelcast.atlassian.net/browse/HZ-3673