### PR TITLE
Fix finding image request using RHEL API [5.2.z]

### DIFF
--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -17,16 +17,17 @@ get_image()
         echo "Need first parameter as 'published' or 'not_published'." ; return 1
     fi
 
-    local FILTER="filter=deleted==false;${PUBLISHED_FILTER}"
-    local INCLUDE="include=total,data.repositories.tags.name,data.certified,data.container_grades,data._id"
+    local FILTER="filter=deleted==false;${PUBLISHED_FILTER};repositories.tags=em=(name=='${VERSION}')"
+    local INCLUDE="include=total,data.repositories.tags.name,data.certified,data.container_grades,data._id,data.creation_date"
+    local SORT_BY='sort_by=creation_date\[desc\]'
 
     local RESPONSE=$( \
         curl --silent \
              --request GET \
              --header "X-API-KEY: ${RHEL_API_KEY}" \
-             "https://catalog.redhat.com/api/containers/v1/projects/certification/id/${RHEL_PROJECT_ID}/images?${FILTER}&${INCLUDE}")
+             "https://catalog.redhat.com/api/containers/v1/projects/certification/id/${RHEL_PROJECT_ID}/images?${FILTER}&${INCLUDE}&${SORT_BY}")
 
-    echo "${RESPONSE}" | jq ".data[] | select(.repositories[].tags[]?.name==\"${VERSION}\")" | jq -s '.[0] | select( . != null)' | jq -s '{data:., total: length}'
+    echo "${RESPONSE}"
 }
 
 wait_for_container_scan()


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/795

Fix publishing RHEL docker images.

It was randomly failing due to a bug in checking if the image was already published. The root cause was paging and client-side filtering. It was changed back to server-side filtering.

Example of the failing workflow: https://github.com/hazelcast/hazelcast-docker/actions/runs/10786754177/job/29935813852#step:24:158

![image](https://github.com/user-attachments/assets/3df40fe9-67db-45fd-85ed-1cbc34c2f087)

docs: https://catalog.redhat.com/api/containers/v1/ui/#/Certification%20projects/graphql.images.get_images_by_project_id
