### PR TITLE
Update Dockerfile versions to 5.3.8-SNAPSHOT [HZ-4188][5.3.z]

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -1,7 +1,7 @@
 FROM redhat/ubi8-minimal:8.7
 
 # Versions of Hazelcast
-ARG HZ_VERSION=5.3.7-SNAPSHOT
+ARG HZ_VERSION=5.3.8-SNAPSHOT
 # Variant - empty for full, "slim" for slim
 ARG HZ_VARIANT=""
 

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18.0
 
 # Versions of Hazelcast
-ARG HZ_VERSION=5.3.7-SNAPSHOT
+ARG HZ_VERSION=5.3.8-SNAPSHOT
 # Variant - empty for full, "slim" for slim
 ARG HZ_VARIANT=""
 


### PR DESCRIPTION
Updating 5.3.z branch after Release 5.3.7 branch was created previously from v5.3.6

Fixes: [HZ-4188]

Backport of: https://github.com/hazelcast/hazelcast-docker/pull/734

[HZ-4188]: https://hazelcast.atlassian.net/browse/HZ-4188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ