### PR TITLE
Fix upgrade to ubi 9.3

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -39,7 +39,7 @@ COPY *.jar get-hz-ee-dist-zip.sh hazelcast-*.zip ${HZ_HOME}/
 
 # Install
 RUN echo "Installing new packages" \
-    && microdnf update --nodocs \
+    && microdnf -y update --nodocs \
     && microdnf -y --nodocs --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms \
         --disableplugin=subscription-manager install shadow-utils java-${JDK_VERSION}-openjdk-headless zip tar tzdata-java \
     && if [[ ! -f ${HZ_HOME}/hazelcast-enterprise-distribution.zip ]]; then \


### PR DESCRIPTION
Make all microdnf commands non-interactive

Fixes https://github.com/hazelcast/hazelcast-docker/pull/673

The PR above passed tests since there were no packages to upgrade when the PR checks were run