### PR TITLE
Drop unsupported `5.2` builds [DI-345]

### DIFF
--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       MINIMAL_SUPPORTED_VERSION:
-        description: 'Minimal supported version from which we should start checking images, e.g. 5.1, 5.0.1, 4.2.3. Default values is 5.2'
+        description: 'Minimal supported version from which we should start checking images, e.g. 5.1, 5.0.1, 4.2.3. Default values is 5.3'
         required: false
   schedule:
     - cron: '0 6 * * *'
@@ -17,7 +17,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     env:
       MINIMAL_SUPPORTED_VERSION: ${{ github.event.inputs.MINIMAL_SUPPORTED_VERSION }}
-      DEFAULT_MINIMAL_SUPPORTED_VERSION: 5.2
+      DEFAULT_MINIMAL_SUPPORTED_VERSION: 5.3
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/scheduled_vulnerability_scan.yml
+++ b/.github/workflows/scheduled_vulnerability_scan.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                ref: [ 'master', '5.5.z', '5.4.z', '5.3.z', '5.2.z' ]
+                ref: [ 'master', '5.5.z', '5.4.z', '5.3.z' ]
         uses: ./.github/workflows/vulnerability_scan_subworkflow.yml
         with:
             ref: ${{ matrix.ref }}


### PR DESCRIPTION
[5.2 is no longer supported](https://support.hazelcast.com/s/article/Version-Support-Windows) so images no longer to be built or maintained.

Fixes: [DI-345](https://hazelcast.atlassian.net/browse/DI-345)

[DI-345]: https://hazelcast.atlassian.net/browse/DI-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ