### PR TITLE
Remove Hazelcast 4 RHEL support

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "!*"
     tags:
-      - "v4.*"
       - "v5.*"
   workflow_dispatch:
     inputs:
@@ -33,7 +32,6 @@ jobs:
       run:
         shell: bash
     env:
-      REQUIRED_HZ_MAJOR_VERSION: 5
       SCAN_REGISTRY: "quay.io"
       TIMEOUT_IN_MINS: 60
       HZ_ENTERPRISE_LICENSE: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
@@ -44,6 +42,9 @@ jobs:
       HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
       PROJECT_NAME: test-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.jdk }}
+      SCAN_REGISTRY_USER: ${{ secrets.SCAN_REGISTRY_USER_V5 }}
+      SCAN_REGISTRY_PASSWORD: ${{ secrets.SCAN_REGISTRY_PASSWORD_V5 }}
+      RHEL_PROJECT_ID: ${{ secrets.RHEL_PROJECT_ID_V5 }}
 
     runs-on: ubuntu-latest
     needs: jdks
@@ -69,21 +70,6 @@ jobs:
              RELEASE_VERSION=${{ env.RELEASE_VERSION }}
           fi
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
-
-      - name: Check HZ major version
-        run: |
-          HZ_MAJOR_VERSION=$(echo "${HZ_VERSION:0:1}")
-          if [[ "$HZ_MAJOR_VERSION" != "$REQUIRED_HZ_MAJOR_VERSION" ]]; then
-            echo "Major version must be ${REQUIRED_HZ_MAJOR_VERSION} but detected: ${HZ_MAJOR_VERSION}"
-            exit 1
-          fi
-          echo "HZ_MAJOR_VERSION=${HZ_MAJOR_VERSION}" >> $GITHUB_ENV
-
-      - name: Set scan registry secrets
-        run: |
-          echo "SCAN_REGISTRY_USER=${{ secrets[format('SCAN_REGISTRY_USER_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
-          echo "SCAN_REGISTRY_PASSWORD=${{ secrets[format('SCAN_REGISTRY_PASSWORD_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
-          echo "RHEL_PROJECT_ID=${{ secrets[format('RHEL_PROJECT_ID_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
 
       - name: Checkout to Management Center Openshift
         uses: actions/checkout@v4

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -78,10 +78,15 @@ jobs:
           path: management-center-openshift
           fetch-depth: 0
 
+      - uses: madhead/semver-utils@latest
+        id: version
+        with:
+          version: ${{ inputs.HZ_VERSION }}
+
       - name: Set Management Center Version to be used in the tests
         working-directory: management-center-openshift
         run: |
-          FILTERED_TAGS=$(git tag --list "v${HZ_MAJOR_VERSION}*" |  grep -E -v '.*(BETA|-).*' )
+          FILTERED_TAGS=$(git tag --list "v${{ steps.version.outputs.major }}*" |  grep -E -v '.*(BETA|-).*' )
           LATEST_TAG=$(echo -en "${FILTERED_TAGS}" | sort | tail -n 1)
           echo $LATEST_TAG
           echo "HZ_MC_VERSION=${LATEST_TAG:1}" >> $GITHUB_ENV


### PR DESCRIPTION
Hazelcast `4.x` support in the workflow requires dynamically choosing credentials - but `4.x` is no longer supported, and this functionality complicates the workflow and can be removed.

Post-merge actions:
- [ ] delete corresponding GitHub secrets