### PR TITLE
Revert using our fork of `dockle-action`

### DIFF
--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Scan ${{ matrix.image.label }} image by Dockle
         if: always()
+        # https://github.com/goodwithtech/dockle-action/releases/tag/v0.4.15
         uses: goodwithtech/dockle-action@e30e6af832aad6ea7dca2a248d31a85eab6dbd68
         with:
           image: ${{ env.IMAGE_TAG }} 

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Scan ${{ matrix.image.label }} image by Dockle
         if: always()
-        uses: goodwithtech/dockle-action@main
+        uses: goodwithtech/dockle-action@e30e6af832aad6ea7dca2a248d31a85eab6dbd68
         with:
           image: ${{ env.IMAGE_TAG }} 
           format: 'list'

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -61,9 +61,7 @@ jobs:
 
       - name: Scan ${{ matrix.image.label }} image by Dockle
         if: always()
-        # Use our fork until https://github.com/goodwithtech/dockle-action/issues/7 is fixed
-        # uses: goodwithtech/dockle-action@main
-        uses: hazelcast/dockle-action/@Upgrade-Dockle-to-`0.4.14`
+        uses: goodwithtech/dockle-action@main
         with:
           image: ${{ env.IMAGE_TAG }} 
           format: 'list'


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-docker/pull/778 we swapped our usage of `dockle-action` to our forked version to workaround https://github.com/goodwithtech/dockle-action/issues/7 - now thhis has been fixed upstream we can use it again.

Post-merge action:
- [ ] delete https://github.com/hazelcast/dockle-action