### PR TITLE
Reduce duplication in scripts between test and released images - `HAZELCAST_ZIP_URL` [DI-156]

### DIFF
--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -5,7 +5,8 @@ set -o pipefail
 
 function test_docker_image() {
     local image=$1
-    local container_name=$2    local expected_distribution_type=$3
+    local container_name=$2
+    local expected_distribution_type=$3
 
     if [ "$(docker ps --all --quiet --filter name="$container_name")" ]; then
       echo "Removing existing '$container_name' container"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run smoke test against OSS image
         timeout-minutes: 2
         run: |
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }}
+          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss
 
       - name: Build Test EE image
         run: |
@@ -79,7 +79,7 @@ jobs:
         timeout-minutes: 2
         run: |
           export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }}
+          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee
 
       - name: Get docker logs
         if: ${{ always() }}
@@ -140,7 +140,7 @@ jobs:
       - name: Run smoke test against OSS image
         timeout-minutes: 2
         run: |
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }}
+          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss
 
       - name: Build Test EE image
         run: |
@@ -160,7 +160,7 @@ jobs:
         timeout-minutes: 2
         run: |
           export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }}
+          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee
 
       - name: Get docker logs
         if: ${{ always() }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -44,16 +44,20 @@ jobs:
         run: |
           .github/scripts/test_scripts.sh
 
+      - name: Get OSS dist ZIP URL
+        run: |
+          . .github/scripts/oss-build.functions.sh
+          echo "HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "" ${HZ_VERSION})" >> $GITHUB_ENV
+
       - name: Build OSS image
         run: |
           DOCKER_PATH=hazelcast-oss
           # Extract from Dockerfile to avoid duplicate hardcoding of the latest SNAPSHOT version
           HZ_VERSION=$(awk -F '=' '/^ARG HZ_VERSION=/ {print $2}' ${DOCKER_PATH}/Dockerfile)
 
-          . .github/scripts/oss-build.functions.sh
           docker buildx build --load \
           --build-arg HZ_VERSION=${HZ_VERSION} \
-          --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "" ${HZ_VERSION} "") \
+          --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
           --tag hazelcast-oss:test \
           ${DOCKER_PATH}
 
@@ -62,16 +66,20 @@ jobs:
         run: |
           .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss
 
+      - name: Get EE dist ZIP URL
+        run: |
+          . .github/scripts/ee-build.functions.sh
+          echo "HAZELCAST_EE_ZIP_URL=$(get_hz_dist_zip "" ${HZ_VERSION})" >> $GITHUB_ENV
+
       - name: Build Test EE image
         run: |
           DOCKER_PATH=hazelcast-enterprise
           # Extract from Dockerfile to avoid duplicate hardcoding of the latest SNAPSHOT version
           HZ_VERSION=$(awk -F '=' '/^ARG HZ_VERSION=/ {print $2}' ${DOCKER_PATH}/Dockerfile)
 
-          . .github/scripts/ee-build.functions.sh
           docker buildx build --load \
           --build-arg HZ_VERSION=${HZ_VERSION} \
-          --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "" ${HZ_VERSION} "") \
+          --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
           --tag hazelcast-ee:test \
           ${DOCKER_PATH}
 
@@ -129,11 +137,10 @@ jobs:
           # Extract from Dockerfile to avoid duplicate hardcoding of the latest SNAPSHOT version
           HZ_VERSION=$(awk -F '=' '/^ARG HZ_VERSION=/ {print $2}' ${DOCKER_PATH}/Dockerfile)
 
-          . .github/scripts/oss-build.functions.sh
           docker buildx build --load \
           --build-arg JDK_VERSION=${{ matrix.jdk }} \
           --build-arg HZ_VERSION=${HZ_VERSION} \
-          --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "" ${HZ_VERSION} "") \
+          --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
           --tag hazelcast-oss:test \
           ${DOCKER_PATH}
 
@@ -148,11 +155,10 @@ jobs:
           # Extract from Dockerfile to avoid duplicate hardcoding of the latest SNAPSHOT version
           HZ_VERSION=$(awk -F '=' '/^ARG HZ_VERSION=/ {print $2}' ${DOCKER_PATH}/Dockerfile)
 
-          . .github/scripts/ee-build.functions.sh
           docker buildx build --load \
           --build-arg JDK_VERSION=${{ matrix.jdk }} \
           --build-arg HZ_VERSION=${HZ_VERSION} \
-          --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "" ${HZ_VERSION} "") \
+          --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
           --tag hazelcast-ee:test \
           ${DOCKER_PATH}
 

--- a/.github/workflows/ee-nlc-snapshot-push.yml
+++ b/.github/workflows/ee-nlc-snapshot-push.yml
@@ -76,12 +76,12 @@ jobs:
         timeout-minutes: 2
         run: |
           export HZ_INSTANCETRACKING_FILENAME=instance-tracking.txt
-          .github/scripts/simple-smoke-test.sh hazelcast-nlc:test ${{ env.test_container_name_ee }}
+          .github/scripts/simple-smoke-test.sh hazelcast-nlc:test ${{ env.test_container_name_ee }} ee
 
       - name: Get docker logs
         if: ${{ always() }}
         run: |
-          DOCKER_LOG_FILE_EE=docker-hazelcast-ee-test-jdk${{ matrix.jdk }}.log
+          DOCKER_LOG_FILE_EE=docker-${{ env.test_container_name_ee }}-jdk${{ matrix.jdk }}.log
           echo "DOCKER_LOG_FILE_EE=${DOCKER_LOG_FILE_EE}" >> $GITHUB_ENV
           docker logs ${{ env.test_container_name_ee }} > ${DOCKER_LOG_FILE_EE}
 

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -90,12 +90,12 @@ jobs:
         timeout-minutes: 2
         run: |
           export HZ_INSTANCETRACKING_FILENAME=instance-tracking.txt
-          .github/scripts/simple-smoke-test.sh hazelcast-nlc:test ${{ env.test_container_name_ee }}
+          .github/scripts/simple-smoke-test.sh hazelcast-nlc:test ${{ env.test_container_name_ee }} ee
 
       - name: Get docker logs
         if: ${{ always() }}
         run: |
-          DOCKER_LOG_FILE_EE=docker-hazelcast-ee-test-jdk${{ matrix.jdk }}.log
+          DOCKER_LOG_FILE_EE=docker-${{ env.test_container_name_ee }}-jdk${{ matrix.jdk }}.log
           echo "DOCKER_LOG_FILE_EE=${DOCKER_LOG_FILE_EE}" >> $GITHUB_ENV
           docker logs ${{ env.test_container_name_ee }} > ${DOCKER_LOG_FILE_EE}
 

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -74,12 +74,12 @@ jobs:
         timeout-minutes: 2
         run: |
           export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }}
+          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee
 
       - name: Get docker logs
         if: ${{ always() }}
         run: |
-          DOCKER_LOG_FILE_EE=docker-hazelcast-ee-test${{ env.SUFFIX }}-jdk${{ matrix.jdk }}.log
+          DOCKER_LOG_FILE_EE=docker-${{ env.test_container_name_ee }}${{ env.SUFFIX }}-jdk${{ matrix.jdk }}.log
           echo "DOCKER_LOG_FILE_EE=${DOCKER_LOG_FILE_EE}" >> $GITHUB_ENV
           docker logs ${{ env.test_container_name_ee }} > ${DOCKER_LOG_FILE_EE}
 

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -60,13 +60,17 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: 'us-east-1'
 
-      - name: Build Test EE image
+      - name: Get EE dist ZIP URL
         run: |
           . .github/scripts/ee-build.functions.sh
+          echo "HAZELCAST_EE_ZIP_URL=$(get_hz_dist_zip ${{ matrix.variant }} ${HZ_VERSION})" >> $GITHUB_ENV
+
+      - name: Build Test EE image
+        run: |
           docker buildx build --load \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
             --build-arg HZ_VERSION=${HZ_VERSION} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" ${HZ_VERSION}) \
+            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
             --tag hazelcast-ee:test \
             hazelcast-enterprise
 
@@ -98,7 +102,6 @@ jobs:
         run: |
           . .github/scripts/get-tags-to-push.sh 
           . .github/scripts/docker.functions.sh
-          . .github/scripts/ee-build.functions.sh
           
           VERSIONS=("$HZ_VERSION")
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
@@ -122,7 +125,7 @@ jobs:
             --build-arg HZ_VERSION=${HZ_VERSION} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
             --label hazelcast.ee.revision=${{ github.event.inputs.HZ_EE_REVISION }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${HZ_VERSION}") \
+            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR
       - name: Slack notification

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -74,12 +74,12 @@ jobs:
       - name: Run smoke test against OSS image
         timeout-minutes: 2
         run: |
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }}
+          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss
 
       - name: Get docker logs
         if: ${{ always() }}
         run: |
-          DOCKER_LOG_FILE_OSS=docker-hazelcast-oss-test${{ env.SUFFIX }}-jdk${{ matrix.jdk }}.log
+          DOCKER_LOG_FILE_OSS=docker-${{ env.test_container_name_oss }}${{ env.SUFFIX }}-jdk${{ matrix.jdk }}.log
           echo "DOCKER_LOG_FILE_OSS=${DOCKER_LOG_FILE_OSS}" >> $GITHUB_ENV
           docker logs ${{ env.test_container_name_oss }} > ${DOCKER_LOG_FILE_OSS}
 

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -62,12 +62,16 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: 'us-east-1'
 
-      - name: Build Test OSS image
+      - name: Get OSS dist ZIP URL
         run: |
           . .github/scripts/oss-build.functions.sh
+          echo "HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip ${{ matrix.variant }} ${HZ_VERSION})" >> $GITHUB_ENV
+
+      - name: Build Test OSS image
+        run: |
           docker buildx build --load \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${HZ_VERSION}") \
+            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
             --tag hazelcast-oss:test \
             hazelcast-oss
 
@@ -99,7 +103,6 @@ jobs:
           set -eEuo pipefail ${RUNNER_DEBUG:+-x}
           . .github/scripts/get-tags-to-push.sh 
           . .github/scripts/docker.functions.sh
-          . .github/scripts/oss-build.functions.sh
           
           VERSIONS=("$HZ_VERSION")
           
@@ -119,7 +122,7 @@ jobs:
           docker buildx build --push \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
             --label hazelcast.revision=${{ github.event.inputs.HZ_REVISION }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${HZ_VERSION}") \
+            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
             $TAGS_ARG \
             --platform=${PLATFORMS} $DOCKER_DIR
       - name: Slack notification

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -132,13 +132,17 @@ jobs:
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
+      - name: Get OSS dist ZIP URL
+        run: |
+          . .github/scripts/oss-build.functions.sh
+          echo "HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip ${{ matrix.variant }} ${{ env.HZ_VERSION }}" >> $GITHUB_ENV
+
       - name: Build Test OSS image
         if: needs.prepare.outputs.should_build_oss == 'yes'
         run: |
-          . .github/scripts/oss-build.functions.sh
           docker buildx build --load \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}") \
+            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
             --tag hazelcast-oss:test \
             hazelcast-oss
 
@@ -148,6 +152,11 @@ jobs:
         run: |
           .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss
 
+      - name: Get EE dist ZIP URL
+        run: |
+          . .github/scripts/ee-build.functions.sh
+          echo "HAZELCAST_EE_ZIP_URL=$(get_hz_dist_zip ${{ matrix.variant }} ${{ env.HZ_VERSION }}" >> $GITHUB_ENV
+
       - name: Build Test EE image
         if: needs.prepare.outputs.should_build_ee == 'yes'
         run: |
@@ -155,7 +164,7 @@ jobs:
           docker buildx build --load \
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}") \
+            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
             --tag hazelcast-ee:test \
             hazelcast-enterprise
 
@@ -186,7 +195,6 @@ jobs:
         run: |
           . .github/scripts/get-tags-to-push.sh 
           . .github/scripts/docker.functions.sh
-          . .github/scripts/oss-build.functions.sh
           
           DOCKER_DIR=hazelcast-oss
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast
@@ -203,7 +211,7 @@ jobs:
           PLATFORMS="$(get_alpine_supported_platforms "${{ matrix.jdk }}")"
           docker buildx build --push \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}" "${{ env.SUFFIX }}") \
+            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR
 
@@ -230,7 +238,7 @@ jobs:
           docker buildx build --push \
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}") \
+            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR
 

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -103,8 +103,8 @@ jobs:
           fi
           echo "SUFFIX=${SUFFIX}" >> $GITHUB_ENV
 
-          echo "DOCKER_LOG_FILE_OSS=docker-hazelcast-oss-test${SUFFIX}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
-          echo "DOCKER_LOG_FILE_EE=docker-hazelcast-ee-test${SUFFIX}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
+          echo "DOCKER_LOG_FILE_OSS=docker-${{ env.test_container_name_oss }}${SUFFIX}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
+          echo "DOCKER_LOG_FILE_EE=docker-${{ env.test_container_name_ee }}${SUFFIX}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
 
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -146,7 +146,7 @@ jobs:
         if: needs.prepare.outputs.should_build_oss == 'yes'
         timeout-minutes: 2
         run: |
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }}
+          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss
 
       - name: Build Test EE image
         if: needs.prepare.outputs.should_build_ee == 'yes'
@@ -164,7 +164,7 @@ jobs:
         timeout-minutes: 2
         run: |
           export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }}
+          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee
 
       - name: Get docker logs
         if: ${{ always() }}

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -146,7 +146,7 @@ jobs:
           docker buildx build --push \
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}") \
+            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip ${{ matrix.variant }} "${{ env.HZ_VERSION }}") \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR
 


### PR DESCRIPTION
The generation of the `HAZELCAST_ZIP_URL` parameter should be saved to ensure consistency between images used for testing, and the image that's ultimately deployed to ensure the test is as representative as possible.

In addition, a test has been added to check the type of distribution in the image - EE or OSS - as a sanity check.

Fixes: [DI-156](https://hazelcast.atlassian.net/browse/DI-156)