### PR TITLE
Prepare 5.2.5 release branch from v5.2.4 [HZ-3723][5.2.5] #198

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -1,7 +1,7 @@
 FROM redhat/ubi8-minimal:8.7
 
 # Versions of Hazelcast
-ARG HZ_VERSION=5.2.4
+ARG HZ_VERSION=5.2.5-SNAPSHOT
 # Variant - empty for full, "slim" for slim
 ARG HZ_VARIANT=""
 

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18.0
 
 # Versions of Hazelcast
-ARG HZ_VERSION=5.2.4
+ARG HZ_VERSION=5.2.5-SNAPSHOT
 # Variant - empty for full, "slim" for slim
 ARG HZ_VARIANT=""
 


### PR DESCRIPTION
Changes to prepare for 5.2.5 release

Branch was manually created from v5.2.4
Updated version manually to 5.2.5-SNAPSHOT