### PR TITLE
Run scheduled vulnerability scans on `Standard Support` versions only

### DIFF
--- a/.github/workflows/scheduled_vulnerability_scan.yml
+++ b/.github/workflows/scheduled_vulnerability_scan.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                ref: [ 'master', '5.4.z', '5.3.z', '5.2.z', '5.1.z', '5.0.z', '4.2.z' ]
+                ref: [ 'master', '5.4.z', '5.3.z', '5.2.z' ]
         uses: ./.github/workflows/vulnerability_scan_subworkflow.yml
         with:
             ref: ${{ matrix.ref }}

--- a/.github/workflows/scheduled_vulnerability_scan.yml
+++ b/.github/workflows/scheduled_vulnerability_scan.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                ref: [ 'master', '5.3.z', '5.2.z', '5.1.z', '5.0.z', '4.2.z' ]
+                ref: [ 'master', '5.4.z', '5.3.z', '5.2.z', '5.1.z', '5.0.z', '4.2.z' ]
         uses: ./.github/workflows/vulnerability_scan_subworkflow.yml
         with:
             ref: ${{ matrix.ref }}


### PR DESCRIPTION
Scheduled vulnerability scans should run on [`Standard Support` versions](https://support.hazelcast.com/s/article/Version-Support-Windows):
- Older `Extended Support` only versions removed
- `5.4.z` added

[Slack discussion](https://hazelcast.slack.com/archives/C05LM8B80UT/p1715258281044019).

Fixes: https://github.com/hazelcast/hazelcast-docker/issues/746