### PR TITLE
Revert "Bump aquasecurity/trivy-action from 0.24.0 to 0.25.0"

### DIFF
--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Scan ${{ matrix.image.label }} image by Trivy
         if: always()
-        uses: aquasecurity/trivy-action@0.25.0
+        uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: ${{ env.IMAGE_TAG }} 
           trivy-config: .github/containerscan/trivy.yaml


### PR DESCRIPTION
Reverts hazelcast/hazelcast-docker#803

[Post this change, the vulnerability scan fails](https://github.com/hazelcast/hazelcast-docker/actions/runs/11233359447).