### PR TITLE
Add support for latest-lts tags [DI-258][REL-343][5.5.1]

### DIFF
--- a/.github/scripts/get-tags-to-push.sh
+++ b/.github/scripts/get-tags-to-push.sh
@@ -45,10 +45,10 @@ function get_version_only_tags_to_push() {
   fi
 
   if verlte "$LATEST" "$VERSION_TO_RELEASE"; then
-    TAGS_TO_PUSH+=(latest)
+    TAGS_TO_PUSH+=("latest")
   fi
   if [ "$IS_LATEST_LTS" == "true" ] ; then
-    TAGS_TO_PUSH+=(latest-lts)
+    TAGS_TO_PUSH+=("latest-lts")
   fi
 
   echo "${TAGS_TO_PUSH[@]}"

--- a/.github/scripts/get-tags-to-push.sh
+++ b/.github/scripts/get-tags-to-push.sh
@@ -15,9 +15,10 @@ function verlte() {
 
 function get_version_only_tags_to_push() {
   local VERSION_TO_RELEASE=$1
+  local IS_LATEST_LTS=$2
 
-  if [ "$#" -ne 1 ]; then
-    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} VERSION_TO_RELEASE"
+  if [ "$#" -ne 2 ]; then
+    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} VERSION_TO_RELEASE IS_LATEST_LTS"
     exit 1;
   fi
 
@@ -46,14 +47,17 @@ function get_version_only_tags_to_push() {
   if verlte "$LATEST" "$VERSION_TO_RELEASE"; then
     TAGS_TO_PUSH+=(latest)
   fi
+  if [ "$IS_LATEST_LTS" == "true" ] ; then
+    TAGS_TO_PUSH+=(latest-lts)
+  fi
 
   echo "${TAGS_TO_PUSH[@]}"
 }
 
 function get_tags_to_push() {
 
-  if [ "$#" -ne 4 ]; then
-    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} VERSION_TO_RELEASE SUFFIX CURRENT_JDK DEFAULT_JDK"
+  if [ "$#" -ne 5 ]; then
+    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} VERSION_TO_RELEASE SUFFIX CURRENT_JDK DEFAULT_JDK IS_LATEST_LTS"
     exit 1;
   fi
 
@@ -61,7 +65,8 @@ function get_tags_to_push() {
   local SUFFIX=$2
   local CURRENT_JDK=$3
   local DEFAULT_JDK=$4
-  local VERSION_ONLY_TAGS_TO_PUSH=$(get_version_only_tags_to_push "$VERSION_TO_RELEASE")
+  local IS_LATEST_LTS=$5
+  local VERSION_ONLY_TAGS_TO_PUSH=$(get_version_only_tags_to_push "$VERSION_TO_RELEASE" "$IS_LATEST_LTS")
   augment_with_suffixed_tags "${VERSION_ONLY_TAGS_TO_PUSH[*]}" "$SUFFIX" "$CURRENT_JDK" "$DEFAULT_JDK"
 }
 

--- a/.github/scripts/get-tags-to-push_tests.sh
+++ b/.github/scripts/get-tags-to-push_tests.sh
@@ -2,39 +2,23 @@
 
 set -eu
 
-function findScriptDir() {
-  CURRENT=$PWD
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
-  DIR=$(dirname "$0")
-  cd "$DIR" || exit
-  TARGET_FILE=$(basename "$0")
-
-  # Iterate down a (possible) chain of symlinks
-  while [ -L "$TARGET_FILE" ]
-  do
-      TARGET_FILE=$(readlink "$TARGET_FILE")
-      DIR=$(dirname "$TARGET_FILE")
-      cd "$DIR" || exit
-      TARGET_FILE=$(basename "$TARGET_FILE")
-  done
-
-  SCRIPT_DIR=$(pwd -P)
-  # Restore current directory
-  cd "$CURRENT" || exit
-}
-
-findScriptDir
-
-. "$SCRIPT_DIR"/assert.sh/assert.sh
+# Source the latest version of assert.sh unit testing library and include in current shell
+assert_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)
+# shellcheck source=/dev/null
+. <(echo "${assert_script_content}")
 . "$SCRIPT_DIR"/get-tags-to-push.sh
 
 TESTS_RESULT=0
 
 function assert_get_version_only_tags_to_push {
   local VERSION_TO_RELEASE=$1
-  local EXPECTED_TAGS_TO_PUSH=$2
-  local ACTUAL_TAGS_TO_PUSH=$(get_version_only_tags_to_push "$VERSION_TO_RELEASE")
-  assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "Tags to push for version $VERSION_TO_RELEASE should be equal to $EXPECTED_TAGS_TO_PUSH " || TESTS_RESULT=$?
+  local IS_LATEST_LTS=$2
+  local EXPECTED_TAGS_TO_PUSH=$3
+  local ACTUAL_TAGS_TO_PUSH=$(get_version_only_tags_to_push "$VERSION_TO_RELEASE" "$IS_LATEST_LTS")
+  local MSG="Tags to push for version $VERSION_TO_RELEASE and is_latest_lts = '$IS_LATEST_LTS' should be equal to $EXPECTED_TAGS_TO_PUSH"
+  assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
 }
 
 function assert_augment_with_suffixed_tags {
@@ -44,7 +28,8 @@ function assert_augment_with_suffixed_tags {
   local DEFAULT_JDK=$4
   local EXPECTED_TAGS_TO_PUSH=$5
   local ACTUAL_TAGS_TO_PUSH=$(augment_with_suffixed_tags "${INITIAL_TAGS[*]}" "$SUFFIX" "$CURRENT_JDK" "$DEFAULT_JDK")
-  assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "Suffixed tags to push for (tags=$INITIAL_TAGS suffix=$SUFFIX current_jdk=$CURRENT_JDK default_jdk=$DEFAULT_JDK) should be equal to: $EXPECTED_TAGS_TO_PUSH " || TESTS_RESULT=$?
+  local MSG="Suffixed tags to push for (tags=$INITIAL_TAGS suffix=$SUFFIX current_jdk=$CURRENT_JDK default_jdk=$DEFAULT_JDK) should be equal to: $EXPECTED_TAGS_TO_PUSH"
+  assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
 }
 
 function assert_get_tags_to_push {
@@ -52,21 +37,25 @@ function assert_get_tags_to_push {
   local SUFFIX=$2
   local CURRENT_JDK=$3
   local DEFAULT_JDK=$4
-  local EXPECTED_TAGS_TO_PUSH=$5
-  local ACTUAL_TAGS_TO_PUSH=$(get_tags_to_push "$VERSION_TO_RELEASE" "$SUFFIX" "$CURRENT_JDK" "$DEFAULT_JDK")
-  assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "Tags to push for (version_to_release=$VERSION_TO_RELEASE suffix=$SUFFIX current_jdk=$CURRENT_JDK default_jdk=$DEFAULT_JDK) should be equal to: $EXPECTED_TAGS_TO_PUSH " || TESTS_RESULT=$?
+  local IS_LATEST_LTS=$5
+  local EXPECTED_TAGS_TO_PUSH=$6
+  local ACTUAL_TAGS_TO_PUSH=$(get_tags_to_push "$VERSION_TO_RELEASE" "$SUFFIX" "$CURRENT_JDK" "$DEFAULT_JDK" "$IS_LATEST_LTS")
+  local MSG="Tags to push for (version_to_release=$VERSION_TO_RELEASE suffix=$SUFFIX current_jdk=$CURRENT_JDK default_jdk=$DEFAULT_JDK is_latest_jdk=$IS_LATEST_LTS) should be equal to: $EXPECTED_TAGS_TO_PUSH "
+  assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
 }
 
 log_header "Tests for get_version_only_tags_to_push"
-assert_get_version_only_tags_to_push "5.2.0" "5.2.0"
-assert_get_version_only_tags_to_push "5.2.1" "5.2.1"
-assert_get_version_only_tags_to_push "5.1.99" "5.1.99 5.1"
-assert_get_version_only_tags_to_push "4.99.0" "4.99.0 4.99 4"
-assert_get_version_only_tags_to_push "99.0.0" "99.0.0 99.0 99 latest"
-assert_get_version_only_tags_to_push "5.3.0-BETA-1" "5.3.0-BETA-1"
-assert_get_version_only_tags_to_push "5.4.0-DEVEL-9" "5.4.0-DEVEL-9"
-assert_get_version_only_tags_to_push "5.99.0-BETA-1" "5.99.0-BETA-1"
-assert_get_version_only_tags_to_push "99.0.0-BETA-1" "99.0.0-BETA-1"
+assert_get_version_only_tags_to_push "5.2.0" "false" "5.2.0"
+assert_get_version_only_tags_to_push "5.2.1" "false" "5.2.1"
+assert_get_version_only_tags_to_push "5.1.99" "false" "5.1.99 5.1"
+assert_get_version_only_tags_to_push "4.99.0" "false" "4.99.0 4.99 4"
+assert_get_version_only_tags_to_push "99.0.0" "false" "99.0.0 99.0 99 latest"
+assert_get_version_only_tags_to_push "5.3.0-BETA-1" "false" "5.3.0-BETA-1"
+assert_get_version_only_tags_to_push "5.4.0-DEVEL-9" "false" "5.4.0-DEVEL-9"
+assert_get_version_only_tags_to_push "5.99.0-BETA-1" "false" "5.99.0-BETA-1"
+assert_get_version_only_tags_to_push "99.0.0-BETA-1" "false" "99.0.0-BETA-1"
+assert_get_version_only_tags_to_push "99.0.0" "true" "99.0.0 99.0 99 latest latest-lts"
+assert_get_version_only_tags_to_push "5.2.0" "true" "5.2.0 latest-lts"
 
 log_header "Tests for augment_with_suffixed_tags"
 assert_augment_with_suffixed_tags "1.2.3" "" "11" "11" "1.2.3 1.2.3-jdk11"
@@ -76,14 +65,17 @@ assert_augment_with_suffixed_tags "1.2.3 latest" "" "17" "11" "1.2.3-jdk17 lates
 assert_augment_with_suffixed_tags "1.2.3" "-slim" "11" "11" "1.2.3-slim 1.2.3-slim-jdk11"
 assert_augment_with_suffixed_tags "1.2.3" "-slim" "17" "11" "1.2.3-slim-jdk17"
 assert_augment_with_suffixed_tags "1.2.3 latest" "-slim" "17" "11" "1.2.3-slim-jdk17 latest-slim-jdk17"
+assert_augment_with_suffixed_tags "1.2.3 latest-lts" "-slim" "17" "11" "1.2.3-slim-jdk17 latest-lts-slim-jdk17"
 tags_array=(1.2.3 latest)
 assert_augment_with_suffixed_tags "${tags_array[*]}" "-slim" "17" "11" "1.2.3-slim-jdk17 latest-slim-jdk17"
 assert_augment_with_suffixed_tags "1.2.3 1.2" "-slim" "17" "11" "1.2.3-slim-jdk17 1.2-slim-jdk17"
 
 log_header "Tests for get_tags_to_push"
-assert_get_tags_to_push "5.2.0" "" "11" "11" "5.2.0 5.2.0-jdk11"
-assert_get_tags_to_push "99.0.0" "" "11" "11" "99.0.0 99.0.0-jdk11 99.0 99.0-jdk11 99 99-jdk11 latest latest-jdk11"
-assert_get_tags_to_push "99.0.0-BETA-1" "" "17" "11" "99.0.0-BETA-1-jdk17"
-assert_get_tags_to_push "5.4.0-DEVEL-9" "-slim" "17" "11" "5.4.0-DEVEL-9-slim-jdk17"
+assert_get_tags_to_push "5.2.0" "" "11" "11" "false" "5.2.0 5.2.0-jdk11"
+assert_get_tags_to_push "99.0.0" "" "11" "11" "false" "99.0.0 99.0.0-jdk11 99.0 99.0-jdk11 99 99-jdk11 latest latest-jdk11"
+assert_get_tags_to_push "99.0.0-BETA-1" "" "17" "11" "false" "99.0.0-BETA-1-jdk17"
+assert_get_tags_to_push "5.4.0-DEVEL-9" "-slim" "17" "false" "11" "5.4.0-DEVEL-9-slim-jdk17"
+assert_get_tags_to_push "5.2.0" "" "11" "11" "true" "5.2.0 5.2.0-jdk11 latest-lts latest-lts-jdk11"
+assert_get_tags_to_push "99.0.0" "" "11" "11" "true" "99.0.0 99.0.0-jdk11 99.0 99.0-jdk11 99 99-jdk11 latest latest-jdk11 latest-lts latest-lts-jdk11"
 
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -23,6 +23,14 @@ on:
           - ALL
           - OSS
           - EE
+      IS_LATEST_LTS:
+        description: 'Is latest LTS'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 env:
   test_container_name_oss: hazelcast-oss-test
   test_container_name_ee: hazelcast-ee-test
@@ -35,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_TYPE: ${{ inputs.RELEASE_TYPE || 'EE' }}
+      IS_LATEST_LTS: ${{ inputs.IS_LATEST_LTS || 'false' }}
     outputs:
       should_build_oss: ${{ steps.which_editions.outputs.should_build_oss }}
       should_build_ee: ${{ steps.which_editions.outputs.should_build_ee }}
@@ -51,6 +60,17 @@ jobs:
           else
               echo "File '$RELEASE_TYPE_FILE' does not exist."
               exit 1
+          fi
+
+      - name: Check if it is latest-lts release
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          IS_LATEST_LTS_FILE=.github/latest_lts
+          if [ -f IS_LATEST_LTS_FILE ]; then
+              echo "IS_LATEST_LTS=true" >> $GITHUB_ENV
+              echo "File '$IS_LATEST_LTS_FILE' exists. Assuming latest-lts release"
+          else
+              echo "File '$IS_LATEST_LTS_FILE' does not exist. Assuming NON-latest-lts release"
           fi
 
       - name: Check which editions should be built
@@ -197,7 +217,9 @@ jobs:
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
           
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          #OSS has no LTS releases
+          IS_LATEST_LTS=false
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}
@@ -223,7 +245,7 @@ jobs:
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast-enterprise
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
           
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -66,7 +66,7 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         run: |
           IS_LATEST_LTS_FILE=.github/latest_lts
-          if [ -f IS_LATEST_LTS_FILE ]; then
+          if [ -f $IS_LATEST_LTS_FILE ]; then
               echo "IS_LATEST_LTS=true" >> $GITHUB_ENV
               echo "File '$IS_LATEST_LTS_FILE' exists. Assuming latest-lts release"
           else

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -217,7 +217,7 @@ jobs:
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
           
-          #OSS has no LTS releases
+          # OSS has no LTS releases
           IS_LATEST_LTS=false
           TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -134,7 +134,7 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         run: |
           IS_LATEST_LTS_FILE=.github/latest_lts
-          if [ -f IS_LATEST_LTS_FILE ]; then
+          if [ -f $IS_LATEST_LTS_FILE ]; then
               echo "IS_LATEST_LTS=true" >> $GITHUB_ENV
               echo "File '$IS_LATEST_LTS_FILE' exists. Assuming latest-lts release"
           else

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -15,6 +15,14 @@ on:
       RELEASE_VERSION:
         description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         required: false
+      IS_LATEST_LTS:
+        description: 'Is latest LTS'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 jobs:
   jdks:
     uses: ./.github/workflows/get-supported-jdks.yaml
@@ -35,6 +43,7 @@ jobs:
       HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
       PROJECT_NAME: test-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.jdk }}
+      IS_LATEST_LTS: ${{ inputs.IS_LATEST_LTS || 'false' }}
 
     runs-on: ubuntu-latest
     needs: jdks
@@ -121,6 +130,17 @@ jobs:
         run: |
           docker login ${SCAN_REGISTRY} -u ${SCAN_REGISTRY_USER} -p ${SCAN_REGISTRY_PASSWORD}
 
+      - name: Check if it is latest-lts release
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          IS_LATEST_LTS_FILE=.github/latest_lts
+          if [ -f IS_LATEST_LTS_FILE ]; then
+              echo "IS_LATEST_LTS=true" >> $GITHUB_ENV
+              echo "File '$IS_LATEST_LTS_FILE' exists. Assuming latest-lts release"
+          else
+              echo "File '$IS_LATEST_LTS_FILE' does not exist. Assuming NON-latest-lts release"
+          fi
+
       - name: Build the Hazelcast Enterprise image
         run: |
           . .github/scripts/get-tags-to-push.sh 
@@ -131,7 +151,7 @@ jobs:
           IMAGE_NAME=${SCAN_REPOSITORY}
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
 
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}


### PR DESCRIPTION
Adds support for latest-lts tags.

Whenever a `.github/latest_lts` file exists the build will push `latest-lts` tags and its variants (e.g. `latest-lts-jdk21`, `latest-lts-slim`, `latest-lts-slim-jdk21`, etc)

For manual runs you need to use `IS_LATEST_LTS` input instead.