### PR TITLE
Update `#!/usr/bin/env bash` references to `#!/bin/bash` [DI-216]

### DIFF
--- a/.github/scripts/abstract-simple-smoke-test.sh
+++ b/.github/scripts/abstract-simple-smoke-test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -o errexit -o nounset -o pipefail
 

--- a/.github/scripts/base-image-updated.sh
+++ b/.github/scripts/base-image-updated.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 function findScriptDir() {
   CURRENT=$PWD

--- a/.github/scripts/build.functions_tests.sh
+++ b/.github/scripts/build.functions_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/.github/scripts/docker.functions.sh
+++ b/.github/scripts/docker.functions.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 function get_default_jdk() {
   local DIR=$1

--- a/.github/scripts/ee-build.functions_tests.sh
+++ b/.github/scripts/ee-build.functions_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 function find_script_dir() {

--- a/.github/scripts/generate-docker-hub-description.sh
+++ b/.github/scripts/generate-docker-hub-description.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eEuo pipefail ${RUNNER_DEBUG:+-x}
 

--- a/.github/scripts/get-tags-to-push.sh
+++ b/.github/scripts/get-tags-to-push.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 function find_last_matching_version() {
   FILTER=$1

--- a/.github/scripts/get-tags-to-push_tests.sh
+++ b/.github/scripts/get-tags-to-push_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/.github/scripts/log.functions.sh
+++ b/.github/scripts/log.functions.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 if command -v tput &>/dev/null && tty -s; then
   RED=$(tput setaf 1)

--- a/.github/scripts/maven.functions_tests.sh
+++ b/.github/scripts/maven.functions_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/.github/scripts/oss-build.functions_tests.sh
+++ b/.github/scripts/oss-build.functions_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 function find_script_dir() {

--- a/.github/scripts/packages-updated.sh
+++ b/.github/scripts/packages-updated.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 function findScriptDir() {
   CURRENT=$PWD

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -o errexit
 

--- a/.github/scripts/test_scripts.sh
+++ b/.github/scripts/test_scripts.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 function findScriptDir() {
   CURRENT=$PWD

--- a/.github/scripts/version.functions.sh
+++ b/.github/scripts/version.functions.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 function get_supported_versions() {
     local MINIMAL_VERSION=$1

--- a/.github/scripts/version.functions_tests.sh
+++ b/.github/scripts/version.functions_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 function findScriptDir() {
   CURRENT=$PWD


### PR DESCRIPTION
We _mostly_ use `#!/bin/bash` ([~700 references](https://github.com/search?q=org%3Ahazelcast+%22%23%21%2Fbin%2Fbash%22&type=code)), but sometimes we use `#!/usr/bin/env bash` ([~500 references](https://github.com/search?q=org%3Ahazelcast+%22%23%21%2Fusr%2Fbin%2Fenv+bash%22&type=code)).

We should be consistent.

Of note - [Google's style guide](https://google.github.io/styleguide/shellguide.html) suggests the same.

Fixes: [DI-216](https://hazelcast.atlassian.net/browse/DI-216)