### PR TITLE
Fix Actionlint warnings

### DIFF
--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -17,6 +17,7 @@ on:
       RELEASE_TYPE:
         description: 'What should be built'
         required: true
+        default: 'EE'
         type: choice
         options:
           - ALL

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -17,7 +17,6 @@ on:
       RELEASE_TYPE:
         description: 'What should be built'
         required: true
-        default: 'EE'
         type: choice
         options:
           - ALL

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -158,7 +158,7 @@ jobs:
           docker buildx build --push \
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}") \
+            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "" "${{ env.HZ_VERSION }}") \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR
 


### PR DESCRIPTION
[Actionlint](https://github.com/rhysd/actionlint) flagged warnings in our GitHub Actions:
- `.github/workflows/tag_image_push_rhel.yml:139:760: property "variant" is not defined in object type {jdk: any} [expression]`
   - The property is empty so implicitly evaluates to empty string, i.e. builds only "base" variant (not `slim`)
   - This is the behaviour we actually want, so made explicit