### PR TITLE
Fix EE `SNAPSHOT` wrong distribution [5.4.z]

### DIFF
--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           . .github/scripts/get-tags-to-push.sh 
           . .github/scripts/docker.functions.sh
-          . .github/scripts/oss-build.functions.sh
+          . .github/scripts/ee-build.functions.sh
           
           VERSIONS=("$HZ_VERSION")
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/765

The `SNAPSHOT` EE workflow is _pushing_ using the OS, not EE distribution.

Introduced in https://github.com/hazelcast/hazelcast-docker/pull/747

[Slack discussion](https://hazelcast.slack.com/archives/C01JU7ZJYGP/p1719230177897049)

(cherry picked from commit 66a9e2dea26dab8ba65785a958d037d8e856746e)