### PR TITLE
Use proper resolving url for snapshot distribution zips

### DIFF
--- a/hazelcast-enterprise/get-hz-ee-dist-zip.sh
+++ b/hazelcast-enterprise/get-hz-ee-dist-zip.sh
@@ -14,7 +14,11 @@ if [[ -n "${HAZELCAST_ZIP_URL}" ]]; then echo "$HAZELCAST_ZIP_URL"; exit; fi
 if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]
 then
     curl -O -fsSL https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/${HZ_VERSION}/maven-metadata.xml
-    version=$(xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()" maven-metadata.xml)
+    classifier_filter="not(classifier)"
+    if [ -n "$HZ_VARIANT" ]; then
+        classifier_filter="classifier='$HZ_VARIANT'"
+    fi
+    version=$(xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[extension='zip' and $classifier_filter]/value/text()" maven-metadata.xml)
 
     url="https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/${HZ_VERSION}/hazelcast-enterprise-distribution-${version}${SUFFIX}.zip"
     rm maven-metadata.xml

--- a/hazelcast-oss/get-hz-dist-zip.sh
+++ b/hazelcast-oss/get-hz-dist-zip.sh
@@ -11,7 +11,11 @@ if [[ -n "${HZ_VARIANT}" ]]; then SUFFIX="-${HZ_VARIANT}"; fi
 if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]
 then
     curl -O -fsSL https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-distribution/${HZ_VERSION}/maven-metadata.xml
-    version=$(xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[1]/value/text()" maven-metadata.xml)
+    classifier_filter="not(classifier)"
+    if [ -n "$HZ_VARIANT" ]; then
+        classifier_filter="classifier='$HZ_VARIANT'"
+    fi
+    version=$(xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[extension='zip' and $classifier_filter]/value/text()" maven-metadata.xml)
 
     url="https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-distribution/${HZ_VERSION}/hazelcast-distribution-${version}${SUFFIX}.zip"
     rm maven-metadata.xml


### PR DESCRIPTION
It turned out that snapshot metadata for different extensions and classifiers can point to different snapshot versions:

![image](https://github.com/hazelcast/hazelcast-docker/assets/1242724/823d8ebf-768a-4f4e-a966-954f1fbdedf6)

Tested locally:
```
cd hazelcast-oss
HZ_VERSION=5.1.8-SNAPSHOT HZ_VARIANT= ./get-hz-dist-zip.sh
https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-distribution/5.1.8-SNAPSHOT/hazelcast-distribution-5.1.8-20240205.134915-37.zip

HZ_VERSION=5.1.8-SNAPSHOT HZ_VARIANT=slim ./get-hz-dist-zip.sh
https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-distribution/5.1.8-SNAPSHOT/hazelcast-distribution-5.1.8-20240205.134915-37-slim.zip

cd ../hazelcast-enterprise
HZ_VERSION=5.1.8-SNAPSHOT HZ_VARIANT= ./get-hz-ee-dist-zip.sh
https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-distribution/5.1.8-SNAPSHOT/hazelcast-distribution-5.1.8-20240205.134915-37-slim.zip

HZ_VERSION=5.1.8-SNAPSHOT HZ_VARIANT=slim ./get-hz-ee-dist-zip.sh
https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.1.8-SNAPSHOT/hazelcast-enterprise-distribution-5.1.8-20231206.131113-54.zip
```

See more: https://hazelcast.slack.com/archives/C01JU7ZJYGP/p1709035491924269