### PR TITLE
Fix EE `SNAPSHOT` wrong distribution

### DIFF
--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           . .github/scripts/get-tags-to-push.sh 
           . .github/scripts/docker.functions.sh
-          . .github/scripts/oss-build.functions.sh
+          . .github/scripts/ee-build.functions.sh
           
           VERSIONS=("$HZ_VERSION")
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then


### PR DESCRIPTION
The `SNAPSHOT` EE workflow is _pushing_ using the OS, not EE distribution.

Introduced in https://github.com/hazelcast/hazelcast-docker/pull/747

[Slack discussion](https://hazelcast.slack.com/archives/C01JU7ZJYGP/p1719230177897049)