### PR TITLE
Add 5.5.z branch for vulnerability scan

### DIFF
--- a/.github/workflows/scheduled_vulnerability_scan.yml
+++ b/.github/workflows/scheduled_vulnerability_scan.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                ref: [ 'master', '5.4.z', '5.3.z', '5.2.z' ]
+                ref: [ 'master', '5.5.z', '5.4.z', '5.3.z', '5.2.z' ]
         uses: ./.github/workflows/vulnerability_scan_subworkflow.yml
         with:
             ref: ${{ matrix.ref }}


### PR DESCRIPTION
Adding 5.5.z branch as dictated [here](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/4681400429/Post+release+tasks+5.x#Update-hazelcast-docker-vulnerability-scanning-branches)