### PR TITLE
Use .github/release_type for controlling releases of the OSS/EE [5.4.z]

### DIFF
--- a/.github/scripts/build.functions.sh
+++ b/.github/scripts/build.functions.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Checks if we should build the OSS docker image.
+# Returns "yes" if we should build it or "no" if we shouldn't.
+function should_build_oss() {
+
+  local release_type=$1
+  if [[ $release_type == "ALL" || $release_type == "OSS" ]]; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}
+
+# Checks if we should build the OSS docker image.
+# Returns "yes" if we should build it or "no" if we shouldn't.
+function should_build_ee() {
+
+  local release_type=$1
+  if [[ $release_type == "ALL" || $release_type == "EE" ]]; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}

--- a/.github/scripts/build.functions_tests.sh
+++ b/.github/scripts/build.functions_tests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -eu
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+. "$SCRIPT_DIR"/assert.sh/assert.sh
+. "$SCRIPT_DIR"/build.functions.sh
+
+TESTS_RESULT=0
+
+function assert_should_build_oss {
+  local release_type=$1
+  local expected_should_build_os=$2
+  local actual=$(should_build_oss "$release_type")
+  assert_eq "$expected_should_build_os" "$actual" "For release_type=$release_type we should$( [ "$expected_should_build_os" = "no" ] && echo " NOT") build OS" || TESTS_RESULT=$?
+}
+
+function assert_should_build_ee {
+  local release_type=$1
+  local expected_should_build_os=$2
+  local actual=$(should_build_ee "$release_type")
+  assert_eq "$expected_should_build_os" "$actual" "For release_type=$release_type we should$( [ "$expected_should_build_os" = "no" ] && echo " NOT") build EE" || TESTS_RESULT=$?
+}
+
+log_header "Tests for should_build_oss"
+assert_should_build_oss  "ALL" "yes"
+assert_should_build_oss  "OSS" "yes"
+assert_should_build_oss  "EE" "no"
+assert_should_build_oss  "dummy value" "no"
+
+log_header "Tests for should_build_ee"
+assert_should_build_ee  "ALL" "yes"
+assert_should_build_ee  "OSS" "no"
+assert_should_build_ee  "EE" "yes"
+assert_should_build_ee  "dummy value" "no"
+
+assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -20,6 +20,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Forbid .github/release_type file
+        run: |
+          if [ -f ".github/release_type" ]; then
+            echo "Error: .github/release_type file is not allowed in the PRs. It's used only during release creation"
+            exit 1
+          fi
+
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -119,7 +119,7 @@ jobs:
         if: env.EE_NEEDS_REBUILD == 'yes'
         run: |
           echo "Rebuilding ${{ matrix.version }} EE image"
-          gh workflow run tag_image_push.yml --ref v${{ matrix.version }} -f HZ_VERSION=${{ matrix.version }} -f EDITIONS=EE
+          gh workflow run tag_image_push.yml --ref v${{ matrix.version }} -f HZ_VERSION=${{ matrix.version }} -f RELEASE_TYPE=EE
           gh workflow run tag_image_push_rhel.yml --ref v${{ matrix.version }} -f HZ_VERSION=${{ matrix.version }}
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -14,13 +14,13 @@ on:
       RELEASE_VERSION:
         description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         required: false
-      EDITIONS:
-        description: 'Editions to build'
+      RELEASE_TYPE:
+        description: 'Which editions should be built'
         required: true
-        default: 'All'
+        default: 'EE'
         type: choice
         options:
-          - All
+          - ALL
           - OSS
           - EE
 env:
@@ -31,9 +31,43 @@ jobs:
   jdks:
     uses: ./.github/workflows/get-supported-jdks.yaml
 
+  prepare:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TYPE: ${{ inputs.RELEASE_TYPE || 'EE' }}
+    outputs:
+      should_build_oss: ${{ steps.which_editions.outputs.should_build_oss }}
+      should_build_ee: ${{ steps.which_editions.outputs.should_build_ee }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Read release type from the file
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          RELEASE_TYPE_FILE=.github/release_type
+          if [ -f $RELEASE_TYPE_FILE ]; then
+              echo "RELEASE_TYPE=$(cat $RELEASE_TYPE_FILE)" >> $GITHUB_ENV
+          else
+              echo "File '$RELEASE_TYPE_FILE' does not exist."
+              exit 1
+          fi
+
+      - name: Check which editions should be built
+        id: which_editions
+        run: |
+          . .github/scripts/build.functions.sh
+          
+          release_type=${{ env.RELEASE_TYPE }}
+          triggered_by=${{ github.event_name }}
+          should_build_oss = $(should_build_oss "$release_type")
+          should_build_ee = $(should_build_ee "$release_type")
+          echo "should_build_ee=${should_build_ee}" >> $GITHUB_OUTPUT
+          echo "should_build_oss=${should_build_oss}" >> $GITHUB_OUTPUT
+
   push:
     runs-on: ubuntu-latest
-    needs: jdks
+    needs: [ jdks, prepare ]
     strategy:
       matrix:
         jdk: ${{ fromJSON(needs.jdks.outputs.jdks) }}
@@ -45,11 +79,10 @@ jobs:
             suffix: ''
     env:
       DOCKER_ORG: hazelcast
-      HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
-      RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
-      EDITIONS: ${{ github.event.inputs.EDITIONS || 'All' }}
+      HZ_VERSION: ${{ inputs.HZ_VERSION }}
+      RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
     steps:
-      - name: Set HZ version as environment variable
+      - name: Set environment variables
         run: |
           if [ -z "${{ env.HZ_VERSION }}" ]; then
              HZ_VERSION=${GITHUB_REF:11}
@@ -57,17 +90,16 @@ jobs:
              HZ_VERSION=${{ env.HZ_VERSION }}
           fi
           echo "HZ_VERSION=${HZ_VERSION}" >> $GITHUB_ENV
-          echo "DOCKER_LOG_FILE_OSS=docker-hazelcast-oss-test${{ matrix.suffix }}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
-          echo "DOCKER_LOG_FILE_EE=docker-hazelcast-ee-test${{ matrix.suffix }}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
-
-      - name: Set Release version as environment variable
-        run: |
+          
           if [ -z "${{ env.RELEASE_VERSION }}" ]; then
              RELEASE_VERSION=${{ env.HZ_VERSION }}
           else
              RELEASE_VERSION=${{ env.RELEASE_VERSION }}
           fi
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+          
+          echo "DOCKER_LOG_FILE_OSS=docker-hazelcast-oss-test${{ matrix.suffix }}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
+          echo "DOCKER_LOG_FILE_EE=docker-hazelcast-ee-test${{ matrix.suffix }}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
 
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -86,7 +118,7 @@ jobs:
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Build Test OSS image
-        if: env.EDITIONS == 'All' || env.EDITIONS == 'OSS'
+        if: needs.prepare.outputs.should_build_oss == 'yes'
         run: |
           docker buildx build --load \
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
@@ -96,13 +128,13 @@ jobs:
             hazelcast-oss
 
       - name: Run smoke test against OSS image
-        if: env.EDITIONS == 'All' || env.EDITIONS == 'OSS'
+        if: needs.prepare.outputs.should_build_oss == 'yes'
         timeout-minutes: 2
         run: |
           .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }}
 
       - name: Build Test EE image
-        if: env.EDITIONS == 'All' || env.EDITIONS == 'EE'
+        if: needs.prepare.outputs.should_build_ee == 'yes'
         run: |
           docker buildx build --load \
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
@@ -112,7 +144,7 @@ jobs:
             hazelcast-enterprise
 
       - name: Run smoke test against EE image
-        if: env.EDITIONS == 'All' || env.EDITIONS == 'EE'
+        if: needs.prepare.outputs.should_build_ee == 'yes'
         timeout-minutes: 2
         run: |
           export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
@@ -134,7 +166,7 @@ jobs:
             ${{ env.DOCKER_LOG_FILE_EE }}
 
       - name: Build and Push OSS image
-        if: env.EDITIONS == 'All' || env.EDITIONS == 'OSS'
+        if: needs.prepare.outputs.should_build_oss == 'yes'
         run: |
           . .github/scripts/get-tags-to-push.sh 
           . .github/scripts/docker.functions.sh
@@ -160,7 +192,7 @@ jobs:
             --platform=${PLATFORMS} $DOCKER_DIR
 
       - name: Build/Push EE image
-        if: env.EDITIONS == 'All' || env.EDITIONS == 'EE'
+        if: needs.prepare.outputs.should_build_ee == 'yes'
         run: |
           . .github/scripts/get-tags-to-push.sh 
           . .github/scripts/docker.functions.sh
@@ -193,9 +225,7 @@ jobs:
 
   post-push:
     runs-on: ubuntu-latest
-    needs: push
-    env:
-      EDITIONS: ${{ github.event.inputs.EDITIONS || 'All' }}
+    needs: [ push, prepare ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -204,7 +234,7 @@ jobs:
         run: |
           .github/scripts/generate-docker-hub-description.sh
       - name: Update Docker Hub Description of OSS image
-        if: env.EDITIONS == 'All' || env.EDITIONS == 'OSS'
+        if: needs.prepare.outputs.should_build_oss == 'yes'
         uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -214,7 +244,7 @@ jobs:
           readme-filepath: ./README-docker.md
 
       - name: Update Docker Hub Description of EE image
-        if: env.EDITIONS == 'All' || env.EDITIONS == 'EE'
+        if: needs.prepare.outputs.should_build_ee == 'yes'
         uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/750

In order to control which editions (OSS/EE/ALL) should be released `.github/release_type` file is introduced.

This file is required now for newly created git tags. It should contains only one of the following values:
- OSS
- EE
- ALL

When a new tag is pushed we read the file to decide which docker image editions should be released.
For manual runs of the `tag_image_push.yml` we ignore this file and use `RELEASE_TYPE` input from the workflow

`.github/release_type` should be added during the release by the automation. It's forbidden to add it master or maintenance branches through PRs.