### PR TITLE
Update version to 5.2.6-SNAPSHOT [HZ-3723][5.2.z]

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -1,7 +1,7 @@
 FROM redhat/ubi8-minimal:8.7
 
 # Versions of Hazelcast
-ARG HZ_VERSION=5.2.5-SNAPSHOT
+ARG HZ_VERSION=5.2.6-SNAPSHOT
 # Variant - empty for full, "slim" for slim
 ARG HZ_VARIANT=""
 

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18.0
 
 # Versions of Hazelcast
-ARG HZ_VERSION=5.2.5-SNAPSHOT
+ARG HZ_VERSION=5.2.6-SNAPSHOT
 # Variant - empty for full, "slim" for slim
 ARG HZ_VARIANT=""
 


### PR DESCRIPTION
Update version in 5.2.z to 5.2.6-SNAPSHOT

Follow-up from https://github.com/hazelcast/hazelcast-docker/pull/723

Fixes: [HZ-3723]

[HZ-3723]: https://hazelcast.atlassian.net/browse/HZ-3723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ