### PR TITLE
Fix flaky CLC installation in tests

### DIFF
--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -35,7 +35,9 @@ function test_docker_image() {
 }
 
 function install_clc() {
-  curl https://hazelcast.com/clc/install.sh | bash
+  # Use specific version as the downloading the latest version often fails: https://hazelcast.slack.com/archives/C0319N7HV8W/p1718023112329759
+  local CLC_VERSION=v5.4.0
+  curl https://raw.githubusercontent.com/hazelcast/hazelcast-commandline-client/main/extras/unix/install.sh | bash -s -- --version "$CLC_VERSION"
   export PATH=$PATH:$HOME/.hazelcast/bin
   clc config add default cluster.name=dev cluster.address=localhost
 }

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -36,8 +36,11 @@ function test_docker_image() {
 
 function install_clc() {
   # Use specific version as the downloading the latest version often fails: https://hazelcast.slack.com/archives/C0319N7HV8W/p1718023112329759
-  local CLC_VERSION=v5.4.0
-  curl https://raw.githubusercontent.com/hazelcast/hazelcast-commandline-client/main/extras/unix/install.sh | bash -s -- --version "$CLC_VERSION"
+  while ! curl https://hazelcast.com/clc/install.sh | bash
+    do
+      echo "Retrying clc installation..."
+      sleep 3
+    done
   export PATH=$PATH:$HOME/.hazelcast/bin
   clc config add default cluster.name=dev cluster.address=localhost
 }

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -35,7 +35,6 @@ function test_docker_image() {
 }
 
 function install_clc() {
-  # Use specific version as the downloading the latest version often fails: https://hazelcast.slack.com/archives/C0319N7HV8W/p1718023112329759
   while ! curl https://hazelcast.com/clc/install.sh | bash
     do
       echo "Retrying clc installation..."


### PR DESCRIPTION
Use specific version as the downloading the latest version often fails: 

```
Hazelcast CLC Installer (c) 2023 Hazelcast, Inc.

INFO  Creating the Home directory: /home/runner/.hazelcast
ERROR could not determine the latest version
Error: Process completed with exit code 1.
```

See also: https://hazelcast.slack.com/archives/C0319N7HV8W/p1718023112329759