### PR TITLE
Run `tag_image_push` workflows during PR builder [DI-315]

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -120,6 +120,73 @@ jobs:
   jdks:
     uses: ./.github/workflows/get-supported-jdks.yaml
 
+  build-pr-custom-jdk:
+    runs-on: ubuntu-latest
+    needs: [ jdks, prepare ]
+    name: Build with jdk-${{ matrix.jdk }}
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: ${{ fromJSON(needs.jdks.outputs.jdks) }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build OSS image
+        run: |
+          DOCKER_PATH=hazelcast-oss
+          HZ_VERSION="${{ needs.prepare.outputs.HZ_VERSION_OSS }}"
+          
+          # duplicated block as GH doesn't support passing sensitive data between jobs
+          . .github/scripts/oss-build.functions.sh
+          export HZ_SNAPSHOT_INTERNAL_PASSWORD=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
+          export HZ_SNAPSHOT_INTERNAL_USERNAME=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
+          HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "" "${HZ_VERSION}")
+          
+          curl --fail --silent --show-error --location "$HAZELCAST_OSS_ZIP_URL" --output $DOCKER_PATH/hazelcast-distribution.zip;
+          docker buildx build --load \
+          --build-arg JDK_VERSION=${{ matrix.jdk }} \
+          --build-arg HZ_VERSION=${HZ_VERSION} \
+          --tag hazelcast-oss:test \
+          ${DOCKER_PATH}
+      - name: Run smoke test against OSS image
+        timeout-minutes: 2
+        run: |
+          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+
+      - name: Build Test EE image
+        run: |
+          DOCKER_PATH=hazelcast-enterprise
+          HZ_VERSION="${{ needs.prepare.outputs.HZ_VERSION_EE }}"
+          curl --fail --silent --show-error --location "${{ needs.prepare.outputs.HAZELCAST_EE_ZIP_URL }}" --output $DOCKER_PATH/hazelcast-enterprise-distribution.zip;
+          docker buildx build --load \
+          --build-arg JDK_VERSION=${{ matrix.jdk }} \
+          --build-arg HZ_VERSION=${HZ_VERSION} \
+          --tag hazelcast-ee:test \
+          ${DOCKER_PATH}
+      - name: Run smoke test against EE image
+        timeout-minutes: 2
+        run: |
+          export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
+          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee ${{ needs.prepare.outputs.HZ_VERSION_EE }}
+      - name: Get docker logs
+        if: ${{ always() }}
+        run: |
+          docker logs ${{ env.test_container_name_oss }} > ${{ env.docker_log_file_oss }}
+          docker logs ${{ env.test_container_name_ee }} > ${{ env.docker_log_file_ee }}
+      - name: Store docker logs as artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-logs-jdk${{ matrix.jdk }}
+          path: |
+            ${{ env.docker_log_file_oss }}
+            ${{ env.docker_log_file_ee }}
   test-push:
     runs-on: ubuntu-latest
     name: Test pushing image (dry run)

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -43,7 +43,7 @@ jobs:
           echo "HZ_VERSION_OSS=$HZ_VERSION_OSS" >> $GITHUB_OUTPUT
 
           source hazelcast-oss/maven.functions.sh
-          LAST_RELEASED_HZ_VERSION_OSS="$(get_latest_url_without_extension com.hazelcast hazelcast-distribution https://repo1.maven.org/maven2)".zip;
+          LAST_RELEASED_HZ_VERSION_OSS="$(get_latest_version com.hazelcast hazelcast-distribution https://repo1.maven.org/maven2)".zip;
           echo "LAST_RELEASED_HZ_VERSION_OSS=$LAST_RELEASED_HZ_VERSION_OSS" >> $GITHUB_OUTPUT
 
       - name: Setup EE variables

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -43,7 +43,7 @@ jobs:
           echo "HZ_VERSION_OSS=$HZ_VERSION_OSS" >> $GITHUB_OUTPUT
 
           source hazelcast-oss/maven.functions.sh
-          LAST_RELEASED_HZ_VERSION_OSS="$(get_latest_version com.hazelcast hazelcast-distribution https://repo1.maven.org/maven2)".zip;
+          LAST_RELEASED_HZ_VERSION_OSS="$(get_latest_version com.hazelcast hazelcast-distribution https://repo1.maven.org/maven2)";
           echo "LAST_RELEASED_HZ_VERSION_OSS=$LAST_RELEASED_HZ_VERSION_OSS" >> $GITHUB_OUTPUT
 
       - name: Setup EE variables

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -208,7 +208,11 @@ jobs:
       RELEASE_VERSION: ${{ needs.prepare.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
       RELEASE_TYPE: ALL
       DRY_RUN: true
-    secrets: inherit
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      HZ_ENTERPRISE_LICENSE: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   test-push-rhel:
     name: Test pushing image RHEL (dry run)

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -117,7 +117,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs
+          name: docker-logs-${{ github.job }}
           path: |
             ${{ env.docker_log_file_oss }}
             ${{ env.docker_log_file_ee }}
@@ -194,7 +194,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs-jdk${{ matrix.jdk }}
+          name: docker-logs-${{ github.job }}-jdk${{ matrix.jdk }}
           path: |
             ${{ env.docker_log_file_oss }}
             ${{ env.docker_log_file_ee }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -154,6 +154,7 @@ jobs:
           --build-arg HZ_VERSION=${HZ_VERSION} \
           --tag hazelcast-oss:test \
           ${DOCKER_PATH}
+
       - name: Run smoke test against OSS image
         timeout-minutes: 2
         run: |
@@ -169,16 +170,19 @@ jobs:
           --build-arg HZ_VERSION=${HZ_VERSION} \
           --tag hazelcast-ee:test \
           ${DOCKER_PATH}
+
       - name: Run smoke test against EE image
         timeout-minutes: 2
         run: |
           export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
           .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee ${{ needs.prepare.outputs.HZ_VERSION_EE }}
+
       - name: Get docker logs
         if: ${{ always() }}
         run: |
           docker logs ${{ env.test_container_name_oss }} > ${{ env.docker_log_file_oss }}
           docker logs ${{ env.test_container_name_ee }} > ${{ env.docker_log_file_ee }}
+
       - name: Store docker logs as artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -187,6 +191,7 @@ jobs:
           path: |
             ${{ env.docker_log_file_oss }}
             ${{ env.docker_log_file_ee }}
+
   test-push:
     runs-on: ubuntu-latest
     name: Test pushing image (dry run)

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       HZ_VERSION_OSS: ${{ steps.get_oss_vars.outputs.HZ_VERSION_OSS }}
       HZ_VERSION_EE: ${{ steps.get_ee_vars.outputs.HZ_VERSION_EE }}
+      LAST_RELEASED_HZ_VERSION_OSS: ${{ steps.get_oss_vars.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
       HAZELCAST_EE_ZIP_URL: ${{ steps.get_ee_vars.outputs.HAZELCAST_EE_ZIP_URL }}
     steps:
       - name: Checkout Code
@@ -40,6 +41,10 @@ jobs:
         run: |
           HZ_VERSION_OSS=$(awk -F '=' '/^ARG HZ_VERSION=/ {print $2}' hazelcast-oss/Dockerfile)
           echo "HZ_VERSION_OSS=$HZ_VERSION_OSS" >> $GITHUB_OUTPUT
+
+          source hazelcast-oss/maven.functions.sh
+          LAST_RELEASED_HZ_VERSION_OSS="$(get_latest_url_without_extension com.hazelcast hazelcast-distribution https://repo1.maven.org/maven2)".zip;
+          echo "LAST_RELEASED_HZ_VERSION_OSS=$LAST_RELEASED_HZ_VERSION_OSS" >> $GITHUB_OUTPUT
 
       - name: Setup EE variables
         id: get_ee_vars
@@ -199,8 +204,8 @@ jobs:
     needs: [ prepare ]
     uses: ./.github/workflows/tag_image_push.yml
     with:
-      HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
-      RELEASE_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+      HZ_VERSION: ${{ needs.prepare.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
+      RELEASE_VERSION: ${{ needs.prepare.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
       RELEASE_TYPE: ALL
       DRY_RUN: true
     secrets: inherit
@@ -210,7 +215,7 @@ jobs:
     needs: [ prepare ]
     uses: ./.github/workflows/tag_image_push_rhel.yml
     with:
-      HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
-      RELEASE_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+      HZ_VERSION: ${{ needs.prepare.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
+      RELEASE_VERSION: ${{ needs.prepare.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
       DRY_RUN: true
     secrets: inherit

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -213,13 +213,3 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       HZ_ENTERPRISE_LICENSE: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-  test-push-rhel:
-    name: Test pushing image RHEL (dry run)
-    needs: [ prepare ]
-    uses: ./.github/workflows/tag_image_push_rhel.yml
-    with:
-      HZ_VERSION: ${{ needs.prepare.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
-      RELEASE_VERSION: ${{ needs.prepare.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
-      DRY_RUN: true
-    secrets: inherit

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -203,6 +203,7 @@ jobs:
       RELEASE_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
       RELEASE_TYPE: ALL
       DRY_RUN: true
+    secrets: inherit
 
   test-push-rhel:
     name: Test pushing image RHEL (dry run)
@@ -212,10 +213,4 @@ jobs:
       HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
       RELEASE_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
       DRY_RUN: true
-
-  debug-vars:
-    runs-on: ubuntu-latest
-    needs: [ prepare ]
-    steps:
-      - run: |
-          echo "needs.prepare.outputs.HZ_VERSION_OSS is ${{ needs.prepare.outputs.HZ_VERSION_OSS }}"
+    secrets: inherit

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -212,3 +212,10 @@ jobs:
       HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
       RELEASE_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
       DRY_RUN: true
+
+  debug-vars:
+    runs-on: ubuntu-latest
+    needs: [ prepare ]
+    steps:
+      - run: |
+          echo "needs.prepare.outputs.HZ_VERSION_OSS is ${{ needs.prepare.outputs.HZ_VERSION_OSS }}"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -195,22 +195,20 @@ jobs:
             ${{ env.docker_log_file_ee }}
 
   test-push:
-    runs-on: ubuntu-latest
     name: Test pushing image (dry run)
     needs: [ prepare ]
-    steps:
-      - uses: actions/checkout@v4
+    uses: ./.github/workflows/tag_image_push.yml
+    with:
+      HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+      RELEASE_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+      RELEASE_TYPE: ALL
+      DRY_RUN: true
 
-      - uses: ./.github/workflows/tag_image_push.yml
-        with:
-          HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
-          RELEASE_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
-          RELEASE_TYPE: ALL
-          DRY_RUN: true
-
-      - uses: ./.github/workflows/tag_image_push_rhel.yml
-        with:
-          HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
-          RELEASE_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
-          RELEASE_TYPE: ALL
-          DRY_RUN: true
+  test-push-rhel:
+    name: Test pushing image RHEL (dry run)
+    needs: [ prepare ]
+    uses: ./.github/workflows/tag_image_push_rhel.yml
+    with:
+      HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+      RELEASE_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+      DRY_RUN: true

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -120,77 +120,23 @@ jobs:
   jdks:
     uses: ./.github/workflows/get-supported-jdks.yaml
 
-  build-pr-custom-jdk:
+  test-push:
     runs-on: ubuntu-latest
-    needs: [ jdks, prepare ]
-    name: Build with jdk-${{ matrix.jdk }}
-    strategy:
-      fail-fast: false
-      matrix:
-        jdk: ${{ fromJSON(needs.jdks.outputs.jdks) }}
+    name: Test pushing image (dry run)
+    needs: [ prepare ]
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/workflows/tag_image_push.yml
         with:
-          fetch-depth: 0
+          HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+          RELEASE_TYPE: ALL
+          DRY_RUN: true
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build OSS image
-        run: |
-          DOCKER_PATH=hazelcast-oss
-          HZ_VERSION="${{ needs.prepare.outputs.HZ_VERSION_OSS }}"
-          
-          # duplicated block as GH doesn't support passing sensitive data between jobs
-          . .github/scripts/oss-build.functions.sh
-          export HZ_SNAPSHOT_INTERNAL_PASSWORD=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
-          export HZ_SNAPSHOT_INTERNAL_USERNAME=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
-          HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "" "${HZ_VERSION}")
-          
-          curl --fail --silent --show-error --location "$HAZELCAST_OSS_ZIP_URL" --output $DOCKER_PATH/hazelcast-distribution.zip;
-
-          docker buildx build --load \
-          --build-arg JDK_VERSION=${{ matrix.jdk }} \
-          --build-arg HZ_VERSION=${HZ_VERSION} \
-          --tag hazelcast-oss:test \
-          ${DOCKER_PATH}
-
-      - name: Run smoke test against OSS image
-        timeout-minutes: 2
-        run: |
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
-
-      - name: Build Test EE image
-        run: |
-          DOCKER_PATH=hazelcast-enterprise
-          HZ_VERSION="${{ needs.prepare.outputs.HZ_VERSION_EE }}"
-          curl --fail --silent --show-error --location "${{ needs.prepare.outputs.HAZELCAST_EE_ZIP_URL }}" --output $DOCKER_PATH/hazelcast-enterprise-distribution.zip;
-
-          docker buildx build --load \
-          --build-arg JDK_VERSION=${{ matrix.jdk }} \
-          --build-arg HZ_VERSION=${HZ_VERSION} \
-          --tag hazelcast-ee:test \
-          ${DOCKER_PATH}
-
-      - name: Run smoke test against EE image
-        timeout-minutes: 2
-        run: |
-          export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee ${{ needs.prepare.outputs.HZ_VERSION_EE }}
-
-      - name: Get docker logs
-        if: ${{ always() }}
-        run: |
-          docker logs ${{ env.test_container_name_oss }} > ${{ env.docker_log_file_oss }}
-          docker logs ${{ env.test_container_name_ee }} > ${{ env.docker_log_file_ee }}
-
-      - name: Store docker logs as artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+      - uses: ./.github/workflows/tag_image_push_rhel.yml
         with:
-          name: docker-logs-jdk${{ matrix.jdk }}
-          path: |
-            ${{ env.docker_log_file_oss }}
-            ${{ env.docker_log_file_ee }}
-
+          HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+          RELEASE_TYPE: ALL
+          DRY_RUN: true

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -149,6 +149,7 @@ jobs:
           HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "" "${HZ_VERSION}")
           
           curl --fail --silent --show-error --location "$HAZELCAST_OSS_ZIP_URL" --output $DOCKER_PATH/hazelcast-distribution.zip;
+
           docker buildx build --load \
           --build-arg JDK_VERSION=${{ matrix.jdk }} \
           --build-arg HZ_VERSION=${HZ_VERSION} \
@@ -165,6 +166,7 @@ jobs:
           DOCKER_PATH=hazelcast-enterprise
           HZ_VERSION="${{ needs.prepare.outputs.HZ_VERSION_EE }}"
           curl --fail --silent --show-error --location "${{ needs.prepare.outputs.HAZELCAST_EE_ZIP_URL }}" --output $DOCKER_PATH/hazelcast-enterprise-distribution.zip;
+
           docker buildx build --load \
           --build-arg JDK_VERSION=${{ matrix.jdk }} \
           --build-arg HZ_VERSION=${HZ_VERSION} \

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     env:
-      MINIMAL_SUPPORTED_VERSION: ${{ github.event.inputs.MINIMAL_SUPPORTED_VERSION }}
+      MINIMAL_SUPPORTED_VERSION: ${{ inputs.MINIMAL_SUPPORTED_VERSION }}
       DEFAULT_MINIMAL_SUPPORTED_VERSION: 5.2
     steps:
       - name: Checkout Code

--- a/.github/workflows/ee-nlc-snapshot-push.yml
+++ b/.github/workflows/ee-nlc-snapshot-push.yml
@@ -86,7 +86,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs-jdk${{ matrix.jdk }}
+          name: docker-logs-${{ github.job }}-jdk${{ matrix.jdk }}
           path: |
             ${{ env.DOCKER_LOG_FILE_EE }}
 

--- a/.github/workflows/ee-nlc-snapshot-push.yml
+++ b/.github/workflows/ee-nlc-snapshot-push.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         jdk: ${{ fromJSON(needs.jdks.outputs.jdks) }}
     env:
-      HZ_VERSION : ${{ github.event.inputs.HZ_VERSION }}
+      HZ_VERSION : ${{ inputs.HZ_VERSION }}
       NLC_REPOSITORY: ${{ secrets.NLC_REPOSITORY }}
       NLC_REPO_USERNAME: ${{ secrets.NLC_REPO_USERNAME }}
       NLC_REPO_TOKEN: ${{ secrets.NLC_REPO_TOKEN }}
@@ -66,7 +66,7 @@ jobs:
             --build-arg HZ_VERSION=${HZ_VERSION} \
             --build-arg HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --label hazelcast.ee.revision=${{ github.event.inputs.HZ_EE_REVISION }} \
+            --label hazelcast.ee.revision=${{ inputs.HZ_EE_REVISION }} \
             --tag hazelcast-nlc:test hazelcast-enterprise
 
       - name: Run smoke test against EE image
@@ -112,7 +112,7 @@ jobs:
             --build-arg HZ_VERSION=${HZ_VERSION} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
             --build-arg HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL} \
-            --label hazelcast.ee.revision=${{ github.event.inputs.HZ_EE_REVISION }} \
+            --label hazelcast.ee.revision=${{ inputs.HZ_EE_REVISION }} \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR
       - name: Slack notification

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -100,7 +100,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs-jdk${{ matrix.jdk }}
+          name: docker-logs-${{ github.job }}-jdk${{ matrix.jdk }}
           path: |
             ${{ env.DOCKER_LOG_FILE_EE }}
 

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -32,7 +32,7 @@ jobs:
       NLC_REPO_TOKEN: ${{ secrets.NLC_REPO_TOKEN }}
       NLC_IMAGE_NAME: ${{ secrets.NLC_IMAGE_NAME }}
       S3_NLC_URL: ${{ secrets.S3_NLC_URL }}
-      HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
+      HZ_VERSION: ${{ inputs.HZ_VERSION }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs${{ env.SUFFIX }}-jdk${{ matrix.jdk }}
+          name: docker-logs${{ env.SUFFIX }}-${{ github.job }}-jdk${{ matrix.jdk }}
           path: |
             ${{ env.DOCKER_LOG_FILE_EE }}
 

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -28,7 +28,7 @@ jobs:
           - variant: ''
     env:
       DOCKER_ORG: hazelcast
-      HZ_VERSION : ${{ github.event.inputs.HZ_VERSION }}
+      HZ_VERSION : ${{ inputs.HZ_VERSION }}
     steps:
       - name: Compute Suffix
         run: |
@@ -121,7 +121,7 @@ jobs:
           docker buildx build --push \
             --build-arg HZ_VERSION=${HZ_VERSION} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --label hazelcast.ee.revision=${{ github.event.inputs.HZ_EE_REVISION }} \
+            --label hazelcast.ee.revision=${{ inputs.HZ_EE_REVISION }} \
             --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -36,7 +36,7 @@ jobs:
       HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
       HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
 
-      HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
+      HZ_VERSION: ${{ inputs.HZ_VERSION }}
     steps:
       - name: Compute Suffix
         run: |
@@ -126,7 +126,7 @@ jobs:
           PLATFORMS="$(get_alpine_supported_platforms "${{ matrix.jdk }}")"
           docker buildx build --push \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --label hazelcast.revision=${{ github.event.inputs.HZ_REVISION }} \
+            --label hazelcast.revision=${{ inputs.HZ_REVISION }} \
             $TAGS_ARG \
             --platform=${PLATFORMS} $DOCKER_DIR
       - name: Slack notification

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -96,7 +96,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs${{ env.SUFFIX }}-jdk${{ matrix.jdk }}
+          name: docker-logs${{ env.SUFFIX }}-${{ github.job }}-jdk${{ matrix.jdk }}
           path: |
             ${{ env.DOCKER_LOG_FILE_OSS }}
 

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Read release type from the file
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name == 'push'
         run: |
           RELEASE_TYPE_FILE=.github/release_type
           if [ -f $RELEASE_TYPE_FILE ]; then

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -40,6 +40,31 @@ on:
         options:
           - 'false'
           - 'true'
+  workflow_call:
+    inputs:
+      HZ_VERSION:
+        type: string
+        description: 'Version of Hazelcast to build the image for, e.g. 5.1.1, 5.0.1, 4.2.3'
+        required: true
+      RELEASE_VERSION:
+        type: string
+        description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
+        required: false
+      RELEASE_TYPE:
+        description: 'What should be built'
+        required: true
+        default: 'EE'
+        type: string
+      IS_LTS_OVERRIDE:
+        description: 'Override is LTS release'
+        required: false
+        type: string
+        default: ''
+      DRY_RUN:
+        description: 'Skip pushing the images to remote registry'
+        default: 'false'
+        type: string
+
 env:
   test_container_name_oss: hazelcast-oss-test
   test_container_name_ee: hazelcast-ee-test
@@ -231,14 +256,14 @@ jobs:
           done
           
           PLATFORMS="$(get_alpine_supported_platforms "${{ matrix.jdk }}")"
-          if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
-            echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
-          else
+          if [ "${{ inputs.DRY_RUN }}" == "false" ] ; then
             docker buildx build --push \
               --build-arg JDK_VERSION=${{ matrix.jdk }} \
               --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
               ${TAGS_ARG} \
               --platform=${PLATFORMS} $DOCKER_DIR
+          else
+            echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
           fi
 
       - name: Check if latest EE LTS release
@@ -269,19 +294,19 @@ jobs:
           done
           
           PLATFORMS="$(get_ubi_supported_platforms "${{ matrix.jdk }}")"
-          if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
-            echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
-          else
+          if [ "${{ inputs.DRY_RUN }}" == "false" ] ; then
             docker buildx build --push \
               --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
               --build-arg JDK_VERSION=${{ matrix.jdk }} \
               --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
               ${TAGS_ARG} \
               --platform=${PLATFORMS} $DOCKER_DIR
+          else
+            echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
           fi
 
       - name: Update Docker Hub Description
-        if: needs.prepare.outputs.should_build_readme_ee == 'yes' || needs.prepare.outputs.should_build_readme_oss == 'yes'
+        if: inputs.DRY_RUN == 'false' && (needs.prepare.outputs.should_build_readme_ee == 'yes' || needs.prepare.outputs.should_build_readme_oss == 'yes')
         uses: ./.github/actions/update-dockerhub-description
         with:
           docker_username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -232,7 +232,7 @@ jobs:
         if: ${{ always() && ( needs.prepare.outputs.should_build_ee == 'yes' || needs.prepare.outputs.should_build_oss == 'yes') }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs${{ env.SUFFIX }}-jdk${{ matrix.jdk }}
+          name: docker-logs${{ env.SUFFIX }}-${{ github.job }}-jdk${{ matrix.jdk }}
           path: docker-*.log
 
       - name: Build and Push OSS image

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -64,6 +64,15 @@ on:
         description: 'Skip pushing the images to remote registry'
         default: 'false'
         type: string
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      HZ_ENTERPRISE_LICENSE:
+        required: true
+      SLACK_WEBHOOK:
+        required: true
 
 env:
   test_container_name_oss: hazelcast-oss-test
@@ -175,6 +184,7 @@ jobs:
           aws-region: 'us-east-1'
 
       - name: Login to Docker Hub
+        if: inputs.DRY_RUN == 'false'
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Get OSS dist ZIP URL

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -256,14 +256,14 @@ jobs:
           done
           
           PLATFORMS="$(get_alpine_supported_platforms "${{ matrix.jdk }}")"
-          if [ "${{ inputs.DRY_RUN }}" == "false" ] ; then
+          if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
+            echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
+          else
             docker buildx build --push \
               --build-arg JDK_VERSION=${{ matrix.jdk }} \
               --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
               ${TAGS_ARG} \
               --platform=${PLATFORMS} $DOCKER_DIR
-          else
-            echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
           fi
 
       - name: Check if latest EE LTS release
@@ -294,15 +294,15 @@ jobs:
           done
           
           PLATFORMS="$(get_ubi_supported_platforms "${{ matrix.jdk }}")"
-          if [ "${{ inputs.DRY_RUN }}" == "false" ] ; then
+          if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
+            echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
+          else
             docker buildx build --push \
               --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
               --build-arg JDK_VERSION=${{ matrix.jdk }} \
               --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
               ${TAGS_ARG} \
               --platform=${PLATFORMS} $DOCKER_DIR
-          else
-            echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
           fi
 
       - name: Update Docker Hub Description

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -271,12 +271,12 @@ jobs:
           VERSION=${RELEASE_VERSION}-jdk${{ matrix.jdk }}
           source .github/scripts/publish-rhel.sh
 
-          if [ "${{ inputs.DRY_RUN }}" == "false" ] ; then
+          if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
+            echo "DRY RUN: Build and push ${VERSION} to ${RHEL_PROJECT_ID}"
+          else
             publish_the_image "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
             wait_for_container_publish "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
             sync_tags "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
-          else
-            echo "DRY RUN: Build and push ${VERSION} to ${RHEL_PROJECT_ID}"
           fi
 
       - name: Slack notification

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -235,13 +235,9 @@ jobs:
           VERSION=${RELEASE_VERSION}-jdk${{ matrix.jdk }}
           source .github/scripts/publish-rhel.sh
 
-          if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
-            echo "DRY RUN: Build and push ${VERSION} to ${RHEL_PROJECT_ID}"
-          else
-            publish_the_image "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
-            wait_for_container_publish "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
-            sync_tags "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
-          fi
+          publish_the_image "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
+          wait_for_container_publish "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
+          sync_tags "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
 
       - name: Slack notification
         uses: ./.github/actions/slack-notification

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -23,32 +23,6 @@ on:
           - ''
           - 'false'
           - 'true'
-      DRY_RUN:
-        description: 'Skip pushing the images to remote registry'
-        default: 'false'
-        type: choice
-        options:
-          - 'false'
-          - 'true'
-  workflow_call:
-    inputs:
-      HZ_VERSION:
-        type: string
-        description: 'Version of Hazelcast to build the image for, e.g. 5.1.1, 5.0.1, 4.2.3'
-        required: true
-      RELEASE_VERSION:
-        type: string
-        description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
-        required: false
-      IS_LTS_OVERRIDE:
-        description: 'Override is LTS release'
-        required: false
-        type: string
-        default: ''
-      DRY_RUN:
-        description: 'Skip pushing the images to remote registry'
-        default: 'false'
-        type: string
 
 jobs:
   jdks:

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -81,6 +81,10 @@ jobs:
     steps:
       - name: Set HZ version as environment variable
         run: |
+          # TODO Delete
+          echo "env.HZ_VERSION is ${{ env.HZ_VERSION }}"
+          echo "inputs.HZ_VERSION is ${{ github.event.inputs.HZ_VERSION }}"
+
           if [ -z "${{ env.HZ_VERSION }}" ]; then
              HZ_VERSION=${GITHUB_REF:11}
           else

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -23,7 +23,6 @@ on:
           - ''
           - 'false'
           - 'true'
-
 jobs:
   jdks:
     uses: ./.github/workflows/get-supported-jdks.yaml

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -68,8 +68,8 @@ jobs:
       OCP_LOGIN_PASSWORD: ${{ secrets.OCP_LOGIN_PASSWORD }}
       OCP_CLUSTER_URL: ${{ secrets.OCP_CLUSTER_URL }}
       RHEL_API_KEY: ${{ secrets.RHEL_API_KEY }}
-      HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
-      RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
+      HZ_VERSION: ${{ inputs.HZ_VERSION }}
+      RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
       PROJECT_NAME: test-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.jdk }}
 
     runs-on: ubuntu-latest

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -24,6 +24,33 @@ on:
           - ''
           - 'false'
           - 'true'
+      DRY_RUN:
+        description: 'Skip pushing the images to remote registry'
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+  workflow_call:
+    inputs:
+      HZ_VERSION:
+        type: string
+        description: 'Version of Hazelcast to build the image for, e.g. 5.1.1, 5.0.1, 4.2.3'
+        required: true
+      RELEASE_VERSION:
+        type: string
+        description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
+        required: false
+      IS_LTS_OVERRIDE:
+        description: 'Override is LTS release'
+        required: false
+        type: string
+        default: ''
+      DRY_RUN:
+        description: 'Skip pushing the images to remote registry'
+        default: 'false'
+        type: string
+
 jobs:
   jdks:
     uses: ./.github/workflows/get-supported-jdks.yaml
@@ -244,9 +271,13 @@ jobs:
           VERSION=${RELEASE_VERSION}-jdk${{ matrix.jdk }}
           source .github/scripts/publish-rhel.sh
 
-          publish_the_image "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
-          wait_for_container_publish "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
-          sync_tags "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
+          if [ "${{ inputs.DRY_RUN }}" == "false" ] ; then
+            publish_the_image "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
+            wait_for_container_publish "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
+            sync_tags "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
+          else
+            echo "DRY RUN: Build and push ${VERSION} to ${RHEL_PROJECT_ID}"
+          fi
 
       - name: Slack notification
         uses: ./.github/actions/slack-notification

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -81,10 +81,6 @@ jobs:
     steps:
       - name: Set HZ version as environment variable
         run: |
-          # TODO Delete
-          echo "env.HZ_VERSION is ${{ env.HZ_VERSION }}"
-          echo "inputs.HZ_VERSION is ${{ github.event.inputs.HZ_VERSION }}"
-
           if [ -z "${{ env.HZ_VERSION }}" ]; then
              HZ_VERSION=${GITHUB_REF:11}
           else


### PR DESCRIPTION
The `tag_image_push` workflows are triggered _only_ with a release, which means that any changes are not able to be tested.

Using a `DRY_RUN` mode we can execute the workflow as a non-destructive sanity check, _without_ making any publicly observable changes.

Changes:
- Add execution of `tag_image_push` workflows (in `DRY_RUN` mode) to PR builder
- Extend `tag_image_push` workflow's `DRY_RUN` parameter by also skipping Dockerhub description/readme updates
- Support calling `tag_image_push` workflows from other workflows via `workflow_call` ([requires duplication of parameters](https://github.com/orgs/community/discussions/39357))
- update how we query `inputs` (`github.event.inputs` -> `inputs`) [to support `workflow_call` executions](https://github.blog/changelog/2022-06-10-github-actions-inputs-unified-across-manual-and-reusable-workflows/)
- give log artifacts more unique names now were running more jobs at once to avoid collisions

Fixes: [DI-315](https://hazelcast.atlassian.net/browse/DI-315)

Post-merge actions:
- [ ] backport

[DI-315]: https://hazelcast.atlassian.net/browse/DI-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ