### PR TITLE
Remove Java artifacts scanning from vulnerability scans [DI-50]

### DIFF
--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -15,10 +15,6 @@ on:
         required: true
         type: string
 
-env:
-  # https://github.com/aquasecurity/trivy/issues/2432
-  DOCKLE_HOST: "unix:///var/run/docker.sock"
-
 jobs:
   scan:
     runs-on: ubuntu-latest
@@ -62,6 +58,9 @@ jobs:
         with:
           image-ref: ${{ env.IMAGE_TAG }} 
           trivy-config: .github/containerscan/trivy.yaml
+        env:
+          # https://github.com/aquasecurity/trivy/issues/2432
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
 
       - name: Scan ${{ matrix.image.label }} image by Dockle
         if: always()

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -26,12 +26,11 @@ jobs:
       matrix:
         image:
           - label: oss
-            directory: hazelcast-oss
             distribution_zip_name: hazelcast-distribution.zip
-          - label: ee
-            directory: hazelcast-enterprise
+          - label: enterprise
             distribution_zip_name: hazelcast-enterprise-distribution.zip
     env:
+      DIRECTORY: hazelcast-${{ matrix.image.label }}
       IMAGE_TAG: hazelcast/${{ matrix.image.label }}:${{ github.sha }}
     steps:
       - name: Checkout Code at ${{ inputs.ref }} branch
@@ -49,11 +48,11 @@ jobs:
           mkdir -p hazelcast-distribution/lib
           mkdir -p hazelcast-distribution/bin
           touch hazelcast-distribution/bin/empty
-          zip -r ${{ matrix.image.directory }}/${{ matrix.image.distribution_zip_name }} hazelcast-distribution
+          zip -r ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }} hazelcast-distribution
 
       - name: Build ${{ matrix.image.label }} image
         run: |
-          docker build -t ${{ env.IMAGE_TAG }} ${{ matrix.image.directory }}
+          docker build -t ${{ env.IMAGE_TAG }} ${{ env.DIRECTORY }}
 
       - name: Scan ${{ matrix.image.label }} image by Trivy
         if: always()
@@ -82,4 +81,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ env.IMAGE_TAG }} 
-          args: --file=${{ matrix.image.directory }}/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
+          args: --file=${{ env.DIRECTORY }}/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
           # DI-50 - Remove java artifacts scanning from hazelcast-docker
-          working_directory=${RUNNER_TEMP}/hazelcast-distribution
+          working_directory=hazelcast-distribution
           mkdir -p ${working_directory}/lib
           mkdir -p ${working_directory}/bin
           touch ${working_directory}/bin/empty

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -15,38 +15,44 @@ on:
                 required: true
                 type: string
 
+env:
+  # https://github.com/aquasecurity/trivy/issues/2432
+  DOCKLE_HOST: "unix:///var/run/docker.sock"
+
 jobs:
   scan-oss:
     env:
-      # https://github.com/aquasecurity/trivy/issues/2432
-      DOCKLE_HOST: "unix:///var/run/docker.sock"
+      DIRECTORY: "hazelcast-oss"
+      IMAGE_TAG: "hazelcast/oss:${{ github.sha }}"
+      DISTRIBUTION_ZIP_NAME: "hazelcast-distribution.zip"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code at ${{ inputs.ref }} branch
         uses: actions/checkout@v4
         with:
-            ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref }}
 
       - name: Install xmllint
         uses: ./.github/actions/install-xmllint
 
       - name: Get OSS dist ZIP
         run: |
-          # TODO Make this an ENV?
+          # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
+          # DI-50 - Remove java artifacts scanning from hazelcast-docker
           mkdir -p hazelcast-distribution/lib
           mkdir -p hazelcast-distribution/bin
           touch hazelcast-distribution/bin/empty
-          zip -r hazelcast-oss/hazelcast-distribution.zip hazelcast-distribution
+          zip -r ${{ env.DIRECTORY }}/${{ env.DISTRIBUTION_ZIP_NAME }} hazelcast-distribution
 
       - name: Build OSS image
         run: |
-            docker build -t hazelcast/oss:${{ github.sha }} hazelcast-oss
+            docker build -t ${{ env.IMAGE_TAG }} ${{ env.DIRECTORY }}
 
       - name: Scan OSS image by Trivy
         if: always()
         uses: aquasecurity/trivy-action@0.23.0
         with:
-          image-ref: hazelcast/oss:${{ github.sha }}
+          image-ref: ${{ env.IMAGE_TAG }}
           trivy-config: .github/containerscan/trivy.yaml
 
       - name: Scan OSS image by Dockle
@@ -55,7 +61,7 @@ jobs:
         # uses: goodwithtech/dockle-action@main
         uses: JackPGreen/dockle-action/@Upgrade-Dockle-to-`0.4.14`
         with:
-          image: hazelcast/oss:${{ github.sha }}
+          image: ${{ env.IMAGE_TAG }}
           format: 'list'
           exit-code: '1'
           exit-level: 'warn'
@@ -68,13 +74,14 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: hazelcast/oss:${{ github.sha }}
-          args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
-  # TODO Can we paramaterizxe this?
+          image: ${{ env.IMAGE_TAG }}
+          args: --file=${{ env.DIRECTORY }}/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
+
   scan-ee:
     env:
-      # https://github.com/aquasecurity/trivy/issues/2432
-      DOCKLE_HOST: "unix:///var/run/docker.sock"
+      DIRECTORY: "hazelcast-enterprise"
+      IMAGE_TAG: "hazelcast/ee:${{ github.sha }}"
+      DISTRIBUTION_ZIP_NAME: "hazelcast-enterprise-distribution.zip"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code at ${{ inputs.ref }} branch
@@ -87,21 +94,22 @@ jobs:
 
       - name: Get EE dist ZIP
         run: |
-          # TODO Make this an ENV?
+          # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
+          # DI-50 - Remove java artifacts scanning from hazelcast-docker
           mkdir -p hazelcast-distribution/lib
           mkdir -p hazelcast-distribution/bin
           touch hazelcast-distribution/bin/empty
-          zip -r hazelcast-enterprise/hazelcast-enterprise-distribution.zip hazelcast-distribution
+          zip -r ${{ env.DIRECTORY }}/${{ env.DISTRIBUTION_ZIP_NAME }} hazelcast-distribution
 
       - name: Build EE image
         run: |
-          docker build -t hazelcast/ee:${{ github.sha }} hazelcast-enterprise
+          docker build -t ${{ env.IMAGE_TAG }} ${{ env.DIRECTORY }}
 
       - name: Scan EE image by Trivy
         if: always()
         uses: aquasecurity/trivy-action@0.23.0
         with:
-          image-ref: hazelcast/ee:${{ github.sha }}
+          image-ref: ${{ env.IMAGE_TAG }}
           trivy-config: .github/containerscan/trivy.yaml
 
       - name: Scan EE image by Dockle
@@ -110,7 +118,7 @@ jobs:
         # uses: goodwithtech/dockle-action@main
         uses: JackPGreen/dockle-action/@Upgrade-Dockle-to-`0.4.14`
         with:
-          image: hazelcast/ee:${{ github.sha }}
+          image: ${{ env.IMAGE_TAG }}
           format: 'list'
           exit-code: '1'
           exit-level: 'warn'
@@ -123,5 +131,5 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: hazelcast/ee:${{ github.sha }}
-          args: --file=hazelcast-enterprise/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
+          image: ${{ env.IMAGE_TAG }}
+          args: --file=${{ env.DIRECTORY }}/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
           # DI-50 - Remove java artifacts scanning from hazelcast-docker
-          working_directory=${RUNNER_TEMP}/hazelcast-distribution
+          working_directory=hazelcast-distribution
           mkdir -p ${working_directory}/lib
           mkdir -p ${working_directory}/bin
           touch ${working_directory}/bin/empty
@@ -83,4 +83,8 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ env.IMAGE_TAG }} 
-          args: --file=${{ env.DIRECTORY }}/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
+          args: |
+            --file=${{ env.DIRECTORY }}/Dockerfile
+            --policy-path=.github/containerscan
+            --severity-threshold=high
+            --exclude-base-image-vulns

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -64,9 +64,9 @@ jobs:
 
       - name: Scan ${{ matrix.image.label }} image by Dockle
         if: always()
-        # Use my fork until https://github.com/goodwithtech/dockle-action/issues/7 is fixed
+        # Use our fork until https://github.com/goodwithtech/dockle-action/issues/7 is fixed
         # uses: goodwithtech/dockle-action@main
-        uses: JackPGreen/dockle-action/@Upgrade-Dockle-to-`0.4.14`
+        uses: hazelcast/dockle-action/@Upgrade-Dockle-to-`0.4.14`
         with:
           image: ${{ env.IMAGE_TAG }} 
           format: 'list'

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -88,10 +88,10 @@ jobs:
       - name: Get EE dist ZIP
         run: |
           # TODO Make this an ENV?
-          mkdir -p hazelcast-enterprise-distribution/lib
-          mkdir -p hazelcast-enterprise-distribution/bin
-          touch hazelcast-enterprise-distribution/bin/empty
-          zip -r hazelcast-enterprise/hazelcast-distribution.zip hazelcast-enterprise-distribution
+          mkdir -p hazelcast-distribution/lib
+          mkdir -p hazelcast-distribution/bin
+          touch hazelcast-distribution/bin/empty
+          zip -r hazelcast-enterprise/hazelcast-enterprise-distribution.zip hazelcast-distribution
 
       - name: Build EE image
         run: |

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -33,6 +33,17 @@ jobs:
     - name: Install xmllint
       uses: ./.github/actions/install-xmllint
 
+    - name: Get dist ZIP
+      run: |
+        # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
+        # DI-50 - Remove java artifacts scanning from hazelcast-docker
+        working_directory=hazelcast-distribution
+        mkdir -p $working_directory/lib
+        mkdir -p $working_directory/bin
+        touch $working_directory/bin/empty
+
+        zip -r hazelcast-distribution.zip $working_directory
+
   scan:
     needs: setup
     runs-on: ubuntu-latest
@@ -47,16 +58,9 @@ jobs:
       DIRECTORY: hazelcast-${{ matrix.image.label }}
       IMAGE_TAG: hazelcast/${{ matrix.image.label }}:${{ github.sha }}
     steps:
-      - name: Get ${{ matrix.image.label }} dist ZIP
+      - name: Copy ${{ matrix.image.label }} dist ZIP
         run: |
-          # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
-          # DI-50 - Remove java artifacts scanning from hazelcast-docker
-          working_directory=hazelcast-distribution
-          mkdir -p ${working_directory}/lib
-          mkdir -p ${working_directory}/bin
-          touch ${working_directory}/bin/empty
-
-          zip -r ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }} ${working_directory}
+          cp hazelcast-distribution.zip ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }}
 
       - name: Build ${{ matrix.image.label }} image
         run: |

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -1,31 +1,34 @@
 name: Vulnerability Scan
 
 on:
-    workflow_call:
-        inputs:
-            ref:
-                required: true
-                type: string
-        secrets:
-            SNYK_TOKEN:
-                required: true
-    workflow_dispatch:
-        inputs:
-            ref:
-                required: true
-                type: string
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+    secrets:
+      SNYK_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      ref:
+        required: true
+        type: string
 
 env:
   # https://github.com/aquasecurity/trivy/issues/2432
   DOCKLE_HOST: "unix:///var/run/docker.sock"
 
 jobs:
-  scan-oss:
-    env:
-      DIRECTORY: "hazelcast-oss"
-      IMAGE_TAG: "hazelcast/oss:${{ github.sha }}"
-      DISTRIBUTION_ZIP_NAME: "hazelcast-distribution.zip"
+  scan:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [oss, ee]
+    env:
+      DIRECTORY: ${{ matrix.variant == 'oss' && 'hazelcast-oss' || 'hazelcast-enterprise' }}
+      IMAGE_TAG: hazelcast/${{ matrix.variant }}:${{ github.sha }}
+      DISTRIBUTION_ZIP_NAME: ${{ matrix.variant == 'oss' && 'hazelcast-distribution.zip' || 'hazelcast-enterprise-distribution.zip' }}
     steps:
       - name: Checkout Code at ${{ inputs.ref }} branch
         uses: actions/checkout@v4
@@ -35,101 +38,44 @@ jobs:
       - name: Install xmllint
         uses: ./.github/actions/install-xmllint
 
-      - name: Get OSS dist ZIP
+      - name: Get ${{ matrix.variant }} dist ZIP
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
           # DI-50 - Remove java artifacts scanning from hazelcast-docker
           mkdir -p hazelcast-distribution/lib
           mkdir -p hazelcast-distribution/bin
           touch hazelcast-distribution/bin/empty
-          zip -r ${{ env.DIRECTORY }}/${{ env.DISTRIBUTION_ZIP_NAME }} hazelcast-distribution
+          zip -r $DIRECTORY/$DISTRIBUTION_ZIP_NAME hazelcast-distribution
 
-      - name: Build OSS image
+      - name: Build ${{ matrix.variant }} image
         run: |
-            docker build -t ${{ env.IMAGE_TAG }} ${{ env.DIRECTORY }}
+          docker build -t $IMAGE_TAG $DIRECTORY
 
-      - name: Scan OSS image by Trivy
+      - name: Scan ${{ matrix.variant }} image by Trivy
         if: always()
         uses: aquasecurity/trivy-action@0.23.0
         with:
-          image-ref: ${{ env.IMAGE_TAG }}
+          image-ref: $IMAGE_TAG
           trivy-config: .github/containerscan/trivy.yaml
 
-      - name: Scan OSS image by Dockle
+      - name: Scan ${{ matrix.variant }} image by Dockle
         if: always()
         # Use my fork until https://github.com/goodwithtech/dockle-action/issues/7 is fixed
         # uses: goodwithtech/dockle-action@main
         uses: JackPGreen/dockle-action/@Upgrade-Dockle-to-`0.4.14`
         with:
-          image: ${{ env.IMAGE_TAG }}
+          image: $IMAGE_TAG
           format: 'list'
           exit-code: '1'
           exit-level: 'warn'
           # too many false positives, we don't use credentials in Dockerfile
           ignore: 'CIS-DI-0010'
 
-      - name: Scan OSS image by Snyk
+      - name: Scan ${{ matrix.variant }} image by Snyk
         if: always()
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: ${{ env.IMAGE_TAG }}
-          args: --file=${{ env.DIRECTORY }}/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
-
-  scan-ee:
-    env:
-      DIRECTORY: "hazelcast-enterprise"
-      IMAGE_TAG: "hazelcast/ee:${{ github.sha }}"
-      DISTRIBUTION_ZIP_NAME: "hazelcast-enterprise-distribution.zip"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code at ${{ inputs.ref }} branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-
-      - name: Install xmllint
-        uses: ./.github/actions/install-xmllint
-
-      - name: Get EE dist ZIP
-        run: |
-          # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
-          # DI-50 - Remove java artifacts scanning from hazelcast-docker
-          mkdir -p hazelcast-distribution/lib
-          mkdir -p hazelcast-distribution/bin
-          touch hazelcast-distribution/bin/empty
-          zip -r ${{ env.DIRECTORY }}/${{ env.DISTRIBUTION_ZIP_NAME }} hazelcast-distribution
-
-      - name: Build EE image
-        run: |
-          docker build -t ${{ env.IMAGE_TAG }} ${{ env.DIRECTORY }}
-
-      - name: Scan EE image by Trivy
-        if: always()
-        uses: aquasecurity/trivy-action@0.23.0
-        with:
-          image-ref: ${{ env.IMAGE_TAG }}
-          trivy-config: .github/containerscan/trivy.yaml
-
-      - name: Scan EE image by Dockle
-        if: always()
-        # Use my fork until https://github.com/goodwithtech/dockle-action/issues/7 is fixed
-        # uses: goodwithtech/dockle-action@main
-        uses: JackPGreen/dockle-action/@Upgrade-Dockle-to-`0.4.14`
-        with:
-          image: ${{ env.IMAGE_TAG }}
-          format: 'list'
-          exit-code: '1'
-          exit-level: 'warn'
-          # too many false positives, we don't use credentials in Dockerfile
-          ignore: 'CIS-DI-0010'
-
-      - name: Scan EE image by Snyk
-        if: always()
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: ${{ env.IMAGE_TAG }}
-          args: --file=${{ env.DIRECTORY }}/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
+          image: $IMAGE_TAG
+          args: --file=$DIRECTORY/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -88,9 +88,9 @@ jobs:
       - name: Get EE dist ZIP
         run: |
           # TODO Make this an ENV?
-          mkdir -p hazelcast-distribution/lib
-          mkdir -p hazelcast-distribution/bin
-          touch hazelcast-distribution/bin/empty
+          mkdir -p hazelcast-enterprise-distribution/lib
+          mkdir -p hazelcast-enterprise-distribution/bin
+          touch hazelcast-enterprise-distribution/bin/empty
           zip -r hazelcast-enterprise/hazelcast-distribution.zip hazelcast-enterprise-distribution
 
       - name: Build EE image

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install xmllint
         uses: ./.github/actions/install-xmllint
 
-      - name: Get ${{ matrix.image.label }} dist ZIP
+      - name: Generate ${{ matrix.image.label }} dist ZIP
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
           # DI-50 - Remove java artifacts scanning from hazelcast-docker

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -24,11 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        variant: [oss, ee]
+        image: [ {label: oss, directory: hazelcast-oss, distribution_zip_name: hazelcast-distribution.zip}, {label: ee, directory: hazelcast-enterprise, distribution_zip_name: hazelcast-enterprise-distribution.zip} ]
     env:
-      DIRECTORY: ${{ matrix.variant == 'oss' && 'hazelcast-oss' || 'hazelcast-enterprise' }}
-      IMAGE_TAG: hazelcast/${{ matrix.variant }}:${{ github.sha }}
-      DISTRIBUTION_ZIP_NAME: ${{ matrix.variant == 'oss' && 'hazelcast-distribution.zip' || 'hazelcast-enterprise-distribution.zip' }}
+      IMAGE_TAG: hazelcast/${{ matrix.image.label }}:${{ github.sha }}
     steps:
       - name: Checkout Code at ${{ inputs.ref }} branch
         uses: actions/checkout@v4
@@ -38,27 +36,27 @@ jobs:
       - name: Install xmllint
         uses: ./.github/actions/install-xmllint
 
-      - name: Get ${{ matrix.variant }} dist ZIP
+      - name: Get ${{ matrix.image.label }} dist ZIP
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
           # DI-50 - Remove java artifacts scanning from hazelcast-docker
           mkdir -p hazelcast-distribution/lib
           mkdir -p hazelcast-distribution/bin
           touch hazelcast-distribution/bin/empty
-          zip -r $DIRECTORY/$DISTRIBUTION_ZIP_NAME hazelcast-distribution
+          zip -r ${{ matrix.image.directory }}/${{ matrix.image.distribution_zip_name }} hazelcast-distribution
 
-      - name: Build ${{ matrix.variant }} image
+      - name: Build ${{ matrix.image.label }} image
         run: |
-          docker build -t ${{ env.IMAGE_TAG }}  $DIRECTORY
+          docker build -t ${{ env.IMAGE_TAG }} ${{ matrix.image.directory }}
 
-      - name: Scan ${{ matrix.variant }} image by Trivy
+      - name: Scan ${{ matrix.image.label }} image by Trivy
         if: always()
         uses: aquasecurity/trivy-action@0.23.0
         with:
           image-ref: ${{ env.IMAGE_TAG }} 
           trivy-config: .github/containerscan/trivy.yaml
 
-      - name: Scan ${{ matrix.variant }} image by Dockle
+      - name: Scan ${{ matrix.image.label }} image by Dockle
         if: always()
         # Use my fork until https://github.com/goodwithtech/dockle-action/issues/7 is fixed
         # uses: goodwithtech/dockle-action@main
@@ -71,7 +69,7 @@ jobs:
           # too many false positives, we don't use credentials in Dockerfile
           ignore: 'CIS-DI-0010'
 
-      - name: Scan ${{ matrix.variant }} image by Snyk
+      - name: Scan ${{ matrix.image.label }} image by Snyk
         if: always()
         uses: snyk/actions/docker@master
         env:

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -33,19 +33,6 @@ jobs:
     - name: Install xmllint
       uses: ./.github/actions/install-xmllint
 
-    - name: Get dist ZIP
-      run: |
-        # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
-        # DI-50 - Remove java artifacts scanning from hazelcast-docker
-        working_directory=hazelcast-distribution
-        mkdir -p $working_directory/lib
-        mkdir -p $working_directory/bin
-        touch $working_directory/bin/empty
-
-        zip -r hazelcast-distribution.zip $working_directory
-        pwd
-        ls
-
   scan:
     needs: setup
     runs-on: ubuntu-latest
@@ -62,12 +49,17 @@ jobs:
     steps:
       - name: Copy ${{ matrix.image.label }} dist ZIP
         run: |
-          pwd
-          ls
+          # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
+          # DI-50 - Remove java artifacts scanning from hazelcast-docker
+          working_directory=hazelcast-distribution
+          mkdir -p $working_directory/lib
+          mkdir -p $working_directory/bin
+          touch $working_directory/bin/empty
+
+          zip -r ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }} $working_directory
 
       - name: Build ${{ matrix.image.label }} image
         run: |
-          cp hazelcast-distribution.zip ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }}
           docker build -t ${{ env.IMAGE_TAG }} ${{ env.DIRECTORY }}
 
       - name: Scan ${{ matrix.image.label }} image by Trivy

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
           # DI-50 - Remove java artifacts scanning from hazelcast-docker
-          working_directory=hazelcast-distribution
+          working_directory=${RUNNER_TEMP}/hazelcast-distribution
           mkdir -p ${working_directory}/lib
           mkdir -p ${working_directory}/bin
           touch ${working_directory}/bin/empty
@@ -83,8 +83,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ env.IMAGE_TAG }} 
-          args: >
-            --file=${{ env.DIRECTORY }}/Dockerfile
-            --policy-path=.github/containerscan
-            --severity-threshold=high
-            --exclude-base-image-vulns
+          args: --file=${{ env.DIRECTORY }}/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -24,7 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: [ {label: oss, directory: hazelcast-oss, distribution_zip_name: hazelcast-distribution.zip}, {label: ee, directory: hazelcast-enterprise, distribution_zip_name: hazelcast-enterprise-distribution.zip} ]
+        image:
+          - label: oss
+            directory: hazelcast-oss
+            distribution_zip_name: hazelcast-distribution.zip
+          - label: ee
+            directory: hazelcast-enterprise
+            distribution_zip_name: hazelcast-enterprise-distribution.zip
     env:
       IMAGE_TAG: hazelcast/${{ matrix.image.label }}:${{ github.sha }}
     steps:
@@ -76,4 +82,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ env.IMAGE_TAG }} 
-          args: --file=$DIRECTORY/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
+          args: --file=${{ matrix.image.directory }}/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -85,6 +85,6 @@ jobs:
           image: ${{ env.IMAGE_TAG }} 
           args: >
             --file=${{ env.DIRECTORY }}/Dockerfile
-            --policy-path=.github/containerscan /
-            --severity-threshold=high /
+            --policy-path=.github/containerscan
+            --severity-threshold=high
             --exclude-base-image-vulns

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
           # DI-50 - Remove java artifacts scanning from hazelcast-docker
-          working-directory=${RUNNER_TEMP}/hazelcast-distribution
+          working-directory=hazelcast-distribution
           mkdir -p ${WORKING_DIRECTORY}/lib
           mkdir -p ${WORKING_DIRECTORY}/bin
           touch ${WORKING_DIRECTORY}/bin/empty

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -48,7 +48,8 @@ jobs:
 
       - name: Scan OSS image by Dockle
         if: always()
-        uses: goodwithtech/dockle-action@main
+        # uses: goodwithtech/dockle-action@main
+        uses: JackPGreen/dockle-action/@Upgrade-Dockle-to-`0.4.14`
         with:
           image: hazelcast/oss:${{ github.sha }}
           format: 'list'

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -20,7 +20,21 @@ env:
   DOCKLE_HOST: "unix:///var/run/docker.sock"
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      workspace: ${{ steps.setup.outputs.workspace }}
+    steps:
+    - name: Checkout Code at ${{ inputs.ref }} branch
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+
+    - name: Install xmllint
+      uses: ./.github/actions/install-xmllint
+
   scan:
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -33,19 +47,12 @@ jobs:
       DIRECTORY: hazelcast-${{ matrix.image.label }}
       IMAGE_TAG: hazelcast/${{ matrix.image.label }}:${{ github.sha }}
     steps:
-      - name: Checkout Code at ${{ inputs.ref }} branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-
-      - name: Install xmllint
-        uses: ./.github/actions/install-xmllint
 
       - name: Get ${{ matrix.image.label }} dist ZIP
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
           # DI-50 - Remove java artifacts scanning from hazelcast-docker
-          working-directory=hazelcast-distribution
+          working_directory=hazelcast-distribution
           mkdir -p ${WORKING_DIRECTORY}/lib
           mkdir -p ${WORKING_DIRECTORY}/bin
           touch ${WORKING_DIRECTORY}/bin/empty

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -45,10 +45,12 @@ jobs:
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
           # DI-50 - Remove java artifacts scanning from hazelcast-docker
-          mkdir -p hazelcast-distribution/lib
-          mkdir -p hazelcast-distribution/bin
-          touch hazelcast-distribution/bin/empty
-          zip -r ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }} hazelcast-distribution
+          working-directory=${RUNNER_TEMP}/hazelcast-distribution
+          mkdir -p ${WORKING_DIRECTORY}/lib
+          mkdir -p ${WORKING_DIRECTORY}/bin
+          touch ${WORKING_DIRECTORY}/bin/empty
+
+          zip -r ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }} ${WORKING_DIRECTORY}
 
       - name: Build ${{ matrix.image.label }} image
         run: |

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -47,16 +47,16 @@ jobs:
       DIRECTORY: hazelcast-${{ matrix.image.label }}
       IMAGE_TAG: hazelcast/${{ matrix.image.label }}:${{ github.sha }}
     steps:
-      - name: Copy ${{ matrix.image.label }} dist ZIP
+      - name: Build ${{ matrix.image.label }} dist ZIP
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
           # DI-50 - Remove java artifacts scanning from hazelcast-docker
           working_directory=hazelcast-distribution
-          mkdir -p $working_directory/lib
-          mkdir -p $working_directory/bin
-          touch $working_directory/bin/empty
+          mkdir -p hazelcast-distribution/lib
+          mkdir -p hazelcast-distribution/bin
+          touch hazelcast-distribution/bin/empty
 
-          zip -r ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }} $working_directory
+          zip -r ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }} hazelcast-distribution
 
       - name: Build ${{ matrix.image.label }} image
         run: |

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -31,12 +31,9 @@ jobs:
 
       - name: Get OSS dist ZIP
         run: |
-          . .github/scripts/oss-build.functions.sh
-          HZ_VERSION=$(awk -F '=' '/^ARG HZ_VERSION=/ {print $2}' hazelcast-oss/Dockerfile)
-          export HZ_SNAPSHOT_INTERNAL_PASSWORD=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
-          export HZ_SNAPSHOT_INTERNAL_USERNAME=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
-          HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "" "${HZ_VERSION}")        
-          curl --fail --silent --show-error --location "$HAZELCAST_OSS_ZIP_URL" --output hazelcast-oss/hazelcast-distribution.zip;
+          touch contents
+          # TODO Make this an ENV?
+          zip -r hazelcast-oss/hazelcast-distribution.zip contents
 
       - name: Build OSS image
         run: |
@@ -84,10 +81,8 @@ jobs:
 
       - name: Get EE dist ZIP
         run: |
-          . .github/scripts/ee-build.functions.sh
-          HZ_VERSION=$(awk -F '=' '/^ARG HZ_VERSION=/ {print $2}' hazelcast-enterprise/Dockerfile)          
-          HAZELCAST_EE_ZIP_URL=$(get_hz_dist_zip "" "${HZ_VERSION}")        
-          curl --fail --silent --show-error --location "$HAZELCAST_EE_ZIP_URL" --output hazelcast-enterprise/hazelcast-enterprise-distribution.zip;
+          touch contents
+          zip -r hazelcast-enterprise/hazelcast-enterprise-distribution.zip contents
 
       - name: Build EE image
         run: |

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -17,8 +17,6 @@ on:
 
 jobs:
   scan-oss:
-    env:
-      DOCKLE_HOST: "unix:///var/run/docker.sock"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code at ${{ inputs.ref }} branch
@@ -58,6 +56,9 @@ jobs:
           exit-level: 'warn'
           # too many false positives, we don't use credentials in Dockerfile
           ignore: 'CIS-DI-0010'
+        env:
+          # https://github.com/aquasecurity/trivy/issues/2432
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
 
       - name: Scan OSS image by Snyk
         if: always()
@@ -69,8 +70,6 @@ jobs:
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
   # TODO Can we paramaterizxe this?
   scan-ee:
-    env:
-      DOCKLE_HOST: "unix:///var/run/docker.sock"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code at ${{ inputs.ref }} branch
@@ -110,6 +109,9 @@ jobs:
           exit-level: 'warn'
           # too many false positives, we don't use credentials in Dockerfile
           ignore: 'CIS-DI-0010'
+        env:
+          # https://github.com/aquasecurity/trivy/issues/2432
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
 
       - name: Scan EE image by Snyk
         if: always()

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -17,6 +17,9 @@ on:
 
 jobs:
   scan-oss:
+    env:
+      # https://github.com/aquasecurity/trivy/issues/2432
+      DOCKLE_HOST: "unix:///var/run/docker.sock"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code at ${{ inputs.ref }} branch
@@ -45,9 +48,6 @@ jobs:
         with:
           image-ref: hazelcast/oss:${{ github.sha }}
           trivy-config: .github/containerscan/trivy.yaml
-        env:
-          # https://github.com/aquasecurity/trivy/issues/2432
-          DOCKLE_HOST: "unix:///var/run/docker.sock"
 
       - name: Scan OSS image by Dockle
         if: always()
@@ -72,6 +72,9 @@ jobs:
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
   # TODO Can we paramaterizxe this?
   scan-ee:
+    env:
+      # https://github.com/aquasecurity/trivy/issues/2432
+      DOCKLE_HOST: "unix:///var/run/docker.sock"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code at ${{ inputs.ref }} branch
@@ -100,9 +103,6 @@ jobs:
         with:
           image-ref: hazelcast/ee:${{ github.sha }}
           trivy-config: .github/containerscan/trivy.yaml
-        env:
-          # https://github.com/aquasecurity/trivy/issues/2432
-          DOCKLE_HOST: "unix:///var/run/docker.sock"
 
       - name: Scan EE image by Dockle
         if: always()

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -64,10 +64,10 @@ jobs:
         run: |
           pwd
           ls
-          cp hazelcast-distribution.zip ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }}
 
       - name: Build ${{ matrix.image.label }} image
         run: |
+          cp hazelcast-distribution.zip ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }}
           docker build -t ${{ env.IMAGE_TAG }} ${{ env.DIRECTORY }}
 
       - name: Scan ${{ matrix.image.label }} image by Trivy

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -43,6 +43,8 @@ jobs:
         touch $working_directory/bin/empty
 
         zip -r hazelcast-distribution.zip $working_directory
+        pwd
+        ls
 
   scan:
     needs: setup
@@ -60,6 +62,8 @@ jobs:
     steps:
       - name: Copy ${{ matrix.image.label }} dist ZIP
         run: |
+          pwd
+          ls
           cp hazelcast-distribution.zip ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }}
 
       - name: Build ${{ matrix.image.label }} image

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -31,9 +31,11 @@ jobs:
 
       - name: Get OSS dist ZIP
         run: |
-          touch contents
           # TODO Make this an ENV?
-          zip -r hazelcast-oss/hazelcast-distribution.zip contents
+          mkdir -p hazelcast-distribution/lib
+          mkdir -p hazelcast-distribution/bin
+          touch hazelcast-distribution/bin/empty
+          zip -r hazelcast-oss/hazelcast-distribution.zip hazelcast-distribution
 
       - name: Build OSS image
         run: |
@@ -65,7 +67,7 @@ jobs:
         with:
           image: hazelcast/oss:${{ github.sha }}
           args: --file=hazelcast-oss/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns
-
+  # TODO Can we paramaterizxe this?
   scan-ee:
     env:
       DOCKLE_HOST: "unix:///var/run/docker.sock"
@@ -81,8 +83,11 @@ jobs:
 
       - name: Get EE dist ZIP
         run: |
-          touch contents
-          zip -r hazelcast-enterprise/hazelcast-enterprise-distribution.zip contents
+          # TODO Make this an ENV?
+          mkdir -p hazelcast-distribution/lib
+          mkdir -p hazelcast-distribution/bin
+          touch hazelcast-distribution/bin/empty
+          zip -r hazelcast-enterprise/hazelcast-distribution.zip hazelcast-enterprise-distribution
 
       - name: Build EE image
         run: |

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
           # DI-50 - Remove java artifacts scanning from hazelcast-docker
-          working_directory=${RUNNER_TEMP}/hazelcast-distribution
+          working_directory=hazelcast-distribution
           mkdir -p ${working_directory}/lib
           mkdir -p ${working_directory}/bin
           touch ${working_directory}/bin/empty

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -47,17 +47,16 @@ jobs:
       DIRECTORY: hazelcast-${{ matrix.image.label }}
       IMAGE_TAG: hazelcast/${{ matrix.image.label }}:${{ github.sha }}
     steps:
-
       - name: Get ${{ matrix.image.label }} dist ZIP
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
           # DI-50 - Remove java artifacts scanning from hazelcast-docker
-          working_directory=hazelcast-distribution
-          mkdir -p ${WORKING_DIRECTORY}/lib
-          mkdir -p ${WORKING_DIRECTORY}/bin
-          touch ${WORKING_DIRECTORY}/bin/empty
+          working_directory=${RUNNER_TEMP}/hazelcast-distribution
+          mkdir -p ${working_directory}/lib
+          mkdir -p ${working_directory}/bin
+          touch ${working_directory}/bin/empty
 
-          zip -r ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }} ${WORKING_DIRECTORY}
+          zip -r ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }} ${working_directory}
 
       - name: Build ${{ matrix.image.label }} image
         run: |

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -83,8 +83,8 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ env.IMAGE_TAG }} 
-          args: |
+          args: >
             --file=${{ env.DIRECTORY }}/Dockerfile
-            --policy-path=.github/containerscan
-            --severity-threshold=high
+            --policy-path=.github/containerscan /
+            --severity-threshold=high /
             --exclude-base-image-vulns

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -49,13 +49,13 @@ jobs:
 
       - name: Build ${{ matrix.variant }} image
         run: |
-          docker build -t $IMAGE_TAG $DIRECTORY
+          docker build -t ${{ env.IMAGE_TAG }}  $DIRECTORY
 
       - name: Scan ${{ matrix.variant }} image by Trivy
         if: always()
         uses: aquasecurity/trivy-action@0.23.0
         with:
-          image-ref: $IMAGE_TAG
+          image-ref: ${{ env.IMAGE_TAG }} 
           trivy-config: .github/containerscan/trivy.yaml
 
       - name: Scan ${{ matrix.variant }} image by Dockle
@@ -64,7 +64,7 @@ jobs:
         # uses: goodwithtech/dockle-action@main
         uses: JackPGreen/dockle-action/@Upgrade-Dockle-to-`0.4.14`
         with:
-          image: $IMAGE_TAG
+          image: ${{ env.IMAGE_TAG }} 
           format: 'list'
           exit-code: '1'
           exit-level: 'warn'
@@ -77,5 +77,5 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: $IMAGE_TAG
+          image: ${{ env.IMAGE_TAG }} 
           args: --file=$DIRECTORY/Dockerfile --policy-path=.github/containerscan --severity-threshold=high --exclude-base-image-vulns

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -45,9 +45,13 @@ jobs:
         with:
           image-ref: hazelcast/oss:${{ github.sha }}
           trivy-config: .github/containerscan/trivy.yaml
+        env:
+          # https://github.com/aquasecurity/trivy/issues/2432
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
 
       - name: Scan OSS image by Dockle
         if: always()
+        # Use my fork until https://github.com/goodwithtech/dockle-action/issues/7 is fixed
         # uses: goodwithtech/dockle-action@main
         uses: JackPGreen/dockle-action/@Upgrade-Dockle-to-`0.4.14`
         with:
@@ -57,9 +61,6 @@ jobs:
           exit-level: 'warn'
           # too many false positives, we don't use credentials in Dockerfile
           ignore: 'CIS-DI-0010'
-        env:
-          # https://github.com/aquasecurity/trivy/issues/2432
-          DOCKLE_HOST: "unix:///var/run/docker.sock"
 
       - name: Scan OSS image by Snyk
         if: always()
@@ -99,10 +100,15 @@ jobs:
         with:
           image-ref: hazelcast/ee:${{ github.sha }}
           trivy-config: .github/containerscan/trivy.yaml
+        env:
+          # https://github.com/aquasecurity/trivy/issues/2432
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
 
       - name: Scan EE image by Dockle
         if: always()
-        uses: goodwithtech/dockle-action@main
+        # Use my fork until https://github.com/goodwithtech/dockle-action/issues/7 is fixed
+        # uses: goodwithtech/dockle-action@main
+        uses: JackPGreen/dockle-action/@Upgrade-Dockle-to-`0.4.14`
         with:
           image: hazelcast/ee:${{ github.sha }}
           format: 'list'
@@ -110,9 +116,6 @@ jobs:
           exit-level: 'warn'
           # too many false positives, we don't use credentials in Dockerfile
           ignore: 'CIS-DI-0010'
-        env:
-          # https://github.com/aquasecurity/trivy/issues/2432
-          DOCKLE_HOST: "unix:///var/run/docker.sock"
 
       - name: Scan EE image by Snyk
         if: always()

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -20,21 +20,7 @@ env:
   DOCKLE_HOST: "unix:///var/run/docker.sock"
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      workspace: ${{ steps.setup.outputs.workspace }}
-    steps:
-    - name: Checkout Code at ${{ inputs.ref }} branch
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.ref }}
-
-    - name: Install xmllint
-      uses: ./.github/actions/install-xmllint
-
   scan:
-    needs: setup
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -47,16 +33,24 @@ jobs:
       DIRECTORY: hazelcast-${{ matrix.image.label }}
       IMAGE_TAG: hazelcast/${{ matrix.image.label }}:${{ github.sha }}
     steps:
-      - name: Build ${{ matrix.image.label }} dist ZIP
+      - name: Checkout Code at ${{ inputs.ref }} branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install xmllint
+        uses: ./.github/actions/install-xmllint
+
+      - name: Get ${{ matrix.image.label }} dist ZIP
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream
           # DI-50 - Remove java artifacts scanning from hazelcast-docker
-          working_directory=hazelcast-distribution
-          mkdir -p hazelcast-distribution/lib
-          mkdir -p hazelcast-distribution/bin
-          touch hazelcast-distribution/bin/empty
+          working_directory=${RUNNER_TEMP}/hazelcast-distribution
+          mkdir -p ${working_directory}/lib
+          mkdir -p ${working_directory}/bin
+          touch ${working_directory}/bin/empty
 
-          zip -r ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }} hazelcast-distribution
+          zip -r ${{ env.DIRECTORY }}/${{ matrix.image.distribution_zip_name }} ${working_directory}
 
       - name: Build ${{ matrix.image.label }} image
         run: |


### PR DESCRIPTION
The [vulnerability scan workflow](https://github.com/hazelcast/hazelcast-docker/actions/workflows/vulnerability_scan.yml) is regularly failing because of false-positive vulnerabilities inside the Hazelcast distribution JAR.

We already scan, manage and catalogue vulnerabilities upstream for the wider Hazelcast product, so this additional layer is not properly managed and ends up failing.

Reworked these checks to _only_ focus on the Docker image, not the Hazelcast distribution, by replacing the Hazelcast distribution with a dummy empty ZIP.

Having got the scanners working, it became apparent we are also affected by https://github.com/goodwithtech/dockle-action/issues/7 - so until my fix is merged upstream, I've moved this action onto using my fixed branch in a fork, instead.

Also refactored duplicated OS + EE job to use a centralised matrix.

Fixes: [DI-50](https://hazelcast.atlassian.net/browse/DI-50)

[DI-50]: https://hazelcast.atlassian.net/browse/DI-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ