### PR TITLE
Convert manual post-release test into a reusable GitHub Action [DI-316] [5.3.z]

### DIFF
--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -5,13 +5,13 @@ on:
     inputs:
       IMAGE_VERSION:
         required: true
-        description: A version, `5.4.1`, `latest` etc
+        description: The version/label of the image e.g. `5.4.1`, `latest` etc
       EXPECTED_HZ_VERSION:
-        description: A fully-qualified version, e.g. `5.4.1`
+        description: The expected Hazelcast version (fully-qualified), e.g. `5.4.1`
         required: true
       DISTRIBUTION_TYPE:
         required: true
-        description: The distribution(s) to test (case-sensitive)
+        description: The distribution(s) to test
         type: choice
         options:
           - oss
@@ -39,25 +39,25 @@ jobs:
         run: |
           case "${{ inputs.DISTRIBUTION_TYPE }}" in
             "oss")
-              matrix=["oss"]
+              matrix='["oss"]'
               ;;
             "ee")
-              matrix=["ee"]
+              matrix='["ee"]'
               ;;
             "all")
-              matrix=["oss","ee"]
+              matrix='["oss","ee"]'
               ;;
             *)
-              echoerr "Unrecognized distribution type ${{ matrix.distribution_type }}"
+              echoerr "Unrecognized distribution type ${{ inputs.DISTRIBUTION_TYPE }}"
               exit 1
               ;;
           esac
-          echo "distribution-type-matrix=$matrix" >> $GITHUB_OUTPUT
+          echo "distribution-type-matrix=${matrix}" >> $GITHUB_OUTPUT
 
           # https://unix.stackexchange.com/a/719752 + trim
           # Add an "empty" option for base image
           matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output 'split(",") + [""] | map(gsub("^\\s+|\\s+$"; ""))' )
-          echo "jdk-image-variants-matrix=$matrix" >> $GITHUB_OUTPUT
+          echo "jdk-image-variants-matrix=${matrix}" >> $GITHUB_OUTPUT
 
   test:
     runs-on: ubuntu-latest
@@ -68,7 +68,7 @@ jobs:
         variant: 
           - ''
           - 'slim'
-        distribution_type: ${{ fromJson(needs.set-matrix.outputs.distribution-type-matrix) }}
+        distribution-type: ${{ fromJson(needs.set-matrix.outputs.distribution-type-matrix) }}
         jdk-image-variant: ${{ fromJson(needs.set-matrix.outputs.jdk-image-variants-matrix) }}
 
     steps:
@@ -101,7 +101,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to NLC Repository
-        if: matrix.distribution_type == 'ee'
+        if: matrix.distribution-type == 'ee'
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.NLC_REPOSITORY }}
@@ -109,7 +109,7 @@ jobs:
           password: ${{ secrets.NLC_REPO_TOKEN }}
 
       - name: Login to Red Hat Catalog
-        if: matrix.distribution_type == 'ee'
+        if: matrix.distribution-type == 'ee'
         uses: docker/login-action@v3
         with:
           registry: registry.connect.redhat.com
@@ -136,10 +136,10 @@ jobs:
             fi
 
             # Compute tag by concatenating tag_elements
-            .github/scripts/simple-smoke-test.sh "${organization}/${image_name}":$(IFS=- ; echo "${tag_elements[*]}") "${CONTAINER_NAME}" "${{ matrix.distribution_type }}" "${{ inputs.EXPECTED_HZ_VERSION }}" "${expected_jdk_version}"
+            .github/scripts/simple-smoke-test.sh "${organization}/${image_name}":$(IFS=- ; echo "${tag_elements[*]}") "${CONTAINER_NAME}" "${{ matrix.distribution-type }}" "${{ inputs.EXPECTED_HZ_VERSION }}" "${expected_jdk_version}"
           }
 
-          case "${{ matrix.distribution_type }}" in
+          case "${{ matrix.distribution-type }}" in
             "oss")
               image_name="hazelcast"
               ;;
@@ -148,12 +148,12 @@ jobs:
               ;;
             *)
               # Impossible as validated earlier
-              echoerr "Unrecognized distribution type ${{ matrix.distribution_type }}"
+              echoerr "Unrecognized distribution type ${{ matrix.distribution-type }}"
               exit 1
               ;;
           esac
 
-          if [[ "${{ matrix.distribution_type }}" == "ee" ]]; then
+          if [[ "${{ matrix.distribution-type }}" == "ee" ]]; then
             export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
             export HZ_INSTANCETRACKING_FILENAME=instance-tracking.txt
           fi
@@ -175,7 +175,7 @@ jobs:
 
           # Check additional EE repos
           # Only populated for default variant, not "slim"
-          if [[ "${{ matrix.distribution_type }}" == "ee" && -z "${{ matrix.variant }}" ]]; then
+          if [[ "${{ matrix.distribution-type }}" == "ee" && -z "${{ matrix.variant }}" ]]; then
             # NLC repo only populated for absolute versions - not "latest", "latest-lts" etc tags
             # Identify absolute version based on earlier parsing of version number
             if [[ -n "${{ steps.version.outputs.major }}" ]]; then


### PR DESCRIPTION
Backports https://github.com/hazelcast/hazelcast-docker/pull/814 & https://github.com/hazelcast/hazelcast-docker/pull/827