### PR TITLE
Change GH Action to only build EE

### DIFF
--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -17,7 +17,7 @@ on:
       EDITIONS:
         description: 'Editions to build'
         required: true
-        default: 'All'
+        default: 'EE'
         type: choice
         options:
           - All


### PR DESCRIPTION
5.4.0-BETA-1 is an Internal release and we don't want to push OSS image

Note: not tested as not sure how?

Fixes: [HZ-3849]

[HZ-3849]: https://hazelcast.atlassian.net/browse/HZ-3849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ