### PR TITLE
Test JDK version as part of PR builder [DI-317]

### DIFF
--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -31,7 +31,6 @@ function stop_container() {
 
 function check_java_version() {
     local expected_major_version=$1
-    echo "Checking Java version - expected ${expected_major_version}"
     local actual_major_version
     actual_major_version=$(docker run --rm "${image}" sh -c 'java -version 2>&1 | head -n 1 | awk -F "\"" "{print \$2}" | awk -F "." "{print \$1}"')
 

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -34,7 +34,9 @@ function check_java_version() {
     local actual_major_version
     actual_major_version=$(docker run --rm "${image}" sh -c 'java -version 2>&1 | head -n 1 | awk -F "\"" "{print \$2}" | awk -F "." "{print \$1}"')
 
-    if [[ "${expected_major_version}" != "${actual_major_version}" ]]; then
+    if [[ "${expected_major_version}" == "${actual_major_version}" ]]; then
+      echo "Expected Java version (${expected_distribution_type}) identified."
+    else
       echoerr "Expected Java version '${expected_major_version}' but got '${actual_major_version}'"
       exit 1;
     fi

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -o errexit
-set -x
 
 # shellcheck source=../.github/scripts/abstract-simple-smoke-test.sh
 . .github/scripts/abstract-simple-smoke-test.sh

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -o errexit
+set -x
 
 # shellcheck source=../.github/scripts/abstract-simple-smoke-test.sh
 . .github/scripts/abstract-simple-smoke-test.sh
@@ -29,6 +30,18 @@ function stop_container() {
     docker stop "${container_name}"
 }
 
+function check_java_version() {
+    local expected_major_version=$1
+    echo "Checking Java version - expected ${expected_major_version}"
+    local actual_major_version
+    actual_major_version=$(docker run --rm "${image}" sh -c 'java -version 2>&1 | head -n 1 | awk -F "\"" "{print \$2}" | awk -F "." "{print \$1}"')
+
+    if [[ "${expected_major_version}" != "${actual_major_version}" ]]; then
+      echoerr "Expected Java version '${expected_major_version}' but got '${actual_major_version}'"
+      exit 1;
+    fi
+}
+
 function derive_expected_distribution_type() {
   local input_distribution_type=$1
 
@@ -50,6 +63,7 @@ image=$1
 container_name=$2
 input_distribution_type=$3
 expected_version=$4
+expected_java_major_version=$5
 
 
 remove_container_if_exists
@@ -59,3 +73,4 @@ trap stop_container EXIT
 
 expected_distribution_type=$(derive_expected_distribution_type "${input_distribution_type}")
 test_package "${expected_distribution_type}" "${expected_version}"
+check_java_version "${expected_java_major_version}"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -82,8 +82,9 @@ jobs:
 
       - name: Run smoke test against OSS image
         timeout-minutes: 2
-        run: |
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+        run: |          
+          . .github/scripts/docker.functions.sh
+          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss ${{ needs.prepare.outputs.HZ_VERSION_OSS }} "$(get_default_jdk hazelcast-oss)"
 
       - name: Build Test EE image
         run: |
@@ -99,8 +100,9 @@ jobs:
       - name: Run smoke test against EE image
         timeout-minutes: 2
         run: |
+          . .github/scripts/docker.functions.sh
           export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee ${{ needs.prepare.outputs.HZ_VERSION_EE }}
+          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee ${{ needs.prepare.outputs.HZ_VERSION_EE }} "$(get_default_jdk hazelcast-enterprise)"
 
       - name: Get docker logs
         if: ${{ always() }}
@@ -159,7 +161,7 @@ jobs:
       - name: Run smoke test against OSS image
         timeout-minutes: 2
         run: |
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss ${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss ${{ needs.prepare.outputs.HZ_VERSION_OSS }} ${{ matrix.jdk }}
 
       - name: Build Test EE image
         run: |
@@ -177,7 +179,7 @@ jobs:
         timeout-minutes: 2
         run: |
           export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee ${{ needs.prepare.outputs.HZ_VERSION_EE }}
+          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee ${{ needs.prepare.outputs.HZ_VERSION_EE }} ${{ matrix.jdk }}
 
       - name: Get docker logs
         if: ${{ always() }}

--- a/.github/workflows/ee-nlc-snapshot-push.yml
+++ b/.github/workflows/ee-nlc-snapshot-push.yml
@@ -73,7 +73,7 @@ jobs:
         timeout-minutes: 2
         run: |
           export HZ_INSTANCETRACKING_FILENAME=instance-tracking.txt
-          .github/scripts/simple-smoke-test.sh hazelcast-nlc:test ${{ env.test_container_name_ee }} ee ${HZ_VERSION}
+          .github/scripts/simple-smoke-test.sh hazelcast-nlc:test ${{ env.test_container_name_ee }} ee ${HZ_VERSION} ${{ matrix.jdk }}
 
       - name: Get docker logs
         if: ${{ always() }}

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -87,7 +87,7 @@ jobs:
         timeout-minutes: 2
         run: |
           export HZ_INSTANCETRACKING_FILENAME=instance-tracking.txt
-          .github/scripts/simple-smoke-test.sh hazelcast-nlc:test ${{ env.test_container_name_ee }} ee ${HZ_VERSION}
+          .github/scripts/simple-smoke-test.sh hazelcast-nlc:test ${{ env.test_container_name_ee }} ee ${HZ_VERSION} ${{ matrix.jdk }}
 
       - name: Get docker logs
         if: ${{ always() }}

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -75,7 +75,7 @@ jobs:
         timeout-minutes: 2
         run: |
           export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee ${HZ_VERSION}
+          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee ${HZ_VERSION} ${{ matrix.jdk }}
 
       - name: Get docker logs
         if: ${{ always() }}

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run smoke test against OSS image
         timeout-minutes: 2
         run: |
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss ${HZ_VERSION}
+          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss ${HZ_VERSION} ${{ matrix.jdk }}
 
       - name: Get docker logs
         if: ${{ always() }}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -171,7 +171,7 @@ jobs:
         if: needs.prepare.outputs.should_build_oss == 'yes'
         timeout-minutes: 2
         run: |
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss ${{ env.HZ_VERSION }}
+          .github/scripts/simple-smoke-test.sh hazelcast-oss:test ${{ env.test_container_name_oss }} oss ${{ env.HZ_VERSION }} ${{ matrix.jdk }}
 
       - name: Get EE dist ZIP URL
         if: needs.prepare.outputs.should_build_ee == 'yes'
@@ -195,7 +195,7 @@ jobs:
         timeout-minutes: 2
         run: |
           export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee ${{ env.HZ_VERSION }}
+          .github/scripts/simple-smoke-test.sh hazelcast-ee:test ${{ env.test_container_name_ee }} ee ${{ env.HZ_VERSION }} ${{ matrix.jdk }}
 
       - name: Get docker logs
         if: ${{ always() }}


### PR DESCRIPTION
Adds additional assertion to the PR builder smoke test that the JDK is the version expected for the image.

This is currently a _manual, post release_ check, moving earlier in the cycle to catch defects earlier.

Fixes: [DI-317](https://hazelcast.atlassian.net/browse/DI-317)

Post merge actions:
- [ ] backport
- [ ] _Discuss_ if we remove the manual, post-release check?

[DI-317]: https://hazelcast.atlassian.net/browse/DI-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ