### PR TITLE
Allow `simple-smoke-test.sh` to be run multiple times 

### DIFF
--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -3,7 +3,6 @@
 set -e
 set -o pipefail
 
-
 function test_docker_image() {
     local image=$1
     local container_name=$2
@@ -26,6 +25,8 @@ function test_docker_image() {
     echo "Getting value for key '$key'"
     local actual
     actual=$(clc map get --format delimited -n some-map $key --log.path stderr)
+    echo "Stopping container $container_name}"
+    docker stop "$container_name"
 
     if [ "$expected" != "$actual" ]; then
         echo "Expected to read '${expected}' but got '${actual}'"

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -8,8 +8,10 @@ function test_docker_image() {
     local image=$1
     local container_name=$2
 
-    # Always clean up the docker container
-    trap 'docker container rm --force "$container_name"' EXIT
+    if [ "$(docker ps --all --quiet --filter name="$container_name")" ]; then
+      echo "Removing existing '$container_name' container"
+      docker container rm --force "$container_name"
+    fi
 
     echo "Starting container '$container_name' from image '$image'"
     docker run -it --name "$container_name" -e HZ_LICENSEKEY -e HZ_INSTANCETRACKING_FILENAME -d -p5701:5701 "$image"

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -9,7 +9,7 @@ function test_docker_image() {
     local container_name=$2
 
     # Always clean up the docker container
-    trap 'docker stop "$container_name"' EXIT
+    trap 'docker container rm --force "$container_name"' EXIT
 
     echo "Starting container '$container_name' from image '$image'"
     docker run -it --name "$container_name" -e HZ_LICENSEKEY -e HZ_INSTANCETRACKING_FILENAME -d -p5701:5701 "$image"

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -3,9 +3,14 @@
 set -e
 set -o pipefail
 
+
 function test_docker_image() {
     local image=$1
     local container_name=$2
+
+    # Always clean up the docker container
+    trap 'docker stop "$container_name"' EXIT
+
     echo "Starting container '$container_name' from image '$image'"
     docker run -it --name "$container_name" -e HZ_LICENSEKEY -e HZ_INSTANCETRACKING_FILENAME -d -p5701:5701 "$image"
     local key="some-key"
@@ -19,8 +24,6 @@ function test_docker_image() {
     echo "Getting value for key '$key'"
     local actual
     actual=$(clc map get --format delimited -n some-map $key --log.path stderr)
-    echo "Stopping container $container_name}"
-    docker stop "$container_name"
 
     if [ "$expected" != "$actual" ]; then
         echo "Expected to read '${expected}' but got '${actual}'"


### PR DESCRIPTION
`.github/scripts/simple-smoke-test.sh` creates and runs a container with a default name (e.g. `hazelcast-oss`), but doesn't remove the container afterwards, because later we query Docker for the logs.

This means when executed locally, subsequent invocations fail as the container already exists.

Changed to remove the container if it already exists, before creation.