### PR TITLE
Improve GitHub Action failure reporting annotation

### DIFF
--- a/.github/scripts/abstract-simple-smoke-test.sh
+++ b/.github/scripts/abstract-simple-smoke-test.sh
@@ -83,5 +83,5 @@ function install_clc() {
 
 # Prints the given message to stderr
 function echoerr() {
-  echo "ERROR - $*" 1>&2;
+  echo "::error::ERROR - $*" 1>&2;
 }


### PR DESCRIPTION
[GitHub parses console  output for special phrases](https://stackoverflow.com/a/71091060) to better format it's output. By doing this when we report errors, we can more clearly communicate errors:

Compare [before](https://github.com/JackPGreen/rel-scripts/actions/runs/11711717220):
![image](https://github.com/user-attachments/assets/7191f6ed-6b94-4575-a23b-96dc65b7043d)

Against [after](https://github.com/JackPGreen/rel-scripts/actions/runs/11711863956):
![image](https://github.com/user-attachments/assets/1276308c-4c9f-4f4c-9fa0-2df666b17685)