### PR TITLE
Add support for LTS versions [DI-258]

### DIFF
--- a/.github/actions/check-if-latest-lts-release/action.yml
+++ b/.github/actions/check-if-latest-lts-release/action.yml
@@ -4,6 +4,9 @@ inputs:
   release_version:
     description: Version to be released
     required: true
+  is_lts_override:
+    description: Override is LTS release or not
+    required: true
 outputs:
   is_latest_lts:
     value: ${{ steps.is_latest_lts.outputs.is_latest_lts }}
@@ -17,10 +20,12 @@ runs:
         echo "IS_LTS_FILE=.github/lts" >> $GITHUB_ENV
 
     - name: Check if EE LTS release
-      if: github.event_name != 'workflow_dispatch'
       shell: bash
       run: |
-        if [ -f $IS_LTS_FILE ]; then
+        if [ -n "${{inputs.is_lts_override}}" ]; then
+            echo "IS_LTS overridden to '${{inputs.is_lts_override}}'"
+            echo "IS_LTS=${{inputs.is_lts_override}}" >> $GITHUB_ENV
+        elif [ -f $IS_LTS_FILE ]; then
             echo "IS_LTS=true" >> $GITHUB_ENV
             echo "File '$IS_LTS_FILE' exists. Assuming LTS release"
         else
@@ -38,5 +43,5 @@ runs:
         if version_less_or_equal "$CURRENT_LATEST_LTS_VERSION" "$RELEASE_VERSION"; then
            echo "is_latest_lts=true" >> $GITHUB_OUTPUT
         else 
-           cho "is_latest_lts=false" >> $GITHUB_OUTPUT
+           echo "is_latest_lts=false" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/check-if-latest-lts-release/action.yml
+++ b/.github/actions/check-if-latest-lts-release/action.yml
@@ -1,0 +1,42 @@
+name: Check if latest EE LTS release
+description: Check if latest EE LTS release
+inputs:
+  release_version:
+    description: Version to be released
+    required: true
+outputs:
+  is_latest_lts:
+    value: ${{ steps.is_latest_lts.outputs.is_latest_lts }}
+    description: Returns 'true' if the release if the latest LTS
+runs:
+  using: "composite"
+  steps:
+    - name: Set Environment Variables
+      shell: bash
+      run: |
+        echo "IS_LTS_FILE=.github/lts" >> $GITHUB_ENV
+
+    - name: Check if EE LTS release
+      if: github.event_name != 'workflow_dispatch'
+      shell: bash
+      run: |
+        if [ -f $IS_LTS_FILE ]; then
+            echo "IS_LTS=true" >> $GITHUB_ENV
+            echo "File '$IS_LTS_FILE' exists. Assuming LTS release"
+        else
+            echo "File '$IS_LTS_FILE' does not exist. Assuming non-LTS release"
+        fi
+
+    - name: Check if latest EE LTS release
+      if: env.IS_LTS == 'true'
+      id: is_latest_lts
+      shell: bash
+      run: |
+        . .github/scripts/version.functions.sh
+        CURRENT_LATEST_LTS_VERSION=$(get_last_version_with_file "$IS_LTS_FILE")
+        RELEASE_VERSION="${{ inputs.release_version }}"
+        if version_less_or_equal "$CURRENT_LATEST_LTS_VERSION" "$RELEASE_VERSION"; then
+           echo "is_latest_lts=true" >> $GITHUB_OUTPUT
+        else 
+           cho "is_latest_lts=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/scripts/get-tags-to-push.sh
+++ b/.github/scripts/get-tags-to-push.sh
@@ -9,7 +9,7 @@ function get_latest_version() {
   find_last_matching_version ""
 }
 
-function verlte() {
+function version_less_or_equal() {
   [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
 }
 
@@ -36,15 +36,15 @@ function get_version_only_tags_to_push() {
 
   local TAGS_TO_PUSH+=($VERSION_TO_RELEASE)
 
-  if verlte "$LATEST_FOR_MINOR" "$VERSION_TO_RELEASE"; then
+  if version_less_or_equal "$LATEST_FOR_MINOR" "$VERSION_TO_RELEASE"; then
     TAGS_TO_PUSH+=($MINOR_VERSION_TO_RELEASE)
   fi
 
-  if verlte "$LATEST_FOR_MAJOR" "$VERSION_TO_RELEASE"; then
+  if version_less_or_equal "$LATEST_FOR_MAJOR" "$VERSION_TO_RELEASE"; then
     TAGS_TO_PUSH+=($MAJOR_VERSION_TO_RELEASE)
   fi
 
-  if verlte "$LATEST" "$VERSION_TO_RELEASE"; then
+  if version_less_or_equal "$LATEST" "$VERSION_TO_RELEASE"; then
     TAGS_TO_PUSH+=("latest")
   fi
   if [ "$IS_LATEST_LTS" == "true" ] ; then

--- a/.github/scripts/get-tags-to-push.sh
+++ b/.github/scripts/get-tags-to-push.sh
@@ -15,9 +15,10 @@ function verlte() {
 
 function get_version_only_tags_to_push() {
   local VERSION_TO_RELEASE=$1
+  local IS_LATEST_LTS=$2
 
-  if [ "$#" -ne 1 ]; then
-    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} VERSION_TO_RELEASE"
+  if [ "$#" -ne 2 ]; then
+    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} VERSION_TO_RELEASE IS_LATEST_LTS"
     exit 1;
   fi
 
@@ -44,7 +45,10 @@ function get_version_only_tags_to_push() {
   fi
 
   if verlte "$LATEST" "$VERSION_TO_RELEASE"; then
-    TAGS_TO_PUSH+=(latest)
+    TAGS_TO_PUSH+=("latest")
+  fi
+  if [ "$IS_LATEST_LTS" == "true" ] ; then
+    TAGS_TO_PUSH+=("latest-lts")
   fi
 
   echo "${TAGS_TO_PUSH[@]}"
@@ -52,8 +56,8 @@ function get_version_only_tags_to_push() {
 
 function get_tags_to_push() {
 
-  if [ "$#" -ne 4 ]; then
-    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} VERSION_TO_RELEASE SUFFIX CURRENT_JDK DEFAULT_JDK"
+  if [ "$#" -ne 5 ]; then
+    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} VERSION_TO_RELEASE SUFFIX CURRENT_JDK DEFAULT_JDK IS_LATEST_LTS"
     exit 1;
   fi
 
@@ -61,7 +65,8 @@ function get_tags_to_push() {
   local SUFFIX=$2
   local CURRENT_JDK=$3
   local DEFAULT_JDK=$4
-  local VERSION_ONLY_TAGS_TO_PUSH=$(get_version_only_tags_to_push "$VERSION_TO_RELEASE")
+  local IS_LATEST_LTS=$5
+  local VERSION_ONLY_TAGS_TO_PUSH=$(get_version_only_tags_to_push "$VERSION_TO_RELEASE" "$IS_LATEST_LTS")
   augment_with_suffixed_tags "${VERSION_ONLY_TAGS_TO_PUSH[*]}" "$SUFFIX" "$CURRENT_JDK" "$DEFAULT_JDK"
 }
 

--- a/.github/scripts/get-tags-to-push_tests.sh
+++ b/.github/scripts/get-tags-to-push_tests.sh
@@ -2,28 +2,7 @@
 
 set -eu
 
-function findScriptDir() {
-  CURRENT=$PWD
-
-  DIR=$(dirname "$0")
-  cd "$DIR" || exit
-  TARGET_FILE=$(basename "$0")
-
-  # Iterate down a (possible) chain of symlinks
-  while [ -L "$TARGET_FILE" ]
-  do
-      TARGET_FILE=$(readlink "$TARGET_FILE")
-      DIR=$(dirname "$TARGET_FILE")
-      cd "$DIR" || exit
-      TARGET_FILE=$(basename "$TARGET_FILE")
-  done
-
-  SCRIPT_DIR=$(pwd -P)
-  # Restore current directory
-  cd "$CURRENT" || exit
-}
-
-findScriptDir
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
 assert_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)
@@ -35,9 +14,10 @@ TESTS_RESULT=0
 
 function assert_get_version_only_tags_to_push {
   local VERSION_TO_RELEASE=$1
-  local EXPECTED_TAGS_TO_PUSH=$2
-  local ACTUAL_TAGS_TO_PUSH=$(get_version_only_tags_to_push "$VERSION_TO_RELEASE")
-  local MSG="Tags to push for version $VERSION_TO_RELEASE should be equal to $EXPECTED_TAGS_TO_PUSH"
+  local IS_LTS=$2
+  local EXPECTED_TAGS_TO_PUSH=$3
+  local ACTUAL_TAGS_TO_PUSH=$(get_version_only_tags_to_push "$VERSION_TO_RELEASE" "$IS_LTS")
+  local MSG="Tags to push for version $VERSION_TO_RELEASE and is_lts = '$IS_LTS' should be equal to $EXPECTED_TAGS_TO_PUSH"
   assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
 }
 
@@ -57,22 +37,25 @@ function assert_get_tags_to_push {
   local SUFFIX=$2
   local CURRENT_JDK=$3
   local DEFAULT_JDK=$4
-  local EXPECTED_TAGS_TO_PUSH=$5
-  local ACTUAL_TAGS_TO_PUSH=$(get_tags_to_push "$VERSION_TO_RELEASE" "$SUFFIX" "$CURRENT_JDK" "$DEFAULT_JDK")
-  local MSG="Tags to push for (version_to_release=$VERSION_TO_RELEASE suffix=$SUFFIX current_jdk=$CURRENT_JDK default_jdk=$DEFAULT_JDK) should be equal to: $EXPECTED_TAGS_TO_PUSH "
+  local IS_LATEST_LTS=$5
+  local EXPECTED_TAGS_TO_PUSH=$6
+  local ACTUAL_TAGS_TO_PUSH=$(get_tags_to_push "$VERSION_TO_RELEASE" "$SUFFIX" "$CURRENT_JDK" "$DEFAULT_JDK" "$IS_LATEST_LTS")
+  local MSG="Tags to push for (version_to_release=$VERSION_TO_RELEASE suffix=$SUFFIX current_jdk=$CURRENT_JDK default_jdk=$DEFAULT_JDK is_latest_lts=$IS_LATEST_LTS) should be equal to: $EXPECTED_TAGS_TO_PUSH "
   assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
 }
 
 log_header "Tests for get_version_only_tags_to_push"
-assert_get_version_only_tags_to_push "5.2.0" "5.2.0"
-assert_get_version_only_tags_to_push "5.2.1" "5.2.1"
-assert_get_version_only_tags_to_push "5.1.99" "5.1.99 5.1"
-assert_get_version_only_tags_to_push "4.99.0" "4.99.0 4.99 4"
-assert_get_version_only_tags_to_push "99.0.0" "99.0.0 99.0 99 latest"
-assert_get_version_only_tags_to_push "5.3.0-BETA-1" "5.3.0-BETA-1"
-assert_get_version_only_tags_to_push "5.4.0-DEVEL-9" "5.4.0-DEVEL-9"
-assert_get_version_only_tags_to_push "5.99.0-BETA-1" "5.99.0-BETA-1"
-assert_get_version_only_tags_to_push "99.0.0-BETA-1" "99.0.0-BETA-1"
+assert_get_version_only_tags_to_push "5.2.0" "false" "5.2.0"
+assert_get_version_only_tags_to_push "5.2.1" "false" "5.2.1"
+assert_get_version_only_tags_to_push "5.1.99" "false" "5.1.99 5.1"
+assert_get_version_only_tags_to_push "4.99.0" "false" "4.99.0 4.99 4"
+assert_get_version_only_tags_to_push "99.0.0" "false" "99.0.0 99.0 99 latest"
+assert_get_version_only_tags_to_push "5.3.0-BETA-1" "false" "5.3.0-BETA-1"
+assert_get_version_only_tags_to_push "5.4.0-DEVEL-9" "false" "5.4.0-DEVEL-9"
+assert_get_version_only_tags_to_push "5.99.0-BETA-1" "false" "5.99.0-BETA-1"
+assert_get_version_only_tags_to_push "99.0.0-BETA-1" "false" "99.0.0-BETA-1"
+assert_get_version_only_tags_to_push "99.0.0" "true" "99.0.0 99.0 99 latest latest-lts"
+assert_get_version_only_tags_to_push "5.2.0" "true" "5.2.0 latest-lts"
 
 log_header "Tests for augment_with_suffixed_tags"
 assert_augment_with_suffixed_tags "1.2.3" "" "11" "11" "1.2.3 1.2.3-jdk11"
@@ -82,14 +65,17 @@ assert_augment_with_suffixed_tags "1.2.3 latest" "" "17" "11" "1.2.3-jdk17 lates
 assert_augment_with_suffixed_tags "1.2.3" "-slim" "11" "11" "1.2.3-slim 1.2.3-slim-jdk11"
 assert_augment_with_suffixed_tags "1.2.3" "-slim" "17" "11" "1.2.3-slim-jdk17"
 assert_augment_with_suffixed_tags "1.2.3 latest" "-slim" "17" "11" "1.2.3-slim-jdk17 latest-slim-jdk17"
+assert_augment_with_suffixed_tags "1.2.3 latest-lts" "-slim" "17" "11" "1.2.3-slim-jdk17 latest-lts-slim-jdk17"
 tags_array=(1.2.3 latest)
 assert_augment_with_suffixed_tags "${tags_array[*]}" "-slim" "17" "11" "1.2.3-slim-jdk17 latest-slim-jdk17"
 assert_augment_with_suffixed_tags "1.2.3 1.2" "-slim" "17" "11" "1.2.3-slim-jdk17 1.2-slim-jdk17"
 
 log_header "Tests for get_tags_to_push"
-assert_get_tags_to_push "5.2.0" "" "11" "11" "5.2.0 5.2.0-jdk11"
-assert_get_tags_to_push "99.0.0" "" "11" "11" "99.0.0 99.0.0-jdk11 99.0 99.0-jdk11 99 99-jdk11 latest latest-jdk11"
-assert_get_tags_to_push "99.0.0-BETA-1" "" "17" "11" "99.0.0-BETA-1-jdk17"
-assert_get_tags_to_push "5.4.0-DEVEL-9" "-slim" "17" "11" "5.4.0-DEVEL-9-slim-jdk17"
+assert_get_tags_to_push "5.2.0" "" "11" "11" "false" "5.2.0 5.2.0-jdk11"
+assert_get_tags_to_push "99.0.0" "" "11" "11" "false" "99.0.0 99.0.0-jdk11 99.0 99.0-jdk11 99 99-jdk11 latest latest-jdk11"
+assert_get_tags_to_push "99.0.0-BETA-1" "" "17" "11" "false" "99.0.0-BETA-1-jdk17"
+assert_get_tags_to_push "5.4.0-DEVEL-9" "-slim" "17" "false" "11" "5.4.0-DEVEL-9-slim-jdk17"
+assert_get_tags_to_push "5.2.0" "" "11" "11" "true" "5.2.0 5.2.0-jdk11 latest-lts latest-lts-jdk11"
+assert_get_tags_to_push "99.0.0" "" "11" "11" "true" "99.0.0 99.0.0-jdk11 99.0 99.0-jdk11 99 99-jdk11 latest latest-jdk11 latest-lts latest-lts-jdk11"
 
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/.github/scripts/version.functions.sh
+++ b/.github/scripts/version.functions.sh
@@ -26,6 +26,10 @@ function get_latest_patch_versions() {
     echo "${LATEST_PATCH_VERSIONS[@]}"
 }
 
+function verlte() {
+  [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
+}
+
 get_tags_descending() {
   git tag -l "v*" | sort -V -r | grep -v '-'
 }

--- a/.github/scripts/version.functions.sh
+++ b/.github/scripts/version.functions.sh
@@ -25,3 +25,32 @@ function get_latest_patch_versions() {
     done
     echo "${LATEST_PATCH_VERSIONS[@]}"
 }
+
+get_tags_descending() {
+  git tag -l "v*" | sort -V -r | grep -v '-'
+}
+
+file_exists_in_tag() {
+  local file=$1
+  local tag=$2
+  # subshell to wrap directory change
+  (
+    set -e
+    cd -- "$(git rev-parse --show-toplevel)"
+    git ls-tree -r "$tag" --name-only | grep "^$file$" | grep -q "^$file$"
+  )
+}
+
+function get_last_version_with_file() {
+  local file=$1
+  if [ "$#" -ne 1 ]; then
+    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} <file>"
+    exit 1
+  fi
+  for tag in $(get_tags_descending); do
+    if file_exists_in_tag "$file" "$tag"; then
+      echo "$tag" | cut -c2-
+      return
+    fi
+  done
+}

--- a/.github/scripts/version.functions.sh
+++ b/.github/scripts/version.functions.sh
@@ -30,11 +30,11 @@ function version_less_or_equal() {
   [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
 }
 
-get_tags_descending() {
+function get_tags_descending() {
   git tag -l "v*" | sort -V -r | grep -v '-'
 }
 
-file_exists_in_tag() {
+function file_exists_in_tag() {
   local file=$1
   local tag=$2
   if [ "$#" -ne 2 ]; then

--- a/.github/scripts/version.functions.sh
+++ b/.github/scripts/version.functions.sh
@@ -26,7 +26,7 @@ function get_latest_patch_versions() {
     echo "${LATEST_PATCH_VERSIONS[@]}"
 }
 
-function verlte() {
+function version_less_or_equal() {
   [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
 }
 

--- a/.github/scripts/version.functions.sh
+++ b/.github/scripts/version.functions.sh
@@ -37,6 +37,10 @@ get_tags_descending() {
 file_exists_in_tag() {
   local file=$1
   local tag=$2
+  if [ "$#" -ne 2 ]; then
+    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} <file> <tag>"
+    exit 1
+  fi
   # subshell to wrap directory change
   (
     set -e

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -244,7 +244,7 @@ jobs:
               --platform=${PLATFORMS} $DOCKER_DIR
           fi
 
-      - name: Check if LTS release
+      - name: Check if EE LTS release
         if: github.event_name != 'workflow_dispatch'
         run: |
           if [ -f $IS_LTS_FILE ]; then
@@ -254,7 +254,7 @@ jobs:
               echo "File '$IS_LTS_FILE' does not exist. Assuming non-LTS release"
           fi
 
-      - name: Check if latest LTS release
+      - name: Check if latest EE LTS release
         if: env.IS_LTS == 'true'
         run: |
           . .github/scripts/version.functions.sh

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -24,9 +24,18 @@ on:
           - OSS
           - EE
           - README
+      IS_LTS:
+        description: 'Is LTS release'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 env:
   test_container_name_oss: hazelcast-oss-test
   test_container_name_ee: hazelcast-ee-test
+  IS_LTS: ${{ inputs.IS_LTS || 'false' }}
 
 jobs:
   jdks:
@@ -55,6 +64,25 @@ jobs:
               echo "File '$RELEASE_TYPE_FILE' does not exist."
               exit 1
           fi
+
+      - name: Check if LTS release
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          IS_LTS_FILE=.github/lts
+          if [ -f $IS_LTS_FILE ]; then
+              echo "IS_LTS=true" >> $GITHUB_ENV
+              echo "File '$IS_LTS_FILE' exists. Assuming LTS release"
+          else
+              echo "File '$IS_LTS_FILE' does not exist. Assuming non-LTS release"
+          fi
+
+      - name: Check if latest LTS release
+        if: env.IS_LTS == 'true'
+        run: |
+          . .github/scripts/version.functions.sh
+          IS_LTS_FILE=.github/lts
+          CURRENT_LATEST_LTS_VERSION=$(get_last_version_with_file "$IS_LTS_FILE")
+          echo "IS_LATEST_LTS=true" >> $GITHUB_ENV 
 
       - name: Check which editions should be built
         id: which_editions
@@ -204,7 +232,9 @@ jobs:
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
           
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          # OSS has no LTS releases
+          IS_LATEST_LTS=false
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}
@@ -230,7 +260,7 @@ jobs:
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast-enterprise
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
           
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -252,7 +252,7 @@ jobs:
           done
           
           PLATFORMS="$(get_alpine_supported_platforms "${{ matrix.jdk }}")"
-          if [ "${{ inputs.DRY_RUN }} " == "true" ] ; then
+          if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
             echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
           else
             docker buildx build --push \
@@ -282,7 +282,7 @@ jobs:
           done
           
           PLATFORMS="$(get_ubi_supported_platforms "${{ matrix.jdk }}")"
-          if [ "${{ inputs.DRY_RUN }} " == "true" ] ; then
+          if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
             echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
           else
             docker buildx build --push \

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -32,6 +32,13 @@ on:
         options:
           - 'false'
           - 'true'
+      DRY_RUN:
+        description: 'Skip pushing the images to remote registry'
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 env:
   test_container_name_oss: hazelcast-oss-test
   test_container_name_ee: hazelcast-ee-test
@@ -243,11 +250,15 @@ jobs:
           done
           
           PLATFORMS="$(get_alpine_supported_platforms "${{ matrix.jdk }}")"
-          docker buildx build --push \
-            --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
-            ${TAGS_ARG} \
-            --platform=${PLATFORMS} $DOCKER_DIR
+          if [ "${{ inputs.DRY_RUN }} " == "true" ] ; then
+            echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
+          else
+            docker buildx build --push \
+              --build-arg JDK_VERSION=${{ matrix.jdk }} \
+              --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
+              ${TAGS_ARG} \
+              --platform=${PLATFORMS} $DOCKER_DIR
+          fi
 
       - name: Build/Push EE image
         if: needs.prepare.outputs.should_build_ee == 'yes'
@@ -269,12 +280,16 @@ jobs:
           done
           
           PLATFORMS="$(get_ubi_supported_platforms "${{ matrix.jdk }}")"
-          docker buildx build --push \
-            --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
-            --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
-            ${TAGS_ARG} \
-            --platform=${PLATFORMS} $DOCKER_DIR
+          if [ "${{ inputs.DRY_RUN }} " == "true" ] ; then
+            echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
+          else
+            docker buildx build --push \
+              --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
+              --build-arg JDK_VERSION=${{ matrix.jdk }} \
+              --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
+              ${TAGS_ARG} \
+              --platform=${PLATFORMS} $DOCKER_DIR
+          fi
 
       - name: Update Docker Hub Description
         if: needs.prepare.outputs.should_build_readme_ee == 'yes' || needs.prepare.outputs.should_build_readme_oss == 'yes'

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -104,6 +104,7 @@ jobs:
       DOCKER_ORG: hazelcast
       HZ_VERSION: ${{ inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
+      IS_LTS_FILE: .github/lts
     steps:
       - name: Set environment variables
         run: |
@@ -246,7 +247,6 @@ jobs:
       - name: Check if LTS release
         if: github.event_name != 'workflow_dispatch'
         run: |
-          IS_LTS_FILE=.github/lts
           if [ -f $IS_LTS_FILE ]; then
               echo "IS_LTS=true" >> $GITHUB_ENV
               echo "File '$IS_LTS_FILE' exists. Assuming LTS release"
@@ -258,7 +258,6 @@ jobs:
         if: env.IS_LTS == 'true'
         run: |
           . .github/scripts/version.functions.sh
-          IS_LTS_FILE=.github/lts
           CURRENT_LATEST_LTS_VERSION=$(get_last_version_with_file "$IS_LTS_FILE")
           if version_less_or_equal "$CURRENT_LATEST_LTS_VERSION" "$RELEASE_VERSION"; then
              echo "IS_LATEST_LTS=true" >> $GITHUB_ENV   

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -43,8 +43,6 @@ env:
   test_container_name_oss: hazelcast-oss-test
   test_container_name_ee: hazelcast-ee-test
   IS_LTS: ${{ inputs.IS_LTS || 'false' }}
-  # default value
-  IS_LATEST_LTS: false
 
 jobs:
   jdks:
@@ -104,7 +102,6 @@ jobs:
       DOCKER_ORG: hazelcast
       HZ_VERSION: ${{ inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
-      IS_LTS_FILE: .github/lts
     steps:
       - name: Set environment variables
         run: |
@@ -244,24 +241,11 @@ jobs:
               --platform=${PLATFORMS} $DOCKER_DIR
           fi
 
-      - name: Check if EE LTS release
-        if: github.event_name != 'workflow_dispatch'
-        run: |
-          if [ -f $IS_LTS_FILE ]; then
-              echo "IS_LTS=true" >> $GITHUB_ENV
-              echo "File '$IS_LTS_FILE' exists. Assuming LTS release"
-          else
-              echo "File '$IS_LTS_FILE' does not exist. Assuming non-LTS release"
-          fi
-
       - name: Check if latest EE LTS release
-        if: env.IS_LTS == 'true'
-        run: |
-          . .github/scripts/version.functions.sh
-          CURRENT_LATEST_LTS_VERSION=$(get_last_version_with_file "$IS_LTS_FILE")
-          if version_less_or_equal "$CURRENT_LATEST_LTS_VERSION" "$RELEASE_VERSION"; then
-             echo "IS_LATEST_LTS=true" >> $GITHUB_ENV   
-          fi
+        id: is_latest_lts
+        uses: ./.github/actions/check-if-latest-lts-release
+        with:
+          release_version: ${{ env.RELEASE_VERSION }}
 
       - name: Build/Push EE image
         if: needs.prepare.outputs.should_build_ee == 'yes'
@@ -274,6 +258,7 @@ jobs:
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast-enterprise
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
           
+          IS_LATEST_LTS="${{ steps.is_latest_lts.outputs.is_latest_lts }}"
           TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -74,25 +74,6 @@ jobs:
               exit 1
           fi
 
-      - name: Check if LTS release
-        if: github.event_name != 'workflow_dispatch'
-        run: |
-          IS_LTS_FILE=.github/lts
-          if [ -f $IS_LTS_FILE ]; then
-              echo "IS_LTS=true" >> $GITHUB_ENV
-              echo "File '$IS_LTS_FILE' exists. Assuming LTS release"
-          else
-              echo "File '$IS_LTS_FILE' does not exist. Assuming non-LTS release"
-          fi
-
-      - name: Check if latest LTS release
-        if: env.IS_LTS == 'true'
-        run: |
-          . .github/scripts/version.functions.sh
-          IS_LTS_FILE=.github/lts
-          CURRENT_LATEST_LTS_VERSION=$(get_last_version_with_file "$IS_LTS_FILE")
-          echo "IS_LATEST_LTS=true" >> $GITHUB_ENV 
-
       - name: Check which editions should be built
         id: which_editions
         run: |
@@ -260,6 +241,27 @@ jobs:
               --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
               ${TAGS_ARG} \
               --platform=${PLATFORMS} $DOCKER_DIR
+          fi
+
+      - name: Check if LTS release
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          IS_LTS_FILE=.github/lts
+          if [ -f $IS_LTS_FILE ]; then
+              echo "IS_LTS=true" >> $GITHUB_ENV
+              echo "File '$IS_LTS_FILE' exists. Assuming LTS release"
+          else
+              echo "File '$IS_LTS_FILE' does not exist. Assuming non-LTS release"
+          fi
+
+      - name: Check if latest LTS release
+        if: env.IS_LTS == 'true'
+        run: |
+          . .github/scripts/version.functions.sh
+          IS_LTS_FILE=.github/lts
+          CURRENT_LATEST_LTS_VERSION=$(get_last_version_with_file "$IS_LTS_FILE")
+          if verlte "$CURRENT_LATEST_LTS_VERSION" "$RELEASE_VERSION"; then
+             echo "IS_LATEST_LTS=true" >> $GITHUB_ENV   
           fi
 
       - name: Build/Push EE image

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -43,6 +43,8 @@ env:
   test_container_name_oss: hazelcast-oss-test
   test_container_name_ee: hazelcast-ee-test
   IS_LTS: ${{ inputs.IS_LTS || 'false' }}
+  # default value
+  IS_LATEST_LTS: false
 
 jobs:
   jdks:

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -26,8 +26,7 @@ on:
           - README
       IS_LTS:
         description: 'Is LTS release'
-        required: true
-        default: 'false'
+        required: false
         type: choice
         options:
           - 'false'
@@ -42,7 +41,6 @@ on:
 env:
   test_container_name_oss: hazelcast-oss-test
   test_container_name_ee: hazelcast-ee-test
-  IS_LTS: ${{ inputs.IS_LTS || 'false' }}
 
 jobs:
   jdks:
@@ -246,6 +244,7 @@ jobs:
         uses: ./.github/actions/check-if-latest-lts-release
         with:
           release_version: ${{ env.RELEASE_VERSION }}
+          is_lts_override: ${{ inputs.IS_LTS }}
 
       - name: Build/Push EE image
         if: needs.prepare.outputs.should_build_ee == 'yes'

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -260,7 +260,7 @@ jobs:
           . .github/scripts/version.functions.sh
           IS_LTS_FILE=.github/lts
           CURRENT_LATEST_LTS_VERSION=$(get_last_version_with_file "$IS_LTS_FILE")
-          if verlte "$CURRENT_LATEST_LTS_VERSION" "$RELEASE_VERSION"; then
+          if version_less_or_equal "$CURRENT_LATEST_LTS_VERSION" "$RELEASE_VERSION"; then
              echo "IS_LATEST_LTS=true" >> $GITHUB_ENV   
           fi
 

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -24,11 +24,13 @@ on:
           - OSS
           - EE
           - README
-      IS_LTS:
-        description: 'Is LTS release'
+      IS_LTS_OVERRIDE:
+        description: 'Override is LTS release'
         required: false
         type: choice
+        default: ''
         options:
+          - ''
           - 'false'
           - 'true'
       DRY_RUN:
@@ -244,7 +246,7 @@ jobs:
         uses: ./.github/actions/check-if-latest-lts-release
         with:
           release_version: ${{ env.RELEASE_VERSION }}
-          is_lts_override: ${{ inputs.IS_LTS }}
+          is_lts_override: ${{ inputs.IS_LTS_OVERRIDE }}
 
       - name: Build/Push EE image
         if: needs.prepare.outputs.should_build_ee == 'yes'

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -46,6 +46,7 @@ jobs:
       IS_LTS: ${{ inputs.IS_LTS || 'false' }}
       # default value
       IS_LATEST_LTS: false
+      IS_LTS_FILE: .github/lts
 
     runs-on: ubuntu-latest
     needs: jdks
@@ -135,7 +136,6 @@ jobs:
       - name: Check if LTS release
         if: github.event_name != 'workflow_dispatch'
         run: |
-          IS_LTS_FILE=.github/lts
           if [ -f $IS_LTS_FILE ]; then
               echo "IS_LTS=true" >> $GITHUB_ENV
               echo "File '$IS_LTS_FILE' exists. Assuming LTS release"
@@ -147,7 +147,6 @@ jobs:
         if: env.IS_LTS == 'true'
         run: |
           . .github/scripts/version.functions.sh
-          IS_LTS_FILE=.github/lts
           CURRENT_LATEST_LTS_VERSION=$(get_last_version_with_file "$IS_LTS_FILE")
           if version_less_or_equal "$CURRENT_LATEST_LTS_VERSION" "$RELEASE_VERSION"; then
              echo "IS_LATEST_LTS=true" >> $GITHUB_ENV   

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -43,7 +43,6 @@ jobs:
       HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
       PROJECT_NAME: test-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.jdk }}
-      IS_LTS: ${{ inputs.IS_LTS || 'false' }}
 
     runs-on: ubuntu-latest
     needs: jdks
@@ -135,6 +134,7 @@ jobs:
         uses: ./.github/actions/check-if-latest-lts-release
         with:
           release_version: ${{ env.RELEASE_VERSION }}
+          is_lts_override: ${{ inputs.IS_LTS }}
 
       - name: Build the Hazelcast Enterprise image
         run: |

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -44,9 +44,6 @@ jobs:
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
       PROJECT_NAME: test-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.jdk }}
       IS_LTS: ${{ inputs.IS_LTS || 'false' }}
-      # default value
-      IS_LATEST_LTS: false
-      IS_LTS_FILE: .github/lts
 
     runs-on: ubuntu-latest
     needs: jdks
@@ -133,24 +130,11 @@ jobs:
         run: |
           docker login ${SCAN_REGISTRY} -u ${SCAN_REGISTRY_USER} -p ${SCAN_REGISTRY_PASSWORD}
 
-      - name: Check if EE LTS release
-        if: github.event_name != 'workflow_dispatch'
-        run: |
-          if [ -f $IS_LTS_FILE ]; then
-              echo "IS_LTS=true" >> $GITHUB_ENV
-              echo "File '$IS_LTS_FILE' exists. Assuming LTS release"
-          else
-              echo "File '$IS_LTS_FILE' does not exist. Assuming non-LTS release"
-          fi
-
       - name: Check if latest EE LTS release
-        if: env.IS_LTS == 'true'
-        run: |
-          . .github/scripts/version.functions.sh
-          CURRENT_LATEST_LTS_VERSION=$(get_last_version_with_file "$IS_LTS_FILE")
-          if version_less_or_equal "$CURRENT_LATEST_LTS_VERSION" "$RELEASE_VERSION"; then
-             echo "IS_LATEST_LTS=true" >> $GITHUB_ENV   
-          fi
+        id: is_latest_lts
+        uses: ./.github/actions/check-if-latest-lts-release
+        with:
+          release_version: ${{ env.RELEASE_VERSION }}
 
       - name: Build the Hazelcast Enterprise image
         run: |
@@ -162,6 +146,7 @@ jobs:
           IMAGE_NAME=${SCAN_REPOSITORY}
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
 
+          IS_LATEST_LTS="${{ steps.is_latest_lts.outputs.is_latest_lts }}"
           TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -149,7 +149,9 @@ jobs:
           . .github/scripts/version.functions.sh
           IS_LTS_FILE=.github/lts
           CURRENT_LATEST_LTS_VERSION=$(get_last_version_with_file "$IS_LTS_FILE")
-          echo "IS_LATEST_LTS=true" >> $GITHUB_ENV 
+          if verlte "$CURRENT_LATEST_LTS_VERSION" "$RELEASE_VERSION"; then
+             echo "IS_LATEST_LTS=true" >> $GITHUB_ENV   
+          fi
 
       - name: Build the Hazelcast Enterprise image
         run: |

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -15,6 +15,14 @@ on:
       RELEASE_VERSION:
         description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         required: false
+      IS_LTS:
+        description: 'Is LTS release'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 jobs:
   jdks:
     uses: ./.github/workflows/get-supported-jdks.yaml
@@ -35,6 +43,7 @@ jobs:
       HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
       PROJECT_NAME: test-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.jdk }}
+      IS_LTS: ${{ inputs.IS_LTS || 'false' }}
 
     runs-on: ubuntu-latest
     needs: jdks
@@ -121,6 +130,25 @@ jobs:
         run: |
           docker login ${SCAN_REGISTRY} -u ${SCAN_REGISTRY_USER} -p ${SCAN_REGISTRY_PASSWORD}
 
+      - name: Check if LTS release
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          IS_LTS_FILE=.github/lts
+          if [ -f $IS_LTS_FILE ]; then
+              echo "IS_LTS=true" >> $GITHUB_ENV
+              echo "File '$IS_LTS_FILE' exists. Assuming LTS release"
+          else
+              echo "File '$IS_LTS_FILE' does not exist. Assuming non-LTS release"
+          fi
+
+      - name: Check if latest LTS release
+        if: env.IS_LTS == 'true'
+        run: |
+          . .github/scripts/version.functions.sh
+          IS_LTS_FILE=.github/lts
+          CURRENT_LATEST_LTS_VERSION=$(get_last_version_with_file "$IS_LTS_FILE")
+          echo "IS_LATEST_LTS=true" >> $GITHUB_ENV 
+
       - name: Build the Hazelcast Enterprise image
         run: |
           . .github/scripts/get-tags-to-push.sh 
@@ -131,7 +159,7 @@ jobs:
           IMAGE_NAME=${SCAN_REPOSITORY}
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
 
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -149,7 +149,7 @@ jobs:
           . .github/scripts/version.functions.sh
           IS_LTS_FILE=.github/lts
           CURRENT_LATEST_LTS_VERSION=$(get_last_version_with_file "$IS_LTS_FILE")
-          if verlte "$CURRENT_LATEST_LTS_VERSION" "$RELEASE_VERSION"; then
+          if version_less_or_equal "$CURRENT_LATEST_LTS_VERSION" "$RELEASE_VERSION"; then
              echo "IS_LATEST_LTS=true" >> $GITHUB_ENV   
           fi
 

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -44,6 +44,8 @@ jobs:
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
       PROJECT_NAME: test-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.jdk }}
       IS_LTS: ${{ inputs.IS_LTS || 'false' }}
+      # default value
+      IS_LATEST_LTS: false
 
     runs-on: ubuntu-latest
     needs: jdks

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           docker login ${SCAN_REGISTRY} -u ${SCAN_REGISTRY_USER} -p ${SCAN_REGISTRY_PASSWORD}
 
-      - name: Check if LTS release
+      - name: Check if EE LTS release
         if: github.event_name != 'workflow_dispatch'
         run: |
           if [ -f $IS_LTS_FILE ]; then
@@ -143,7 +143,7 @@ jobs:
               echo "File '$IS_LTS_FILE' does not exist. Assuming non-LTS release"
           fi
 
-      - name: Check if latest LTS release
+      - name: Check if latest EE LTS release
         if: env.IS_LTS == 'true'
         run: |
           . .github/scripts/version.functions.sh

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -15,12 +15,13 @@ on:
       RELEASE_VERSION:
         description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         required: false
-      IS_LTS:
-        description: 'Is LTS release'
-        required: true
-        default: 'false'
+      IS_LTS_OVERRIDE:
+        description: 'Override is LTS release'
+        required: false
         type: choice
+        default: ''
         options:
+          - ''
           - 'false'
           - 'true'
 jobs:
@@ -134,7 +135,7 @@ jobs:
         uses: ./.github/actions/check-if-latest-lts-release
         with:
           release_version: ${{ env.RELEASE_VERSION }}
-          is_lts_override: ${{ inputs.IS_LTS }}
+          is_lts_override: ${{ inputs.IS_LTS_OVERRIDE }}
 
       - name: Build the Hazelcast Enterprise image
         run: |


### PR DESCRIPTION
Fixes: https://hazelcast.atlassian.net/browse/DI-258

The previous LTS approach had an issue that it wouldn't work when we automatically rebuild previous LTS releases (due to CVE fixes etc). It would result with two concurrent LTS builds (e.g. 5.5 and 6.5) both overwriting `latest-lts` tag. 

This PR changes the logic that before overwriting the tag we make sure that the current version is the newest LTS. It's done by looking for the latest released version containing `.github/lts` file. 

Whenever a `.github/lts` file exists the workflow will check if we're building a latest LTS version and if so it will add `latest-lts` tags and its variants (e.g. `latest-lts-jdk21`,`latest-lts-slim`, `latest-lts-slim-jdk21`, etc)

For manual runs you need to use `IS_LTS` input. It will overwrite checking the existence of the file.

Additionally added `DRY_RUN` flag to manual runs to be able test the `tag_image_push.yml` workflow in more safer way, instead of actual push you'll see something like:
```
DRY RUN: Build and push for platforms linux/arm64,linux/amd64,linux/s390x,linux/ppc64le and tags: 5.5.1 5.5.1-jdk21 5.5 5.5-jdk21 5 5-jdk21 latest latest-jdk21 latest-lts latest-lts-jdk21
```

Test run: https://github.com/hazelcast/hazelcast-docker/actions/runs/11361921888/job/31602670125