### PR TITLE
`xmllint` missing from `build-pr-custom-jdk` PR builder job

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -113,6 +113,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install xmllint
+        uses: ./.github/actions/install-xmllint
+
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
`xmllint` is required since https://github.com/hazelcast/hazelcast-docker/pull/747, but [a PR builder execution failed](https://github.com/hazelcast/hazelcast-docker/actions/runs/9698651682/job/26765696410) because it wasn't available.

This is because while it's in the workflow, it's not in the specific `build-pr-custom-jdk` _job_.

I'm unsure why this failure is intermittent as it should be continual.

Post-Merge Checklist:
- [ ] Backport to `5.4.z`