### PR TITLE
Remove `suffix` parameter from scripts

### DIFF
--- a/.github/scripts/ee-build.functions.sh
+++ b/.github/scripts/ee-build.functions.sh
@@ -11,10 +11,9 @@ set -euo pipefail
 function get_hz_dist_zip() {
   local hz_variant=$1
   local hz_version=$2
-  local suffix=$3
 
   # The slim is an artifact with a classifier, need to add `-` there
-  if [[ -n "${hz_variant}" ]]; then suffix="-${hz_variant}"; fi
+  suffix=${hz_variant:+-$hz_variant}
 
   if [[ "${hz_version}" == *"SNAPSHOT"* ]]
   then  

--- a/.github/scripts/ee-build.functions_tests.sh
+++ b/.github/scripts/ee-build.functions_tests.sh
@@ -31,15 +31,14 @@ TESTS_RESULT=0
 function assert_get_hz_dist_zip {
   local hz_variant=$1
   local hz_version=$2
-  local suffix=$3
-  local expected_url=$4
-  local actual_url=$(get_hz_dist_zip "$hz_variant" "$hz_version" "$suffix")
-  assert_eq "$expected_url" "$actual_url" "Expected URL for variant \"$hz_variant\", version \"$hz_version\", suffix \"$suffix\"" || TESTS_RESULT=$?
+  local expected_url=$3
+  local actual_url=$(get_hz_dist_zip "$hz_variant" "$hz_version")
+  assert_eq "$expected_url" "$actual_url" "Expected URL for variant \"$hz_variant\", version \"$hz_version\"" || TESTS_RESULT=$?
 }
 
 log_header "Tests for get_hz_dist_zip"
-assert_get_hz_dist_zip slim 5.4.0 -slim https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-distribution/5.4.0/hazelcast-enterprise-distribution-5.4.0-slim.zip
-assert_get_hz_dist_zip "" 5.4.0 "" https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-distribution/5.4.0/hazelcast-enterprise-distribution-5.4.0.zip
-assert_get_hz_dist_zip "" 5.4.0-SNAPSHOT "" https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.4.0-SNAPSHOT/hazelcast-enterprise-distribution-5.4.0-20240301.103418-1664.zip
+assert_get_hz_dist_zip slim 5.4.0 https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-distribution/5.4.0/hazelcast-enterprise-distribution-5.4.0-slim.zip
+assert_get_hz_dist_zip "" 5.4.0 https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-distribution/5.4.0/hazelcast-enterprise-distribution-5.4.0.zip
+assert_get_hz_dist_zip "" 5.4.0-SNAPSHOT https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.4.0-SNAPSHOT/hazelcast-enterprise-distribution-5.4.0-20240301.103418-1664.zip
 
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/.github/scripts/oss-build.functions.sh
+++ b/.github/scripts/oss-build.functions.sh
@@ -5,10 +5,9 @@ set -euo pipefail
 function get_hz_dist_zip() {
   local hz_variant=$1
   local hz_version=$2
-  local suffix=$3
 
   # The slim is an artifact with a classifier, need to add `-` there
-  if [[ -n "${hz_variant}" ]]; then suffix="-${hz_variant}"; fi
+  suffix=${hz_variant:+-$hz_variant}
 
   if [[ "${hz_version}" == *"SNAPSHOT"* ]]
   then

--- a/.github/scripts/oss-build.functions_tests.sh
+++ b/.github/scripts/oss-build.functions_tests.sh
@@ -32,14 +32,13 @@ TESTS_RESULT=0
 function assert_get_hz_dist_zip {
   local hz_variant=$1
   local hz_version=$2
-  local suffix=$3
-  local expected_url=$4
-  local actual_url=$(get_hz_dist_zip "$hz_variant" "$hz_version" "$suffix")
-  assert_eq "$expected_url" "$actual_url" "Expected URL for variant \"$hz_variant\", version \"$hz_version\", suffix \"$suffix\"" || TESTS_RESULT=$?
+  local expected_url=$3
+  local actual_url=$(get_hz_dist_zip "$hz_variant" "$hz_version")
+  assert_eq "$expected_url" "$actual_url" "Expected URL for variant \"$hz_variant\", version \"$hz_version\"" || TESTS_RESULT=$?
 }
 
 log_header "Tests for get_hz_dist_zip"
-assert_get_hz_dist_zip slim 5.4.0 -slim https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0-slim.zip
-assert_get_hz_dist_zip "" 5.4.0 "" https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0.zip
+assert_get_hz_dist_zip slim 5.4.0 https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0-slim.zip
+assert_get_hz_dist_zip "" 5.4.0 https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0.zip
 
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -25,13 +25,20 @@ jobs:
         variant: [ 'slim','' ]
         include:
           - variant: slim
-            suffix: '-slim'
           - variant: ''
-            suffix: ''
     env:
       DOCKER_ORG: hazelcast
       HZ_VERSION : ${{ github.event.inputs.HZ_VERSION }}
     steps:
+      - name: Compute Suffix
+        run: |
+          if [ -n "${{ matrix.variant }}" ]; then
+            SUFFIX=-${{ matrix.variant }}
+          else
+            SUFFIX=
+          fi
+          echo "SUFFIX=${SUFFIX}" >> $GITHUB_ENV
+
       - name: Checkout Code
         uses: actions/checkout@v4
 
@@ -72,7 +79,7 @@ jobs:
       - name: Get docker logs
         if: ${{ always() }}
         run: |
-          DOCKER_LOG_FILE_EE=docker-hazelcast-ee-test${{ matrix.suffix }}-jdk${{ matrix.jdk }}.log
+          DOCKER_LOG_FILE_EE=docker-hazelcast-ee-test${SUFFIX}-jdk${{ matrix.jdk }}.log
           echo "DOCKER_LOG_FILE_EE=${DOCKER_LOG_FILE_EE}" >> $GITHUB_ENV
           docker logs ${{ env.test_container_name_ee }} > ${DOCKER_LOG_FILE_EE}
 
@@ -80,7 +87,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs${{ matrix.suffix }}-jdk${{ matrix.jdk }}
+          name: docker-logs${SUFFIX}-jdk${{ matrix.jdk }}
           path: |
             ${{ env.DOCKER_LOG_FILE_EE }}
 
@@ -102,7 +109,7 @@ jobs:
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast-enterprise
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
 
-          TAGS_TO_PUSH=$(augment_with_suffixed_tags "${VERSIONS[*]}" "${{ matrix.suffix }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          TAGS_TO_PUSH=$(augment_with_suffixed_tags "${VERSIONS[*]}" "${SUFFIX}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -59,7 +59,7 @@ jobs:
           docker buildx build --load \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
             --build-arg HZ_VERSION=${HZ_VERSION} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" ${HZ_VERSION} "${{ matrix.suffix }}") \
+            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" ${HZ_VERSION}) \
             --tag hazelcast-ee:test \
             hazelcast-enterprise
 
@@ -115,7 +115,7 @@ jobs:
             --build-arg HZ_VERSION=${HZ_VERSION} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
             --label hazelcast.ee.revision=${{ github.event.inputs.HZ_EE_REVISION }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${HZ_VERSION}" "${{ matrix.suffix }}") \
+            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${HZ_VERSION}") \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR
       - name: Slack notification

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -59,7 +59,7 @@ jobs:
           . .github/scripts/oss-build.functions.sh
           docker buildx build --load \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${HZ_VERSION}" "${{ matrix.suffix }}") \
+            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${HZ_VERSION}") \
             --tag hazelcast-oss:test \
             hazelcast-oss
 
@@ -114,7 +114,7 @@ jobs:
           docker buildx build --push \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
             --label hazelcast.revision=${{ github.event.inputs.HZ_REVISION }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${HZ_VERSION}" "${{ matrix.suffix }}") \
+            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${HZ_VERSION}") \
             $TAGS_ARG \
             --platform=${PLATFORMS} $DOCKER_DIR
       - name: Slack notification

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -26,13 +26,21 @@ jobs:
         variant: [ 'slim','' ]
         include:
           - variant: slim
-            suffix: '-slim'
           - variant: ''
-            suffix: ''
     env:
       DOCKER_ORG: hazelcast
       HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
     steps:
+      - name: Compute Suffix
+        run: |
+          if [ -n "${{ matrix.variant }}" ]; then
+            SUFFIX=-${{ matrix.variant }}
+          else
+            SUFFIX=
+          fi
+          echo "SUFFIX=${SUFFIX}" >> $GITHUB_ENV
+          
+
       - name: Checkout Code
         uses: actions/checkout@v4
 
@@ -71,7 +79,7 @@ jobs:
       - name: Get docker logs
         if: ${{ always() }}
         run: |
-          DOCKER_LOG_FILE_OSS=docker-hazelcast-oss-test${{ matrix.suffix }}-jdk${{ matrix.jdk }}.log
+          DOCKER_LOG_FILE_OSS=docker-hazelcast-oss-test${SUFFIX}-jdk${{ matrix.jdk }}.log
           echo "DOCKER_LOG_FILE_OSS=${DOCKER_LOG_FILE_OSS}" >> $GITHUB_ENV
           docker logs ${{ env.test_container_name_oss }} > ${DOCKER_LOG_FILE_OSS}
 
@@ -79,7 +87,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs${{ matrix.suffix }}-jdk${{ matrix.jdk }}
+          name: docker-logs${SUFFIX}-jdk${{ matrix.jdk }}
           path: |
             ${{ env.DOCKER_LOG_FILE_OSS }}
 
@@ -102,7 +110,7 @@ jobs:
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
 
-          TAGS_TO_PUSH=$(augment_with_suffixed_tags "${VERSIONS[*]}" "${{ matrix.suffix }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          TAGS_TO_PUSH=$(augment_with_suffixed_tags "${VERSIONS[*]}" "${SUFFIX}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -133,7 +133,7 @@ jobs:
           . .github/scripts/oss-build.functions.sh
           docker buildx build --load \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}" "${{ matrix.suffix }}") \
+            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}") \
             --tag hazelcast-oss:test \
             hazelcast-oss
 
@@ -150,7 +150,7 @@ jobs:
           docker buildx build --load \
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}" "${{ matrix.suffix }}") \
+            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}") \
             --tag hazelcast-ee:test \
             hazelcast-enterprise
 
@@ -225,7 +225,7 @@ jobs:
           docker buildx build --push \
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}" "${{ matrix.suffix }}") \
+            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}") \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR
 

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -74,9 +74,7 @@ jobs:
         variant: [ 'slim','' ]
         include:
           - variant: slim
-            suffix: '-slim'
           - variant: ''
-            suffix: ''
     env:
       DOCKER_ORG: hazelcast
       HZ_VERSION: ${{ inputs.HZ_VERSION }}
@@ -97,9 +95,16 @@ jobs:
              RELEASE_VERSION=${{ env.RELEASE_VERSION }}
           fi
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
-          
-          echo "DOCKER_LOG_FILE_OSS=docker-hazelcast-oss-test${{ matrix.suffix }}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
-          echo "DOCKER_LOG_FILE_EE=docker-hazelcast-ee-test${{ matrix.suffix }}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
+
+          if [ -n "${{ matrix.variant }}" ]; then
+            SUFFIX=-${{ matrix.variant }}
+          else
+            SUFFIX=
+          fi
+          echo "SUFFIX=${SUFFIX}" >> $GITHUB_ENV
+
+          echo "DOCKER_LOG_FILE_OSS=docker-hazelcast-oss-test${SUFFIX}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
+          echo "DOCKER_LOG_FILE_EE=docker-hazelcast-ee-test${SUFFIX}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
 
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -171,7 +176,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs${{ matrix.suffix }}-jdk${{ matrix.jdk }}
+          name: docker-logs${SUFFIX}-jdk${{ matrix.jdk }}
           path: | 
             ${{ env.DOCKER_LOG_FILE_OSS }}
             ${{ env.DOCKER_LOG_FILE_EE }}
@@ -187,7 +192,7 @@ jobs:
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
           
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ matrix.suffix }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${SUFFIX}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}
@@ -198,7 +203,7 @@ jobs:
           PLATFORMS="$(get_alpine_supported_platforms "${{ matrix.jdk }}")"
           docker buildx build --push \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}" "${{ matrix.suffix }}") \
+            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}" "${SUFFIX}") \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR
 
@@ -213,7 +218,7 @@ jobs:
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast-enterprise
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
           
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ matrix.suffix }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${SUFFIX}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -42,6 +42,10 @@ jobs:
       fail-fast: false
       matrix:
         jdk: ${{ fromJSON(needs.jdks.outputs.jdks) }}
+        variant: [ 'slim','' ]
+        include:
+          - variant: slim
+          - variant: ''
     steps:
       - name: Set HZ version as environment variable
         run: |
@@ -75,6 +79,15 @@ jobs:
           echo "SCAN_REGISTRY_USER=${{ secrets[format('SCAN_REGISTRY_USER_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
           echo "SCAN_REGISTRY_PASSWORD=${{ secrets[format('SCAN_REGISTRY_PASSWORD_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
           echo "RHEL_PROJECT_ID=${{ secrets[format('RHEL_PROJECT_ID_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
+
+      - name: Compute Suffix
+        run: |
+          if [ -n "${{ matrix.variant }}" ]; then
+            SUFFIX=-${{ matrix.variant }}
+          else
+            SUFFIX=
+          fi
+          echo "SUFFIX=${SUFFIX}" >> $GITHUB_ENV
 
       - name: Checkout to Management Center Openshift
         uses: actions/checkout@v4
@@ -134,7 +147,7 @@ jobs:
           IMAGE_NAME=${SCAN_REPOSITORY}
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
 
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${SUFFIX}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "$SUFFIX" "${{ matrix.jdk }}" "$DEFAULT_JDK")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -146,7 +146,7 @@ jobs:
           docker buildx build --push \
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}" "${{ matrix.suffix }}") \
+            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}") \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR
 

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -134,7 +134,7 @@ jobs:
           IMAGE_NAME=${SCAN_REPOSITORY}
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
 
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ matrix.suffix }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${SUFFIX}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -42,10 +42,6 @@ jobs:
       fail-fast: false
       matrix:
         jdk: ${{ fromJSON(needs.jdks.outputs.jdks) }}
-        variant: [ 'slim','' ]
-        include:
-          - variant: slim
-          - variant: ''
     steps:
       - name: Set HZ version as environment variable
         run: |
@@ -79,15 +75,6 @@ jobs:
           echo "SCAN_REGISTRY_USER=${{ secrets[format('SCAN_REGISTRY_USER_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
           echo "SCAN_REGISTRY_PASSWORD=${{ secrets[format('SCAN_REGISTRY_PASSWORD_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
           echo "RHEL_PROJECT_ID=${{ secrets[format('RHEL_PROJECT_ID_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
-
-      - name: Compute Suffix
-        run: |
-          if [ -n "${{ matrix.variant }}" ]; then
-            SUFFIX=-${{ matrix.variant }}
-          else
-            SUFFIX=
-          fi
-          echo "SUFFIX=${SUFFIX}" >> $GITHUB_ENV
 
       - name: Checkout to Management Center Openshift
         uses: actions/checkout@v4
@@ -147,7 +134,7 @@ jobs:
           IMAGE_NAME=${SCAN_REPOSITORY}
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
 
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "$SUFFIX" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "" "${{ matrix.jdk }}" "$DEFAULT_JDK")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}


### PR DESCRIPTION
`suffix` is a hardcoded derivative of `variant`, and can instead be derived dynamically.

`tag_image_push_rhel.yml` used `suffix`, but never actually set it (unlike `tag_image_push.yml` which did), so hardcoded it to `""` instead.

Fixes: https://github.com/hazelcast/hazelcast-docker/issues/753