### PR TITLE
Fix checking if EE base image has changed

### DIFF
--- a/.github/scripts/packages-updated.sh
+++ b/.github/scripts/packages-updated.sh
@@ -38,7 +38,7 @@ function packages_updated_oss() {
 function packages_updated_ee() {
   local IMAGE=$1
   docker pull "$IMAGE"
-  local OUTPUT=$(docker run --user 0 --rm $IMAGE sh -c 'microdnf upgrade --nodocs')
+  local OUTPUT=$(docker run --user 0 --rm $IMAGE sh -c 'microdnf -y upgrade --nodocs')
   echo "$OUTPUT"
   PACKAGE_UPGRADES=$(echo "$OUTPUT" | grep --count Upgrading)
   if [ "$PACKAGE_UPGRADES" -ne 0 ]; then

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       MINIMAL_SUPPORTED_VERSION:
-        description: 'Minimal supported version from which we should start checking images, e.g. 5.1, 5.0.1, 4.2.3. Default values is 5.1'
+        description: 'Minimal supported version from which we should start checking images, e.g. 5.1, 5.0.1, 4.2.3. Default values is 5.2'
         required: false
   schedule:
     - cron: '0 6 * * *'
@@ -17,7 +17,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     env:
       MINIMAL_SUPPORTED_VERSION: ${{ github.event.inputs.MINIMAL_SUPPORTED_VERSION }}
-      DEFAULT_MINIMAL_SUPPORTED_VERSION: 5.1
+      DEFAULT_MINIMAL_SUPPORTED_VERSION: 5.2
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Fix checking if EE base image has changed.

`microdnf` has changed behaviour and waits for the confirmation. Added `-y` flag to enable non-interactive mode. 

Blocks jobs like this: https://github.com/hazelcast/hazelcast-docker/actions/runs/8795597617

Also changed minimal version that we rebuild to 5.2 to follow https://support.hazelcast.com/s/article/Version-Support-Windows

Test run: https://github.com/hazelcast/hazelcast-docker/actions/runs/8812797009