### PR TITLE
Remove MaxGCPauseMillis=5ms from docker image [SUP-354]

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -14,7 +14,7 @@ ARG HAZELCAST_ZIP_URL=""
 # Runtime variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -XX:MaxRAMPercentage=80.0 -XX:MaxGCPauseMillis=5" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -XX:MaxRAMPercentage=80.0" \
     PROMETHEUS_PORT="" \
     PROMETHEUS_CONFIG="${HZ_HOME}/config/jmx_agent_config.yaml" \
     CLASSPATH="" \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -12,7 +12,7 @@ ARG JDK_VERSION="11"
 # Runtime variables
 ENV HZ_HOME="${HZ_HOME}" \
     CLASSPATH_DEFAULT="${HZ_HOME}/*" \
-    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -XX:MaxRAMPercentage=80.0 -XX:MaxGCPauseMillis=5" \
+    JAVA_OPTS_DEFAULT="-Djava.net.preferIPv4Stack=true -XX:MaxRAMPercentage=80.0" \
     PROMETHEUS_PORT="" \
     PROMETHEUS_CONFIG="${HZ_HOME}/config/jmx_agent_config.yaml" \
     CLASSPATH="" \


### PR DESCRIPTION
Use default GC settings and let users tune the GC depending on their use case

Fixes https://hazelcast.atlassian.net/browse/SUP-354 

Fixes https://github.com/hazelcast/hazelcast-docker/issues/323

Discussion: https://hazelcast.slack.com/archives/C01JU7ZJYGP/p1705502603741759