### PR TITLE
Get OCP credentials from AWS during RHEL release [DI-78]

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -36,11 +36,6 @@ jobs:
       REQUIRED_HZ_MAJOR_VERSION: 5
       SCAN_REGISTRY: "quay.io"
       TIMEOUT_IN_MINS: 60
-      HZ_ENTERPRISE_LICENSE: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
-      OCP_LOGIN_USERNAME: ${{ secrets.OCP_LOGIN_USERNAME }}
-      OCP_LOGIN_PASSWORD: ${{ secrets.OCP_LOGIN_PASSWORD }}
-      OCP_CLUSTER_URL: ${{ secrets.OCP_CLUSTER_URL }}
-      RHEL_API_KEY: ${{ secrets.RHEL_API_KEY }}
       HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
       PROJECT_NAME: test-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.jdk }}
@@ -78,12 +73,6 @@ jobs:
             exit 1
           fi
           echo "HZ_MAJOR_VERSION=${HZ_MAJOR_VERSION}" >> $GITHUB_ENV
-
-      - name: Set scan registry secrets
-        run: |
-          echo "SCAN_REGISTRY_USER=${{ secrets[format('SCAN_REGISTRY_USER_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
-          echo "SCAN_REGISTRY_PASSWORD=${{ secrets[format('SCAN_REGISTRY_PASSWORD_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
-          echo "RHEL_PROJECT_ID=${{ secrets[format('RHEL_PROJECT_ID_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
 
       - name: Checkout to Management Center Openshift
         uses: actions/checkout@v4
@@ -125,6 +114,18 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: 'us-east-1'
+
+      - name: Get Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            OCP_LOGIN_USERNAME,CN/OCP_USERNAME
+            OCP_LOGIN_PASSWORD,CN/OCP_PASSWORD
+            OCP_CLUSTER_URL,CN/OCP_CLUSTER_URL
+            RHEL_API_KEY,CN/PREFLIGHT_RHEL_API_KEY
+            SCAN_REGISTRY_USER,SCAN_REGISTRY_USER_V${{ env.REQUIRED_HZ_MAJOR_VERSION }}
+            SCAN_REGISTRY_PASSWORD,SCAN_REGISTRY_PASSWORD_V${{ env.REQUIRED_HZ_MAJOR_VERSION }}
+            RHEL_PROJECT_ID,RHEL_PROJECT_ID_V${{ env.REQUIRED_HZ_MAJOR_VERSION }}
 
       - name: Log in to Red Hat Scan Registry
         run: |
@@ -204,6 +205,7 @@ jobs:
 
         env:
           CLUSTER_SIZE: 3
+          HZ_ENTERPRISE_LICENSE: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
 
       - name: Validate Cluster Size
         run: |

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -36,6 +36,7 @@ jobs:
       REQUIRED_HZ_MAJOR_VERSION: 5
       SCAN_REGISTRY: "quay.io"
       TIMEOUT_IN_MINS: 60
+      RHEL_API_KEY: ${{ secrets.RHEL_API_KEY }}
       HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
       PROJECT_NAME: test-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.jdk }}
@@ -128,7 +129,6 @@ jobs:
             OCP_LOGIN_USERNAME,CN/OCP_USERNAME
             OCP_LOGIN_PASSWORD,CN/OCP_PASSWORD
             OCP_CLUSTER_URL,CN/OCP_CLUSTER_URL
-            RHEL_API_KEY,CN/PREFLIGHT_RHEL_API_KEY
 
       - name: Log in to Red Hat Scan Registry
         run: |

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -74,6 +74,12 @@ jobs:
           fi
           echo "HZ_MAJOR_VERSION=${HZ_MAJOR_VERSION}" >> $GITHUB_ENV
 
+      - name: Set scan registry secrets
+        run: |
+          echo "SCAN_REGISTRY_USER=${{ secrets[format('SCAN_REGISTRY_USER_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
+          echo "SCAN_REGISTRY_PASSWORD=${{ secrets[format('SCAN_REGISTRY_PASSWORD_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
+          echo "RHEL_PROJECT_ID=${{ secrets[format('RHEL_PROJECT_ID_V{0}', env.REQUIRED_HZ_MAJOR_VERSION)] }}" >> $GITHUB_ENV
+
       - name: Checkout to Management Center Openshift
         uses: actions/checkout@v4
         with:
@@ -123,9 +129,6 @@ jobs:
             OCP_LOGIN_PASSWORD,CN/OCP_PASSWORD
             OCP_CLUSTER_URL,CN/OCP_CLUSTER_URL
             RHEL_API_KEY,CN/PREFLIGHT_RHEL_API_KEY
-            SCAN_REGISTRY_USER,SCAN_REGISTRY_USER_V${{ env.REQUIRED_HZ_MAJOR_VERSION }}
-            SCAN_REGISTRY_PASSWORD,SCAN_REGISTRY_PASSWORD_V${{ env.REQUIRED_HZ_MAJOR_VERSION }}
-            RHEL_PROJECT_ID,RHEL_PROJECT_ID_V${{ env.REQUIRED_HZ_MAJOR_VERSION }}
 
       - name: Log in to Red Hat Scan Registry
         run: |


### PR DESCRIPTION
Currently, credentials are duplicated between:
- AWS Secrets Manager
- GitHub Secrets

In the past this has lead to build failures when credentials were updated in only one place.

This PR updates any credentials which are duplicated, migrating them to use the value directly from AWS Secrets Manager. The methodology on this logic is described [here](https://hazelcast.atlassian.net/browse/DI-78?focusedCommentId=104219).

I'm confident [from my testing](https://hazelcast.atlassian.net/browse/DI-78?focusedCommentId=104219) the values will resolve correctly, but as the job is triggered on `tag`, I am unable to test in a non-destructive way.

I've also rescoped `secrets.HZ_ENTERPRISE_LICENSE` to reduce the cognitive complexity of looking through the actions' environment secrets.

Fixes: [DI-78](https://hazelcast.atlassian.net/browse/DI-78)

Post-merge actions:
- [ ] backport
- [ ] delete secrets from repo

[DI-78]: https://hazelcast.atlassian.net/browse/DI-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ