### PR TITLE
`xmllint` missing from `build-pr-custom-jdk` PR builder job [5.4.z]

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -113,6 +113,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install xmllint
+        uses: ./.github/actions/install-xmllint
+
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           . .github/scripts/get-tags-to-push.sh 
           . .github/scripts/docker.functions.sh
-          . .github/scripts/oss-build.functions.sh
+          . .github/scripts/ee-build.functions.sh
           
           VERSIONS=("$HZ_VERSION")
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/768