### PR TITLE
Replace `docker login` with `login-action` [DI-318]

### DIFF
--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -43,9 +43,6 @@ jobs:
     name: Rebuild ${{ matrix.version }} if base image changed
     needs: get-latest-patch-versions
     env:
-      NLC_REPOSITORY: ${{ secrets.NLC_REPOSITORY }}
-      NLC_REPO_USERNAME: ${{ secrets.NLC_REPO_USERNAME }}
-      NLC_REPO_TOKEN: ${{ secrets.NLC_REPO_TOKEN }}
       NLC_IMAGE_NAME: ${{ secrets.NLC_IMAGE_NAME }}
     strategy:
       fail-fast: false
@@ -60,7 +57,11 @@ jobs:
           path: v${{ matrix.version }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to NLC Docker Repository
-        run: echo "${NLC_REPO_TOKEN}" | docker login -u ${NLC_REPO_USERNAME} ${NLC_REPOSITORY} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.NLC_REPOSITORY }}
+          username: ${{ secrets.NLC_REPO_USERNAME }}
+          password: ${{ secrets.NLC_REPO_TOKEN }}
       - name: Check if ${{ matrix.version }} base images updated
         run: |
           . .github/scripts/base-image-updated.sh

--- a/.github/workflows/ee-nlc-snapshot-push.yml
+++ b/.github/workflows/ee-nlc-snapshot-push.yml
@@ -25,9 +25,6 @@ jobs:
         jdk: ${{ fromJSON(needs.jdks.outputs.jdks) }}
     env:
       HZ_VERSION : ${{ inputs.HZ_VERSION }}
-      NLC_REPOSITORY: ${{ secrets.NLC_REPOSITORY }}
-      NLC_REPO_USERNAME: ${{ secrets.NLC_REPO_USERNAME }}
-      NLC_REPO_TOKEN: ${{ secrets.NLC_REPO_TOKEN }}
       NLC_IMAGE_NAME: ${{ secrets.NLC_IMAGE_NAME }}
       S3_NLC_URL: ${{ secrets.S3_NLC_URL }}
     steps:
@@ -50,7 +47,11 @@ jobs:
           echo "HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL}" >> $GITHUB_ENV
 
       - name: Login to Docker Hub
-        run: echo "${NLC_REPO_TOKEN}" | docker login -u ${NLC_REPO_USERNAME} ${NLC_REPOSITORY} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.NLC_REPOSITORY }}
+          username: ${{ secrets.NLC_REPO_USERNAME }}
+          password: ${{ secrets.NLC_REPO_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.2.0

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -27,9 +27,6 @@ jobs:
       matrix:
         jdk: ${{ fromJSON(needs.jdks.outputs.jdks) }}
     env:
-      NLC_REPOSITORY: ${{ secrets.NLC_REPOSITORY }}
-      NLC_REPO_USERNAME: ${{ secrets.NLC_REPO_USERNAME }}
-      NLC_REPO_TOKEN: ${{ secrets.NLC_REPO_TOKEN }}
       NLC_IMAGE_NAME: ${{ secrets.NLC_IMAGE_NAME }}
       S3_NLC_URL: ${{ secrets.S3_NLC_URL }}
       HZ_VERSION: ${{ inputs.HZ_VERSION }}
@@ -65,7 +62,11 @@ jobs:
           echo "HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL}" >> $GITHUB_ENV
 
       - name: Login to Docker Hub
-        run: echo "${NLC_REPO_TOKEN}" | docker login -u ${NLC_REPO_USERNAME} ${NLC_REPOSITORY} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.NLC_REPOSITORY }}
+          username: ${{ secrets.NLC_REPO_USERNAME }}
+          password: ${{ secrets.NLC_REPO_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.2.0

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -93,7 +93,10 @@ jobs:
             ${{ env.DOCKER_LOG_FILE_EE }}
 
       - name: Login to Docker Hub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build/Push EE image
         run: |

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -29,8 +29,6 @@ jobs:
           - variant: ''
     env:
       DOCKER_REGISTRY: ${{ secrets.HZ_SNAPSHOT_INTERNAL_DOCKER_REGISTRY }}
-      DOCKER_USERNAME: ${{ secrets.JFROG_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
 
       # required by OSS get_hz_dist_zip function
       HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
@@ -101,7 +99,10 @@ jobs:
             ${{ env.DOCKER_LOG_FILE_OSS }}
 
       - name: Login to Docker Registry
-        run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin $DOCKER_REGISTRY
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.JFROG_USERNAME }}
+          password: ${{ secrets.JFROG_PASSWORD }}
 
       - name: Build/Push OSS image
         run: |

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -101,6 +101,7 @@ jobs:
       - name: Login to Docker Registry
         uses: docker/login-action@v3
         with:
+          registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ secrets.JFROG_USERNAME }}
           password: ${{ secrets.JFROG_PASSWORD }}
 

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -185,7 +185,10 @@ jobs:
 
       - name: Login to Docker Hub
         if: inputs.DRY_RUN == 'false'
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Get OSS dist ZIP URL
         if: needs.prepare.outputs.should_build_oss == 'yes'

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -118,8 +118,11 @@ jobs:
           aws-region: 'us-east-1'
 
       - name: Log in to Red Hat Scan Registry
-        run: |
-          docker login ${SCAN_REGISTRY} -u ${SCAN_REGISTRY_USER} -p ${SCAN_REGISTRY_PASSWORD}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.SCAN_REGISTRY }}
+          username: ${{ env.SCAN_REGISTRY_USER }}
+          password: ${{ env.SCAN_REGISTRY_PASSWORD }}
 
       - name: Check if latest EE LTS release
         id: is_latest_lts


### PR DESCRIPTION
`docker login` logs a warning:
> WARNING! Your password will be stored unencrypted in /home/runner/.docker/config.json.
Configure a credential helper to remove this warning. See https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Instead we should be using [the action](https://github.com/docker/login-action).

[Example Action execution showing success with this change](https://github.com/hazelcast/hazelcast-docker/actions/runs/11943525999).

Fixes: [DI-318](https://hazelcast.atlassian.net/browse/DI-318)

[DI-318]: https://hazelcast.atlassian.net/browse/DI-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ