### PR TITLE
Upgrade CLC in simple smoke test

### DIFF
--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -16,7 +16,7 @@ function test_docker_image() {
     clc map set -n some-map $key $expected --log.path stderr
     echo "Getting value for key '$key'"
     local actual
-    actual=$(clc map get -n some-map $key --log.path stderr)
+    actual=$(clc map get --format delimited -n some-map $key --log.path stderr)
     echo "Stopping container $container_name}"
     docker stop "$container_name"
 
@@ -27,9 +27,9 @@ function test_docker_image() {
 }
 
 function install_clc() {
-  CLC_URL="https://github.com/hazelcast/hazelcast-commandline-client/releases/download/${CLC_VERSION}/hazelcast-clc_${CLC_VERSION}_linux_amd64.tar.gz"
-  curl -L $CLC_URL | tar xzf - --strip-components=1 -C /usr/local/bin
-  chmod +x /usr/local/bin/clc
+  curl https://hazelcast.com/clc/install.sh | bash
+  . ~/.bashrc
+  clc config add default cluster.name=dev cluster.address=localhost
 }
 
 install_clc

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -3,8 +3,6 @@
 set -e
 set -o pipefail
 
-export CLC_VERSION=v5.2.0-beta3
-
 function test_docker_image() {
     local image=$1
     local container_name=$2
@@ -28,7 +26,7 @@ function test_docker_image() {
 
 function install_clc() {
   curl https://hazelcast.com/clc/install.sh | bash
-  . ~/.bashrc
+  export PATH=$PATH:$HOME/.hazelcast/bin
   clc config add default cluster.name=dev cluster.address=localhost
 }
 

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -11,7 +11,11 @@ function test_docker_image() {
     local key="some-key"
     local expected="some-value"
     echo "Putting value '$expected' for key '$key'"
-    clc map set -n some-map $key $expected --log.path stderr
+    while ! clc --timeout 5s map set -n some-map $key $expected --log.path stderr
+    do
+      echo "Retrying..."
+      sleep 3
+    done
     echo "Getting value for key '$key'"
     local actual
     actual=$(clc map get --format delimited -n some-map $key --log.path stderr)


### PR DESCRIPTION
- Use the latest CLC for smoke tests
- Add retrying for CLC in smoke tests