### PR TITLE
Remove Java 11 from Docker runtime images [HZ-4198]

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ '11', '17', '21' ]
+        jdk: [ '17', '21' ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/ee-nlc-snapshot-push.yml
+++ b/.github/workflows/ee-nlc-snapshot-push.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ '11', '17', '21' ]
+        jdk: [ '17', '21' ]
     env:
       HZ_VERSION : ${{ github.event.inputs.HZ_VERSION }}
       NLC_REPOSITORY: ${{ secrets.NLC_REPOSITORY }}

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ '11', '17', '21' ]
+        jdk: [ '17', '21' ]
     env:
       NLC_REPOSITORY: ${{ secrets.NLC_REPOSITORY }}
       NLC_REPO_USERNAME: ${{ secrets.NLC_REPO_USERNAME }}

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        jdk: [ '11', '17', '21' ]
+        jdk: [ '17', '21' ]
         variant: [ 'slim','' ]
         include:
           - variant: slim

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ '11', '17', '21' ]
+        jdk: [ '17', '21' ]
         variant: [ 'slim','' ]
         include:
           - variant: slim

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        jdk: [ '11', '17', '21' ]
+        jdk: [ '17', '21' ]
         variant: [ 'slim','' ]
         include:
           - variant: slim

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ '11', '17', '21' ]
+        jdk: [ '17', '21' ]
     steps:
       - name: Set HZ version as environment variable
         run: |

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -4,7 +4,7 @@ FROM redhat/ubi9-minimal:9.3
 ARG HZ_VERSION=5.4.0-SNAPSHOT
 # Variant - empty for full, "slim" for slim
 ARG HZ_VARIANT=""
-ARG JDK_VERSION="11"
+ARG JDK_VERSION="17"
 
 # Build constants
 ARG HZ_HOME="/opt/hazelcast"

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -7,7 +7,7 @@ ARG HZ_VARIANT=""
 
 # Build constants
 ARG HZ_HOME="/opt/hazelcast"
-ARG JDK_VERSION="11"
+ARG JDK_VERSION="17"
 
 # Runtime variables
 ENV HZ_HOME="${HZ_HOME}" \


### PR DESCRIPTION
To support increasing Java version of Hazelcast 5.4 to Java 17, Java 11 Docker image must be removed.

Fixes: [HZ-4198](https://hazelcast.atlassian.net/browse/HZ-4198)

[HZ-4198]: https://hazelcast.atlassian.net/browse/HZ-4198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ