### PR TITLE
Fix verification of docker image in RH catalog [5.2.z]

### DIFF
--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -46,7 +46,9 @@ wait_for_container_scan()
         local IMAGE=$(get_image not_published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}")
         local SCAN_STATUS=$(echo "$IMAGE" | jq -r '.data[0].scan_status')
 
-        if [[ $SCAN_STATUS == "in progress" ]]; then
+        if [[ $SCAN_STATUS == "pending" ]]; then
+            echo "Scanning pending, waiting..."
+        elif [[ $SCAN_STATUS == "in progress" ]]; then
             echo "Scanning in progress, waiting..."
         elif [[ $SCAN_STATUS == "null" ]];  then
             echo "Image is still not present in the registry!"


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/726

There were API changes.  It turned out that `container_grades.status` can be also `pending` which we haven't handled

![image](https://github.com/hazelcast/hazelcast-docker/assets/1242724/1ec14ada-4b9b-4687-8245-8d119f27b4f8)


https://catalog.redhat.com/api/containers/docs/objects/ContainerGrading.html?tab=Fields