### PR TITLE
Convert manual post-release test into a reusable GitHub Action [DI-316]

### DIFF
--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -170,7 +170,8 @@ jobs:
           fi
 
           echo "Testing Docker registry"
-          simple-smoke-test hazelcast "${image_name}"
+          organization=hazelcast
+          simple-smoke-test "${organization}" "${image_name}"
 
           # Check additional EE repos
           # Only populated for default variant, not "slim"

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -188,6 +188,6 @@ jobs:
           fi
 
       - name: Get docker logs
-        if: ${{ failure() }}
+        if: always()
         run: |
           docker logs "${CONTAINER_NAME}"

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -11,7 +11,12 @@ on:
         required: true
       DISTRIBUTION_TYPE:
         required: true
-        description: The distribution(s) to test - `oss`, `ee` or `all` (case-sensitive)
+        description: The distribution(s) to test (case-sensitive)
+        type: choice
+        options:
+          - oss
+          - ee
+          - all
       EXPECTED_DEFAULT_JAVA_VERSION:
         required: true
         description: The expected Java major version (e.g. `21`, `8`) used by default in the image

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -1,0 +1,172 @@
+name: Test published images
+
+on:
+  workflow_dispatch:
+    inputs:
+      IMAGE_VERSION:
+        required: true
+        description: A version, `5.4.1`, `latest` etc
+      EXPECTED_HZ_VERSION:
+        description: A fully-qualified version, e.g. `5.4.1`
+        required: true
+      DISTRIBUTION_TYPE:
+        required: true
+        description: The type of distribution - `oss` or `ee` - supplied as a comma-separated list (e.g. `oss`, `ee`)
+      DEFAULT_JAVA_VERSION:
+        required: true
+        description: The expected Java major version (e.g. `21`, `8`) used by default in the image
+      OTHER_JDKS:
+        required: true
+        description: The other Java variant images to test (e.g. `5-jdk21`) - supplied as a comma-separated list of major Java versions (e.g. `8, 11, 17`)
+
+env:
+  CONTAINER_NAME: my-container
+
+jobs:
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      distribution-type-matrix: ${{ steps.set-matrix.outputs.distribution-type-matrix }}
+      jdk-image-variants-matrix: ${{ steps.set-matrix.outputs.jdk-image-variants-matrix }}
+    steps:
+      - name: Parse input into matrix
+        id: set-matrix
+        run: |
+          # https://unix.stackexchange.com/a/719752 + trim
+          matrix=$(echo '"${{ inputs.DISTRIBUTION_TYPE }}"' | jq --compact-output 'split(",") | map(gsub("^\\s+|\\s+$"; ""))' )
+          echo "distribution-type-matrix=$matrix" >> $GITHUB_OUTPUT
+
+          # Add an "empty" option for base image
+          matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output 'split(",") + [""] | map(gsub("^\\s+|\\s+$"; ""))' )
+          echo "jdk-image-variants-matrix=$matrix" >> $GITHUB_OUTPUT
+
+  test:
+    runs-on: ubuntu-latest
+    needs: set-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: 
+          - ''
+          - 'slim'
+        distribution_type: ${{ fromJson(needs.set-matrix.outputs.distribution-type-matrix) }}
+        jdk-image-variant: ${{ fromJson(needs.set-matrix.outputs.jdk-image-variants-matrix) }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - uses: madhead/semver-utils@latest
+        id: version
+        with:
+          version: ${{ inputs.IMAGE_VERSION }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_DEV_INFRA_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEV_INFRA_SECRET_ACCESS_KEY }}
+          aws-region: 'us-east-1'
+
+      - name: Get Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            REDHAT_CATALOG_REGISTRY_CONNECT_ROBOT,REDHAT/REDHAT_CATALOG_REGISTRY_CONNECT_ROBOT
+          parse-json-secrets: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to NLC Repository
+        if: matrix.distribution_type == 'ee'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.NLC_REPOSITORY }}
+          username: ${{ secrets.NLC_REPO_USERNAME }}
+          password: ${{ secrets.NLC_REPO_TOKEN }}
+
+      - name: Login to OCP
+        if: matrix.distribution_type == 'ee'
+        uses: docker/login-action@v3
+        with:
+          registry: registry.connect.redhat.com
+          username: ${{ env.REDHAT_CATALOG_REGISTRY_CONNECT_ROBOT_USERNAME }}
+          password: ${{ env.REDHAT_CATALOG_REGISTRY_CONNECT_ROBOT_PASSWORD }}
+
+      - name: Run smoke test against image
+        timeout-minutes: 10
+        run: |
+          set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
+
+          # shellcheck source=../.github/scripts/abstract-simple-smoke-test.sh
+          . .github/scripts/abstract-simple-smoke-test.sh
+
+          function simple-smoke-test() {
+            local organization=$1
+            local image_name=$2
+
+            local expected_jdk_version
+            if [ -n "${{ matrix.jdk-image-variant }}" ]; then
+              expected_jdk_version=${{ matrix.jdk-image-variant }}
+            else
+              expected_jdk_version=${{ inputs.DEFAULT_JAVA_VERSION }}
+            fi
+
+            # Compute tag by concatenating tag_elements
+            .github/scripts/simple-smoke-test.sh "${organization}/${image_name}":$(IFS=- ; echo "${tag_elements[*]}") "${CONTAINER_NAME}" "${{ matrix.distribution_type }}" "${{ inputs.EXPECTED_HZ_VERSION }}" "${expected_jdk_version}"
+          }
+
+          case "${{ matrix.distribution_type }}" in
+            "oss")
+              image_name="hazelcast"
+              ;;
+            "ee")
+              image_name="hazelcast-enterprise"
+              ;;
+            *)
+              echoerr "Unrecognized distribution type ${{ matrix.distribution_type }}"
+              exit 1
+              ;;
+          esac
+
+          if [[ "${{ matrix.distribution_type }}" == "ee" ]]; then
+            export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
+            export HZ_INSTANCETRACKING_FILENAME=instance-tracking.txt
+          fi
+
+          # To allow computing the required tag, store the elements in an array
+          tag_elements=("${{ inputs.IMAGE_VERSION }}")
+
+          if [[ -n "${{ matrix.variant }}" ]]; then
+            tag_elements+=("${{ matrix.variant }}")
+          fi
+
+          if [[ -n "${{ matrix.jdk-image-variant }}" ]]; then
+            tag_elements+=("jdk${{ matrix.jdk-image-variant }}")
+          fi
+
+          echo "Testing Docker registry"
+          simple-smoke-test hazelcast "${image_name}"
+
+          # Check additional EE repos
+          # Only populated for default variant, not "slim"
+          if [[ "${{ matrix.distribution_type }}" == "ee" && -z "${{ matrix.variant }}" ]]; then
+            # NLC repo only populated for absolute versions - not "latest", "latest-lts" etc tags
+            # Identify absolute version based on earlier parsing of version number
+            if [[ -n "${{ steps.version.outputs.major }}" ]]; then
+              echo "Testing NLC"
+              simple-smoke-test "${{ secrets.NLC_REPOSITORY }}/hazelcast_cloud" "hazelcast-nlc"
+            fi
+
+            echo "Testing OCP"
+            simple-smoke-test "registry.connect.redhat.com/hazelcast" "${image_name}-${{ steps.version.outputs.major }}-rhel8"
+          fi
+
+      - name: Get docker logs
+        if: ${{ failure() }}
+        run: |
+          docker logs "${CONTAINER_NAME}"

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -12,7 +12,7 @@ on:
       DISTRIBUTION_TYPE:
         required: true
         description: The distribution(s) to test - `oss`, `ee` or `all` (case-sensitive)
-      DEFAULT_JAVA_VERSION:
+      EXPECTED_DEFAULT_JAVA_VERSION:
         required: true
         description: The expected Java major version (e.g. `21`, `8`) used by default in the image
       OTHER_JDKS:
@@ -127,7 +127,7 @@ jobs:
             if [ -n "${{ matrix.jdk-image-variant }}" ]; then
               expected_jdk_version=${{ matrix.jdk-image-variant }}
             else
-              expected_jdk_version=${{ inputs.DEFAULT_JAVA_VERSION }}
+              expected_jdk_version=${{ inputs.EXPECTED_DEFAULT_JAVA_VERSION }}
             fi
 
             # Compute tag by concatenating tag_elements

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -45,7 +45,7 @@ jobs:
               matrix=["ee"]
               ;;
             "all")
-              matrix=["oss","all"]
+              matrix=["oss","ee"]
               ;;
             *)
               echoerr "Unrecognized distribution type ${{ matrix.distribution_type }}"

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -11,7 +11,7 @@ on:
         required: true
       DISTRIBUTION_TYPE:
         required: true
-        description: The type of distribution - `oss` or `ee` - supplied as a comma-separated list (e.g. `oss`, `ee`)
+        description: The distribution(s) to test - `oss`, `ee` or `all` (case-sensitive)
       DEFAULT_JAVA_VERSION:
         required: true
         description: The expected Java major version (e.g. `21`, `8`) used by default in the image
@@ -32,10 +32,24 @@ jobs:
       - name: Parse input into matrix
         id: set-matrix
         run: |
-          # https://unix.stackexchange.com/a/719752 + trim
-          matrix=$(echo '"${{ inputs.DISTRIBUTION_TYPE }}"' | jq --compact-output 'split(",") | map(gsub("^\\s+|\\s+$"; ""))' )
+          case "${{ inputs.DISTRIBUTION_TYPE }}" in
+            "oss")
+              matrix=["oss"]
+              ;;
+            "ee")
+              matrix=["ee"]
+              ;;
+            "all")
+              matrix=["oss","all"]
+              ;;
+            *)
+              echoerr "Unrecognized distribution type ${{ matrix.distribution_type }}"
+              exit 1
+              ;;
+          esac
           echo "distribution-type-matrix=$matrix" >> $GITHUB_OUTPUT
 
+          # https://unix.stackexchange.com/a/719752 + trim
           # Add an "empty" option for base image
           matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output 'split(",") + [""] | map(gsub("^\\s+|\\s+$"; ""))' )
           echo "jdk-image-variants-matrix=$matrix" >> $GITHUB_OUTPUT
@@ -128,6 +142,7 @@ jobs:
               image_name="hazelcast-enterprise"
               ;;
             *)
+              # Impossible as validated earlier
               echoerr "Unrecognized distribution type ${{ matrix.distribution_type }}"
               exit 1
               ;;

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -89,7 +89,7 @@ jobs:
           username: ${{ secrets.NLC_REPO_USERNAME }}
           password: ${{ secrets.NLC_REPO_TOKEN }}
 
-      - name: Login to OCP
+      - name: Login to Red Hat Catalog
         if: matrix.distribution_type == 'ee'
         uses: docker/login-action@v3
         with:
@@ -162,7 +162,7 @@ jobs:
               simple-smoke-test "${{ secrets.NLC_REPOSITORY }}/hazelcast_cloud" "hazelcast-nlc"
             fi
 
-            echo "Testing OCP"
+            echo "Testing Red Hat Catalog"
             simple-smoke-test "registry.connect.redhat.com/hazelcast" "${image_name}-${{ steps.version.outputs.major }}-rhel8"
           fi
 


### PR DESCRIPTION
Converts the existing manual [post-release Docker checklist](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/4681302104/Create+release+5.x#Docker-release-tag-test) into a single GitHub Action.

Improvements:
- faster - runs in parallel
- reproducible - requires no special credentials
- better coverage - leveraging existing smoke test (i.e. beyond just "does it start")
- explicit expectations - requiring expected JDK version upfront avoids "looks ok" confirmation bias when checking outputs

Fixes: [DI-316](https://hazelcast.atlassian.net/browse/DI-316)

Note - it’s difficult to test a new, manual GitHub action that depends on repo secrets. I’ve tested by committing with hardcoded values and then reverting for PR - once merged, if there any issues will be much easier to fix as can be run direct from branch.

Post merge actions:
- [ ] Update release workflow

[DI-316]: https://hazelcast.atlassian.net/browse/DI-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ