### PR TITLE
Add `xtrace` shell command tracing when running action in GitHub Debug mode

### DIFF
--- a/.github/scripts/abstract-simple-smoke-test.sh
+++ b/.github/scripts/abstract-simple-smoke-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o errexit -o nounset -o pipefail
+set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
 
 # Performs simple validation tests on an already-running Hazelcast instance
 # Abstract as could be from Docker, Homebrew, local binary etc

--- a/.github/scripts/build.functions.sh
+++ b/.github/scripts/build.functions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euo pipefail ${RUNNER_DEBUG:+-x}
 
 # Checks if we should build the OSS docker image.
 # Returns "yes" if we should build it or "no" if we shouldn't.

--- a/.github/scripts/build.functions_tests.sh
+++ b/.github/scripts/build.functions_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eu ${RUNNER_DEBUG:+-x}
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 

--- a/.github/scripts/ee-build.functions.sh
+++ b/.github/scripts/ee-build.functions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euo pipefail ${RUNNER_DEBUG:+-x}
 
 # This is a simple script imitating what maven does for snapshot versions. We are not using maven because currently Docker Buildx and QEMU on Github Actions
 # don't work with Java on architectures ppc64le and s390x. When the problem is fixed we will revert back to using maven.

--- a/.github/scripts/ee-build.functions_tests.sh
+++ b/.github/scripts/ee-build.functions_tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eu ${RUNNER_DEBUG:+-x}
+
 function find_script_dir() {
   CURRENT=$PWD
 

--- a/.github/scripts/get-tags-to-push_tests.sh
+++ b/.github/scripts/get-tags-to-push_tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eu ${RUNNER_DEBUG:+-x}
+
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 

--- a/.github/scripts/maven.functions_tests.sh
+++ b/.github/scripts/maven.functions_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eu ${RUNNER_DEBUG:+-x}
 
 function find_script_dir() {
   CURRENT=$PWD

--- a/.github/scripts/oss-build.functions.sh
+++ b/.github/scripts/oss-build.functions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euo pipefail ${RUNNER_DEBUG:+-x}
 
 function get_hz_dist_zip() {
   local hz_variant=$1

--- a/.github/scripts/oss-build.functions_tests.sh
+++ b/.github/scripts/oss-build.functions_tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eu ${RUNNER_DEBUG:+-x}
+
 function find_script_dir() {
   CURRENT=$PWD
 

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o errexit
+set -o errexit ${RUNNER_DEBUG:+-x}
 
 # shellcheck source=../.github/scripts/abstract-simple-smoke-test.sh
 . .github/scripts/abstract-simple-smoke-test.sh

--- a/.github/scripts/smoke-test.sh
+++ b/.github/scripts/smoke-test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-set -e
-set -o pipefail
+set -e -o pipefail ${RUNNER_DEBUG:+-x}
 
 # Fill the variables before running the script
 WORKDIR=$1

--- a/hazelcast-enterprise/maven.functions.sh
+++ b/hazelcast-enterprise/maven.functions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euo pipefail ${RUNNER_DEBUG:+-x}
 
 # THIS FILE IS DUPLICATED AND MUST BE KEPT IN SYNC MANUALLY
 # Docker requires any included script to be in the current folder, hence we must duplicate this script for OS and EE

--- a/hazelcast-oss/maven.functions.sh
+++ b/hazelcast-oss/maven.functions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euo pipefail ${RUNNER_DEBUG:+-x}
 
 # THIS FILE IS DUPLICATED AND MUST BE KEPT IN SYNC MANUALLY
 # Docker requires any included script to be in the current folder, hence we must duplicate this script for OS and EE


### PR DESCRIPTION
We already do this in _some_ places, make it consistent everywhere.

Raised from [PR feedback](https://github.com/hazelcast/hazelcast-docker/pull/816#discussion_r1827704039).