### PR TITLE
Get OCP credentials from AWS during RHEL release [5.3.z]

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -27,10 +27,6 @@ jobs:
       REQUIRED_HZ_MAJOR_VERSION: 5
       SCAN_REGISTRY: "quay.io"
       TIMEOUT_IN_MINS: 60
-      HZ_ENTERPRISE_LICENSE: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
-      OCP_LOGIN_USERNAME: ${{ secrets.OCP_LOGIN_USERNAME }}
-      OCP_LOGIN_PASSWORD: ${{ secrets.OCP_LOGIN_PASSWORD }}
-      OCP_CLUSTER_URL: ${{ secrets.OCP_CLUSTER_URL }}
       RHEL_API_KEY: ${{ secrets.RHEL_API_KEY }}
       HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
@@ -117,6 +113,14 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: 'us-east-1'
 
+      - name: Get Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            OCP_LOGIN_USERNAME,CN/OCP_USERNAME
+            OCP_LOGIN_PASSWORD,CN/OCP_PASSWORD
+            OCP_CLUSTER_URL,CN/OCP_CLUSTER_URL
+
       - name: Log in to Red Hat Scan Registry
         run: |
           docker login ${SCAN_REGISTRY} -u ${SCAN_REGISTRY_USER} -p ${SCAN_REGISTRY_PASSWORD}
@@ -187,6 +191,7 @@ jobs:
 
         env:
           CLUSTER_SIZE: 3
+          HZ_ENTERPRISE_LICENSE: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
 
       - name: Validate Cluster Size
         run: |


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/812

Currently, credentials are duplicated between:
- AWS Secrets Manager
- GitHub Secrets

In the past this has lead to build failures when credentials were updated in only one place.

This PR updates any credentials which are duplicated, migrating them to use the value directly from AWS Secrets Manager. The methodology on this logic is described [here](https://hazelcast.atlassian.net/browse/DI-78?focusedCommentId=104219).

I'm confident [from my testing](https://hazelcast.atlassian.net/browse/DI-78?focusedCommentId=104219) the values will resolve correctly, but as the job is triggered on `tag`, I am unable to test in a non-destructive way.

I've also rescoped `secrets.HZ_ENTERPRISE_LICENSE` to reduce the cognitive complexity of looking through the actions' environment secrets.

Fixes: [DI-78](https://hazelcast.atlassian.net/browse/DI-78)

[DI-78]: https://hazelcast.atlassian.net/browse/DI-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ