### PR TITLE
Make PR builder use `pull_request_target` to support Dependabot

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -2,7 +2,7 @@ name: Build PR
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
 
 env:
   test_container_name_oss: hazelcast-oss-test


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast-docker/issues/763