### PR TITLE
Fix `test_published_images.yml` [DI-316]

### DIFF
--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -5,13 +5,13 @@ on:
     inputs:
       IMAGE_VERSION:
         required: true
-        description: A version, `5.4.1`, `latest` etc
+        description: The version/label of the image e.g. `5.4.1`, `latest` etc
       EXPECTED_HZ_VERSION:
-        description: A fully-qualified version, e.g. `5.4.1`
+        description: The expected Hazelcast version (fully-qualified), e.g. `5.4.1`
         required: true
       DISTRIBUTION_TYPE:
         required: true
-        description: The distribution(s) to test (case-sensitive)
+        description: The distribution(s) to test
         type: choice
         options:
           - oss

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -52,8 +52,7 @@ jobs:
               exit 1
               ;;
           esac
-          matrix=$(jq --compact-output '{"distribution-type": .}' <<< "${matrix}")
-          echo "distribution-type-matrix=$matrix" >> $GITHUB_OUTPUT
+          echo "distribution-type-matrix=${matrix}" >> $GITHUB_OUTPUT
 
           # https://unix.stackexchange.com/a/719752 + trim
           # Add an "empty" option for base image

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -53,7 +53,7 @@ jobs:
               ;;
           esac
           matrix=$(jq --compact-output '{"distribution-type": .}' <<< "${matrix}")
-          echo "distribution-type-matrix=${matrix}" >> $GITHUB_OUTPUT
+          echo "distribution-type-matrix=$matrix" >> $GITHUB_OUTPUT
 
           # https://unix.stackexchange.com/a/719752 + trim
           # Add an "empty" option for base image
@@ -69,8 +69,8 @@ jobs:
         variant: 
           - ''
           - 'slim'
-        jdk-image-variant: ${{ fromJson(needs.set-matrix.outputs.jdk-image-variants-matrix) }}
         distribution-type: ${{ fromJson(needs.set-matrix.outputs.distribution-type-matrix) }}
+        jdk-image-variant: ${{ fromJson(needs.set-matrix.outputs.jdk-image-variants-matrix) }}
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -57,7 +57,7 @@ jobs:
 
           # https://unix.stackexchange.com/a/719752 + trim
           # Add an "empty" option for base image
-          matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output '{"jdk-image-variants": (split(",") + [""] | map(gsub("^\\s+|\\s+$"; "")))}' )
+          matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output 'split(",") + [""] | map(gsub("^\\s+|\\s+$"; ""))' )
           echo "jdk-image-variants-matrix=${matrix}" >> $GITHUB_OUTPUT
 
   test:

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -68,8 +68,8 @@ jobs:
         variant: 
           - ''
           - 'slim'
-        distribution_type: ${{ fromJson(needs.set-matrix.outputs.distribution-type-matrix) }}
         jdk-image-variant: ${{ fromJson(needs.set-matrix.outputs.jdk-image-variants-matrix) }}
+        distribution_type: ${{ fromJson(needs.set-matrix.outputs.distribution-type-matrix) }}
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -39,13 +39,13 @@ jobs:
         run: |
           case "${{ inputs.DISTRIBUTION_TYPE }}" in
             "oss")
-              matrix=['oss']
+              matrix='["oss"]'
               ;;
             "ee")
-              matrix=['ee']
+              matrix='["ee"]'
               ;;
             "all")
-              matrix=['oss','ee']
+              matrix='["oss","ee"]'
               ;;
             *)
               echoerr "Unrecognized distribution type ${{ matrix.distribution_type }}"

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -52,12 +52,12 @@ jobs:
               exit 1
               ;;
           esac
-          matrix=$(jq '{distribution-type: .}' <<< "${matrix}")
+          matrix=$(jq '{"distribution-type": .}' <<< "${matrix}")
           echo "distribution-type-matrix=${matrix}" >> $GITHUB_OUTPUT
 
           # https://unix.stackexchange.com/a/719752 + trim
           # Add an "empty" option for base image
-          matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output 'split(",") + [""] | map(gsub("^\\s+|\\s+$"; ""))' | jq '{jdk-image-variants: .}' )
+          matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output 'split(",") + [""] | map(gsub("^\\s+|\\s+$"; ""))' | jq '{"jdk-image-variants": .}' )
           echo "jdk-image-variants-matrix=${matrix}" >> $GITHUB_OUTPUT
 
   test:

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -39,13 +39,13 @@ jobs:
         run: |
           case "${{ inputs.DISTRIBUTION_TYPE }}" in
             "oss")
-              matrix=["oss"]
+              matrix=['oss']
               ;;
             "ee")
-              matrix=["ee"]
+              matrix=['ee']
               ;;
             "all")
-              matrix=["oss","ee"]
+              matrix=['oss','ee']
               ;;
             *)
               echoerr "Unrecognized distribution type ${{ matrix.distribution_type }}"

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -48,16 +48,16 @@ jobs:
               matrix='["oss","ee"]'
               ;;
             *)
-              echoerr "Unrecognized distribution type ${{ matrix.distribution_type }}"
+              echoerr "Unrecognized distribution type ${{ inputs.DISTRIBUTION_TYPE }}"
               exit 1
               ;;
           esac
-          matrix=$(jq  --compact-output '{"distribution-type": .}' <<< "${matrix}")
+          matrix=$(jq --compact-output '{"distribution-type": .}' <<< "${matrix}")
           echo "distribution-type-matrix=${matrix}" >> $GITHUB_OUTPUT
 
           # https://unix.stackexchange.com/a/719752 + trim
           # Add an "empty" option for base image
-          matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output 'split(",") + [""] | map(gsub("^\\s+|\\s+$"; ""))' | jq --compact-output '{"jdk-image-variants": .}' )
+          matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output '{"jdk-image-variants": (split(",") + [""] | map(gsub("^\\s+|\\s+$"; "")))}' )
           echo "jdk-image-variants-matrix=${matrix}" >> $GITHUB_OUTPUT
 
   test:
@@ -70,7 +70,7 @@ jobs:
           - ''
           - 'slim'
         jdk-image-variant: ${{ fromJson(needs.set-matrix.outputs.jdk-image-variants-matrix) }}
-        distribution_type: ${{ fromJson(needs.set-matrix.outputs.distribution-type-matrix) }}
+        distribution-type: ${{ fromJson(needs.set-matrix.outputs.distribution-type-matrix) }}
 
     steps:
       - name: Checkout Code
@@ -102,7 +102,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to NLC Repository
-        if: matrix.distribution_type == 'ee'
+        if: matrix.distribution-type == 'ee'
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.NLC_REPOSITORY }}
@@ -110,7 +110,7 @@ jobs:
           password: ${{ secrets.NLC_REPO_TOKEN }}
 
       - name: Login to Red Hat Catalog
-        if: matrix.distribution_type == 'ee'
+        if: matrix.distribution-type == 'ee'
         uses: docker/login-action@v3
         with:
           registry: registry.connect.redhat.com
@@ -137,10 +137,10 @@ jobs:
             fi
 
             # Compute tag by concatenating tag_elements
-            .github/scripts/simple-smoke-test.sh "${organization}/${image_name}":$(IFS=- ; echo "${tag_elements[*]}") "${CONTAINER_NAME}" "${{ matrix.distribution_type }}" "${{ inputs.EXPECTED_HZ_VERSION }}" "${expected_jdk_version}"
+            .github/scripts/simple-smoke-test.sh "${organization}/${image_name}":$(IFS=- ; echo "${tag_elements[*]}") "${CONTAINER_NAME}" "${{ matrix.distribution-type }}" "${{ inputs.EXPECTED_HZ_VERSION }}" "${expected_jdk_version}"
           }
 
-          case "${{ matrix.distribution_type }}" in
+          case "${{ matrix.distribution-type }}" in
             "oss")
               image_name="hazelcast"
               ;;
@@ -149,12 +149,12 @@ jobs:
               ;;
             *)
               # Impossible as validated earlier
-              echoerr "Unrecognized distribution type ${{ matrix.distribution_type }}"
+              echoerr "Unrecognized distribution type ${{ matrix.distribution-type }}"
               exit 1
               ;;
           esac
 
-          if [[ "${{ matrix.distribution_type }}" == "ee" ]]; then
+          if [[ "${{ matrix.distribution-type }}" == "ee" ]]; then
             export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
             export HZ_INSTANCETRACKING_FILENAME=instance-tracking.txt
           fi
@@ -176,7 +176,7 @@ jobs:
 
           # Check additional EE repos
           # Only populated for default variant, not "slim"
-          if [[ "${{ matrix.distribution_type }}" == "ee" && -z "${{ matrix.variant }}" ]]; then
+          if [[ "${{ matrix.distribution-type }}" == "ee" && -z "${{ matrix.variant }}" ]]; then
             # NLC repo only populated for absolute versions - not "latest", "latest-lts" etc tags
             # Identify absolute version based on earlier parsing of version number
             if [[ -n "${{ steps.version.outputs.major }}" ]]; then

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -52,12 +52,12 @@ jobs:
               exit 1
               ;;
           esac
-          matrix=$(jq '{"distribution-type": .}' <<< "${matrix}")
+          matrix=$(jq  --compact-output '{"distribution-type": .}' <<< "${matrix}")
           echo "distribution-type-matrix=${matrix}" >> $GITHUB_OUTPUT
 
           # https://unix.stackexchange.com/a/719752 + trim
           # Add an "empty" option for base image
-          matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output 'split(",") + [""] | map(gsub("^\\s+|\\s+$"; ""))' | jq '{"jdk-image-variants": .}' )
+          matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output 'split(",") + [""] | map(gsub("^\\s+|\\s+$"; ""))' | jq --compact-output '{"jdk-image-variants": .}' )
           echo "jdk-image-variants-matrix=${matrix}" >> $GITHUB_OUTPUT
 
   test:

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -52,12 +52,13 @@ jobs:
               exit 1
               ;;
           esac
-          echo "distribution-type-matrix=$matrix" >> $GITHUB_OUTPUT
+          matrix=$(jq '{distribution-type: .}' <<< "${matrix}")
+          echo "distribution-type-matrix=${matrix}" >> $GITHUB_OUTPUT
 
           # https://unix.stackexchange.com/a/719752 + trim
           # Add an "empty" option for base image
-          matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output 'split(",") + [""] | map(gsub("^\\s+|\\s+$"; ""))' )
-          echo "jdk-image-variants-matrix=$matrix" >> $GITHUB_OUTPUT
+          matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output 'split(",") + [""] | map(gsub("^\\s+|\\s+$"; ""))' | jq '{jdk-image-variants: .}' )
+          echo "jdk-image-variants-matrix=${matrix}" >> $GITHUB_OUTPUT
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The action added in https://github.com/hazelcast/hazelcast-docker/pull/814 could not be properly tested via GitHub until merged and at that point additional defects were discovered.

[Example of now successful completion](https://github.com/hazelcast/hazelcast-docker/actions/runs/11943342729).

Post-merge actions:
- [ ] backport this + previous PRs to maintenance branches
- [ ] update [release documentation to reference](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/4681302104/Create+release+5.x#Docker-release-tag-test)

Fixes: [DI-316](https://hazelcast.atlassian.net/browse/DI-316)

[DI-316]: https://hazelcast.atlassian.net/browse/DI-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ