### PR TITLE
Get OCP credentials from AWS during RHEL release [5.4.z]

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -125,11 +125,8 @@ jobs:
             OCP_CLUSTER_URL,CN/OCP_CLUSTER_URL
 
       - name: Log in to Red Hat Scan Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.SCAN_REGISTRY }}
-          username: ${{ env.SCAN_REGISTRY_USER }}
-          password: ${{ env.SCAN_REGISTRY_PASSWORD }}
+        run: |
+          docker login ${SCAN_REGISTRY} -u ${SCAN_REGISTRY_USER} -p ${SCAN_REGISTRY_PASSWORD}
 
       - name: Build the Hazelcast Enterprise image
         run: |

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -27,10 +27,6 @@ jobs:
       REQUIRED_HZ_MAJOR_VERSION: 5
       SCAN_REGISTRY: "quay.io"
       TIMEOUT_IN_MINS: 60
-      HZ_ENTERPRISE_LICENSE: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
-      OCP_LOGIN_USERNAME: ${{ secrets.OCP_LOGIN_USERNAME }}
-      OCP_LOGIN_PASSWORD: ${{ secrets.OCP_LOGIN_PASSWORD }}
-      OCP_CLUSTER_URL: ${{ secrets.OCP_CLUSTER_URL }}
       RHEL_API_KEY: ${{ secrets.RHEL_API_KEY }}
       HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
@@ -120,6 +116,21 @@ jobs:
       - name: Install xmllint
         uses: ./.github/actions/install-xmllint
 
+      - name: Get Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            OCP_LOGIN_USERNAME,CN/OCP_USERNAME
+            OCP_LOGIN_PASSWORD,CN/OCP_PASSWORD
+            OCP_CLUSTER_URL,CN/OCP_CLUSTER_URL
+
+      - name: Log in to Red Hat Scan Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.SCAN_REGISTRY }}
+          username: ${{ env.SCAN_REGISTRY_USER }}
+          password: ${{ env.SCAN_REGISTRY_PASSWORD }}
+
       - name: Log in to Red Hat Scan Registry
         run: |
           docker login ${SCAN_REGISTRY} -u ${SCAN_REGISTRY_USER} -p ${SCAN_REGISTRY_PASSWORD}
@@ -190,6 +201,7 @@ jobs:
 
         env:
           CLUSTER_SIZE: 3
+          HZ_ENTERPRISE_LICENSE: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
 
       - name: Validate Cluster Size
         run: |

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -131,10 +131,6 @@ jobs:
           username: ${{ env.SCAN_REGISTRY_USER }}
           password: ${{ env.SCAN_REGISTRY_PASSWORD }}
 
-      - name: Log in to Red Hat Scan Registry
-        run: |
-          docker login ${SCAN_REGISTRY} -u ${SCAN_REGISTRY_USER} -p ${SCAN_REGISTRY_PASSWORD}
-
       - name: Build the Hazelcast Enterprise image
         run: |
           . .github/scripts/get-tags-to-push.sh 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/812

Currently, credentials are duplicated between:
- AWS Secrets Manager
- GitHub Secrets

In the past this has lead to build failures when credentials were updated in only one place.

This PR updates any credentials which are duplicated, migrating them to use the value directly from AWS Secrets Manager. The methodology on this logic is described [here](https://hazelcast.atlassian.net/browse/DI-78?focusedCommentId=104219).

I'm confident [from my testing](https://hazelcast.atlassian.net/browse/DI-78?focusedCommentId=104219) the values will resolve correctly, but as the job is triggered on `tag`, I am unable to test in a non-destructive way.

I've also rescoped `secrets.HZ_ENTERPRISE_LICENSE` to reduce the cognitive complexity of looking through the actions' environment secrets.

Fixes: [DI-78](https://hazelcast.atlassian.net/browse/DI-78)

[DI-78]: https://hazelcast.atlassian.net/browse/DI-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ