### PR TITLE
Do not create latest-snapshot tag for OS docker image [DI-150]

### DIFF
--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -94,9 +94,6 @@ jobs:
           . .github/scripts/oss-build.functions.sh
           
           VERSIONS=("$HZ_VERSION")
-          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
-          VERSIONS+=(latest-snapshot)
-          fi
           
           DOCKER_DIR=hazelcast-oss
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast


### PR DESCRIPTION
It doesn't make sense to keep this tag anymore, probably we won't publish any OS snapshot docker images