### PR TITLE
Build OSS editions on push only when final release and OSS and EE versions are equal [DI-51]

### DIFF
--- a/.github/scripts/docker.functions.sh
+++ b/.github/scripts/docker.functions.sh
@@ -19,3 +19,9 @@ function get_ubi_supported_platforms() {
   local JDK=$1
   echo "linux/arm64,linux/amd64,linux/s390x,linux/ppc64le"
 }
+
+function get_dockerfile_arg_value() {
+  local dockerfile=$1
+  local arg_name=$2
+  awk -F= "/^ARG $arg_name=/{print \$2}" $dockerfile  | sed 's/"//g'
+}

--- a/.github/scripts/oss_build.functions.sh
+++ b/.github/scripts/oss_build.functions.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -euo pipefail
+
+get_patch_part() {
+  local version=$1
+  local patch_part=$(echo "$version" | awk -F'.' '{print $3}')
+  echo "$patch_part"
+}
+
+is_numeric() {
+  local str=$1
+  [[ $str =~ ^[0-9]+$ ]]
+}
+
+assert_same_minor_version() {
+  local oss_version=$1
+  local ee_version=$2
+
+  local oss_xy_part=$(echo "$oss_version" | awk -F'.' '{print $1 "." $2}')
+  local ee_xy_part=$(echo "$ee_version" | awk -F'.' '{print $1 "." $2}')
+
+  if [[ $oss_xy_part != $ee_xy_part ]]; then
+    echo "Error: OSS and EE version must have same minor version"
+    exit 1
+  fi
+}
+
+should_build_os() {
+
+  local oss_version=$1
+  local ee_version=$2
+  local triggered_by=$3
+  local editions=$4
+
+  assert_same_minor_version "$oss_version" "$ee_version"
+
+  if [[ $triggered_by == "workflow_dispatch" ]]; then
+    if [[ $editions == "All" || $editions == "OSS" ]]; then
+      echo "yes"
+      return
+    fi
+  fi
+
+  if [[ $triggered_by == "push" ]]; then
+    local oss_patch_part=$(get_patch_part "$oss_version")
+    local ee_patch_part=$(get_patch_part "$ee_version")
+
+    if is_numeric "$oss_patch_part" && [[ "$oss_patch_part" == "$ee_patch_part" ]]; then
+      echo "yes"
+      return
+    fi
+  fi
+
+  echo "no"
+}

--- a/.github/scripts/oss_build.functions.sh
+++ b/.github/scripts/oss_build.functions.sh
@@ -26,6 +26,25 @@ assert_same_minor_version() {
   fi
 }
 
+# Checks if we should build the OSS docker image.
+# Returns "yes" if we should build it or "no" if we shouldn't.
+# If the workflow was triggered by "push" (usually tag push) we two conditions:
+#  - both (OSS and EE) HZ versions are final release (non-BETA/DEVEL/SNAPSHOT)
+#  - both (OSS and EE) HZ versions are equal
+#
+# The reasoning:
+# - For minor releases we will have the same version set (OSS=`6.6.0` and EE=`6.6.0`) which means
+# we should build both editions.
+#
+# - For patch releases we will increment only EE version (i.e. OSS="6.6.0" and EE=`6.6.1`) which means we should build EE only
+#
+# - If for some reason we will have to build an emergency OSS patch release we should change OSS version
+# as well (i.e. OSS="6.6.1" and EE=`6.6.1`) this will mean we should build both editions
+#
+# - If the workflows was triggered manually by `workflow_dispatch` we assume that the caller knows what they're doing
+# so we return "yes" for "All" and "OSS" editions
+#
+# Check test cases in `oss_build.functions_tests.sh` to see the examples
 should_build_oss() {
 
   local oss_version=$1

--- a/.github/scripts/oss_build.functions.sh
+++ b/.github/scripts/oss_build.functions.sh
@@ -28,7 +28,7 @@ function assert_same_minor_version() {
 
 # Checks if we should build the OSS docker image.
 # Returns "yes" if we should build it or "no" if we shouldn't.
-# If the workflow was triggered by "push" (usually tag push) we two conditions:
+# If the workflow was triggered by "push" (usually tag push) we should build an OSS image only with these conditions fulfilled:
 #  - both (OSS and EE) HZ versions are final release (non-BETA/DEVEL/SNAPSHOT)
 #  - both (OSS and EE) HZ versions are equal
 #

--- a/.github/scripts/oss_build.functions.sh
+++ b/.github/scripts/oss_build.functions.sh
@@ -26,7 +26,7 @@ assert_same_minor_version() {
   fi
 }
 
-should_build_os() {
+should_build_oss() {
 
   local oss_version=$1
   local ee_version=$2

--- a/.github/scripts/oss_build.functions.sh
+++ b/.github/scripts/oss_build.functions.sh
@@ -2,18 +2,18 @@
 
 set -euo pipefail
 
-get_patch_part() {
+function get_patch_part() {
   local version=$1
   local patch_part=$(echo "$version" | awk -F'.' '{print $3}')
   echo "$patch_part"
 }
 
-is_numeric() {
+function is_numeric() {
   local str=$1
   [[ $str =~ ^[0-9]+$ ]]
 }
 
-assert_same_minor_version() {
+function assert_same_minor_version() {
   local oss_version=$1
   local ee_version=$2
 
@@ -45,7 +45,7 @@ assert_same_minor_version() {
 # so we return "yes" for "All" and "OSS" editions
 #
 # Check test cases in `oss_build.functions_tests.sh` to see the examples
-should_build_oss() {
+function should_build_oss() {
 
   local oss_version=$1
   local ee_version=$2

--- a/.github/scripts/oss_build.functions_tests.sh
+++ b/.github/scripts/oss_build.functions_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -eu
-function findScriptDir() {
+function find_script_dir() {
   CURRENT=$PWD
 
   DIR=$(dirname "$0")
@@ -16,11 +16,12 @@ function findScriptDir() {
       TARGET_FILE=$(basename "$TARGET_FILE")
   done
 
-  SCRIPT_DIR=$(pwd -P)
+  local SCRIPT_DIR=$(pwd -P)
   cd "$CURRENT" || exit
+  echo "$SCRIPT_DIR"
 }
 
-findScriptDir
+SCRIPT_DIR=$(find_script_dir)
 
 . "$SCRIPT_DIR"/assert.sh/assert.sh
 . "$SCRIPT_DIR"/oss_build.functions.sh

--- a/.github/scripts/oss_build.functions_tests.sh
+++ b/.github/scripts/oss_build.functions_tests.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+set -eu
+function findScriptDir() {
+  CURRENT=$PWD
+
+  DIR=$(dirname "$0")
+  cd "$DIR" || exit
+  TARGET_FILE=$(basename "$0")
+
+  while [ -L "$TARGET_FILE" ]
+  do
+      TARGET_FILE=$(readlink "$TARGET_FILE")
+      DIR=$(dirname "$TARGET_FILE")
+      cd "$DIR" || exit
+      TARGET_FILE=$(basename "$TARGET_FILE")
+  done
+
+  SCRIPT_DIR=$(pwd -P)
+  cd "$CURRENT" || exit
+}
+
+findScriptDir
+
+. "$SCRIPT_DIR"/assert.sh/assert.sh
+. "$SCRIPT_DIR"/oss_build.functions.sh
+
+TESTS_RESULT=0
+
+function assert_get_patch_part {
+  local version_to_release=$1
+  local expected=$2
+  local actual=$(get_patch_part "$version_to_release")
+  assert_eq "$expected" "$actual" "Expected patch part for version $version_to_release should be equal to $expected " || TESTS_RESULT=$?
+}
+
+function assert_is_patch_release {
+  local version_to_release=$1
+  local expected="yes"
+  local actual=$(is_patch_release "$version_to_release")
+  assert_eq "$expected" "$actual" "Version $version_to_release should be patch release" || TESTS_RESULT=$?
+}
+
+function assert_is_numeric {
+  local str=$1
+  local expected=$2
+  local actual=$(is_numeric "$str"; echo $?)
+  assert_eq "$expected" "$actual" "String $str should$( [ "$expected" != 0 ] && echo " NOT") be numeric" || TESTS_RESULT=$?
+}
+
+function assert_should_build_os {
+  local os_version=$1
+  local ee_version=$2
+  local triggered_by=$3
+  local editions=$4
+  local expected_should_build_os=$5
+  local actual=$(should_build_os "$os_version" "$ee_version" "$triggered_by" "$editions")
+  assert_eq "$expected_should_build_os" "$actual" "For OS=$os_version EE=$ee_version triggered_by=$triggered_by editions=$editions we should$( [ "$expected_should_build_os" = "no" ] && echo " NOT") build OS" || TESTS_RESULT=$?
+}
+
+log_header "Tests for get_patch_part"
+assert_get_patch_part "5.2.0" "0"
+assert_get_patch_part "5.2.1" "1"
+assert_get_patch_part "5.1.99" "99"
+assert_get_patch_part "5.3.0-BETA-1" "0-BETA-1"
+assert_get_patch_part "5.4.0-DEVEL-9" "0-DEVEL-9"
+
+log_header "Tests for is_numeric"
+assert_is_numeric "0" 0
+assert_is_numeric "1" 0
+assert_is_numeric "0-BETA-1" 1
+assert_is_numeric "0-DEVEL-9" 1
+assert_is_numeric "0-SNAPSHOT" 1
+
+log_header "Tests for should_build_os"
+assert_should_build_os "5.0.0" "5.0.0" "push" "All" "yes"
+assert_should_build_os "5.0.0" "5.0.0" "push" "OSS" "yes"
+assert_should_build_os "5.0.0" "5.0.0" "push" "EE" "yes"
+assert_should_build_os "5.0.0" "5.0.0" "workflow_dispatch" "All" "yes"
+assert_should_build_os "5.0.0" "5.0.0" "workflow_dispatch" "OSS" "yes"
+assert_should_build_os "5.0.0" "5.0.0" "workflow_dispatch" "EE" "no"
+
+assert_should_build_os "5.0.0" "5.0.1" "push" "All" "no"
+assert_should_build_os "5.0.0" "5.0.1" "push" "OSS" "no"
+assert_should_build_os "5.0.0" "5.0.1" "push" "EE" "no"
+assert_should_build_os "5.0.0" "5.0.1" "workflow_dispatch" "All" "yes"
+assert_should_build_os "5.0.0" "5.0.1" "workflow_dispatch" "OSS" "yes"
+assert_should_build_os "5.0.0" "5.0.1" "workflow_dispatch" "EE" "no"
+
+assert_should_build_os "5.0.1" "5.0.1" "push" "All" "yes"
+assert_should_build_os "5.0.1" "5.0.1" "workflow_dispatch" "All" "yes"
+assert_should_build_os "5.0.1" "5.0.1" "workflow_dispatch" "OSS" "yes"
+assert_should_build_os "5.0.1" "5.0.1" "workflow_dispatch" "EE" "no"
+
+assert_should_build_os "5.0.1" "5.0.2" "push" "All" "no"
+assert_should_build_os "5.0.1" "5.0.2" "workflow_dispatch" "All" "yes"
+assert_should_build_os "5.0.1" "5.0.2" "workflow_dispatch" "OSS" "yes"
+assert_should_build_os "5.0.1" "5.0.2" "workflow_dispatch" "EE" "no"
+
+assert_should_build_os "5.0.2" "5.1.0" "push" "All" "Error: OSS and EE version must have same minor version"
+assert_should_build_os "5.0.2" "5.1.0" "workflow_dispatch" "All" "Error: OSS and EE version must have same minor version"
+assert_should_build_os "5.0.2" "5.1.0" "workflow_dispatch" "OSS" "Error: OSS and EE version must have same minor version"
+assert_should_build_os "5.0.2" "5.1.0" "workflow_dispatch" "EE" "Error: OSS and EE version must have same minor version"
+
+assert_should_build_os "5.1.0" "5.1.0" "push" "All" "yes"
+assert_should_build_os "5.1.0" "5.1.0" "workflow_dispatch" "All" "yes"
+assert_should_build_os "5.1.0" "5.1.0" "workflow_dispatch" "OSS" "yes"
+assert_should_build_os "5.1.0" "5.1.0" "workflow_dispatch" "EE" "no"
+
+assert_should_build_os "5.1.0" "5.1.1" "push" "All" "no"
+assert_should_build_os "5.1.0" "5.1.1" "workflow_dispatch" "All" "yes"
+assert_should_build_os "5.1.0" "5.1.1" "workflow_dispatch" "OSS" "yes"
+assert_should_build_os "5.1.0" "5.1.1" "workflow_dispatch" "EE" "no"
+
+assert_should_build_os "5.3.0-BETA-1" "5.3.0-BETA-1" "push" "All" "no"
+assert_should_build_os "5.3.0-BETA-1" "5.3.0-BETA-1" "workflow_dispatch" "All" "yes"
+assert_should_build_os "5.3.0-BETA-1" "5.3.0-BETA-1" "workflow_dispatch" "OSS" "yes"
+assert_should_build_os "5.3.0-BETA-1" "5.3.0-BETA-1" "workflow_dispatch" "EE" "no"
+
+assert_should_build_os "5.3.0-SNAPSHOT" "5.3.0-SNAPSHOT" "push" "All" "no"
+assert_should_build_os "5.3.0-SNAPSHOT" "5.3.0-SNAPSHOT" "workflow_dispatch" "All" "yes"
+assert_should_build_os "5.3.0-SNAPSHOT" "5.3.0-SNAPSHOT" "workflow_dispatch" "OSS" "yes"
+assert_should_build_os "5.3.0-SNAPSHOT" "5.3.0-SNAPSHOT" "workflow_dispatch" "EE" "no"
+
+assert_should_build_os "5.4.0-DEVEL-9" "5.4.0-DEVEL-9" "push" "All" "no"
+assert_should_build_os "5.4.0-DEVEL-9" "5.4.0-DEVEL-9" "workflow_dispatch" "All" "yes"
+assert_should_build_os "5.4.0-DEVEL-9" "5.4.0-DEVEL-9" "workflow_dispatch" "OSS" "yes"
+assert_should_build_os "5.4.0-DEVEL-9" "5.4.0-DEVEL-9" "workflow_dispatch" "EE" "no"
+
+assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/.github/scripts/oss_build.functions_tests.sh
+++ b/.github/scripts/oss_build.functions_tests.sh
@@ -128,4 +128,10 @@ assert_should_build_os "5.4.0-DEVEL-9" "5.4.0-DEVEL-9" "workflow_dispatch" "All"
 assert_should_build_os "5.4.0-DEVEL-9" "5.4.0-DEVEL-9" "workflow_dispatch" "OSS" "yes"
 assert_should_build_os "5.4.0-DEVEL-9" "5.4.0-DEVEL-9" "workflow_dispatch" "EE" "no"
 
+# large version number tests
+assert_should_build_os "11.11.33" "11.22.33" "push" "All" "Error: OSS and EE version must have same minor version"
+assert_should_build_os "11.22.33" "22.22.33" "push" "All" "Error: OSS and EE version must have same minor version"
+assert_should_build_os "11.22.33" "11.22.33" "push" "All" "yes"
+assert_should_build_os "11.22.33" "11.22.00" "push" "All" "no"
+
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/.github/scripts/oss_build.functions_tests.sh
+++ b/.github/scripts/oss_build.functions_tests.sh
@@ -54,7 +54,7 @@ function assert_should_build_os {
   local triggered_by=$3
   local editions=$4
   local expected_should_build_os=$5
-  local actual=$(should_build_os "$os_version" "$ee_version" "$triggered_by" "$editions")
+  local actual=$(should_build_oss "$os_version" "$ee_version" "$triggered_by" "$editions")
   assert_eq "$expected_should_build_os" "$actual" "For OS=$os_version EE=$ee_version triggered_by=$triggered_by editions=$editions we should$( [ "$expected_should_build_os" = "no" ] && echo " NOT") build OS" || TESTS_RESULT=$?
 }
 
@@ -72,7 +72,7 @@ assert_is_numeric "0-BETA-1" 1
 assert_is_numeric "0-DEVEL-9" 1
 assert_is_numeric "0-SNAPSHOT" 1
 
-log_header "Tests for should_build_os"
+log_header "Tests for should_build_oss"
 assert_should_build_os "5.0.0" "5.0.0" "push" "All" "yes"
 assert_should_build_os "5.0.0" "5.0.0" "push" "OSS" "yes"
 assert_should_build_os "5.0.0" "5.0.0" "push" "EE" "yes"

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -17,7 +17,7 @@ on:
       EDITIONS:
         description: 'Editions to build'
         required: true
-        default: 'All'
+        default: 'EE'
         type: choice
         options:
           - All
@@ -47,7 +47,7 @@ jobs:
       DOCKER_ORG: hazelcast
       HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
-      EDITIONS: ${{ github.event.inputs.EDITIONS || 'All' }}
+      EDITIONS: ${{ github.event.inputs.EDITIONS || 'EE' }}
     steps:
       - name: Set HZ version as environment variable
         run: |
@@ -195,7 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: push
     env:
-      EDITIONS: ${{ github.event.inputs.EDITIONS || 'All' }}
+      EDITIONS: ${{ github.event.inputs.EDITIONS || 'EE' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -88,9 +88,10 @@ jobs:
       - name: Check if OSS should be built
         run: |
           . .github/scripts/oss_build.functions.sh
+          . .github/scripts/docker.functions.sh
           
-          oss_hz_version=$(awk -F= '/^ARG HZ_VERSION=/{print $2}' hazelcast-oss/Dockerfile  | sed 's/"//g')
-          ee_hz_version=$(awk -F= '/^ARG HZ_VERSION=/{print $2}' hazelcast-enterprise/Dockerfile  | sed 's/"//g')
+          oss_hz_version=$(get_dockerfile_arg_value hazelcast-oss/Dockerfile HZ_VERSION)
+          ee_hz_version=$(get_dockerfile_arg_value hazelcast-enterprise/Dockerfile HZ_VERSION)
           editions=${{ env.EDITIONS }}
           triggered_by=${{ github.event_name }}
           SHOULD_BUILD_OSS = $(should_build_oss "$oss_hz_version" "$ee_hz_version" "$triggered_by" "$editions")

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Check if OSS should be built
         run: |
-          . .github/scripts/os_build.functions.sh
+          . .github/scripts/oss_build.functions.sh
           
           os_hz_version=$(awk -F= '/^ARG HZ_VERSION=/{print $2}' hazelcast-oss/Dockerfile  | sed 's/"//g')
           ee_hz_version=$(awk -F= '/^ARG HZ_VERSION=/{print $2}' hazelcast-enterprise/Dockerfile  | sed 's/"//g')

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -85,8 +85,19 @@ jobs:
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
+      - name: Check if OSS should be built
+        run: |
+          . .github/scripts/os_build.functions.sh
+          
+          os_hz_version=$(awk -F= '/^ARG HZ_VERSION=/{print $2}' hazelcast-oss/Dockerfile  | sed 's/"//g')
+          ee_hz_version=$(awk -F= '/^ARG HZ_VERSION=/{print $2}' hazelcast-enterprise/Dockerfile  | sed 's/"//g')
+          editions=${{ env.EDITIONS }}
+          triggered_by=${{ github.event_name }}
+          SHOULD_BUILD_OSS = $(should_build_os "$os_hz_version" "$ee_hz_version" "$triggered_by" "$editions")
+          echo "SHOULD_BUILD_OSS=${SHOULD_BUILD_OSS}" >> $GITHUB_ENV
+
       - name: Build Test OSS image
-        if: env.EDITIONS == 'All' || env.EDITIONS == 'OSS'
+        if: env.SHOULD_BUILD_OSS == 'yes'
         run: |
           docker buildx build --load \
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
@@ -96,7 +107,7 @@ jobs:
             hazelcast-oss
 
       - name: Run smoke test against OSS image
-        if: env.EDITIONS == 'All' || env.EDITIONS == 'OSS'
+        if: env.SHOULD_BUILD_OSS == 'yes'
         timeout-minutes: 2
         run: |
           .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }}
@@ -134,7 +145,7 @@ jobs:
             ${{ env.DOCKER_LOG_FILE_EE }}
 
       - name: Build and Push OSS image
-        if: env.EDITIONS == 'All' || env.EDITIONS == 'OSS'
+        if: env.SHOULD_BUILD_OSS == 'yes'
         run: |
           . .github/scripts/get-tags-to-push.sh 
           . .github/scripts/docker.functions.sh

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -89,11 +89,11 @@ jobs:
         run: |
           . .github/scripts/oss_build.functions.sh
           
-          os_hz_version=$(awk -F= '/^ARG HZ_VERSION=/{print $2}' hazelcast-oss/Dockerfile  | sed 's/"//g')
+          oss_hz_version=$(awk -F= '/^ARG HZ_VERSION=/{print $2}' hazelcast-oss/Dockerfile  | sed 's/"//g')
           ee_hz_version=$(awk -F= '/^ARG HZ_VERSION=/{print $2}' hazelcast-enterprise/Dockerfile  | sed 's/"//g')
           editions=${{ env.EDITIONS }}
           triggered_by=${{ github.event_name }}
-          SHOULD_BUILD_OSS = $(should_build_os "$os_hz_version" "$ee_hz_version" "$triggered_by" "$editions")
+          SHOULD_BUILD_OSS = $(should_build_oss "$oss_hz_version" "$ee_hz_version" "$triggered_by" "$editions")
           echo "SHOULD_BUILD_OSS=${SHOULD_BUILD_OSS}" >> $GITHUB_ENV
 
       - name: Build Test OSS image


### PR DESCRIPTION
 - Build OSS editions on push only when final release and OSS and EE versions are equal [DI-51]
 - Build EE edition only by default

Fixes: https://hazelcast.atlassian.net/browse/DI-51

[DI-51]: https://hazelcast.atlassian.net/browse/DI-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ