### PR TITLE
Fix `openshift-tools` installation issues

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -154,6 +154,11 @@ jobs:
       - uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "latest"
+          source: mirror
+          skip_cache: true
+
+      - uses: redhat-actions/openshift-tools-installer@v1
+        with:
           preflight: "latest"
           source: github
           skip_cache: true

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -151,13 +151,15 @@ jobs:
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR
 
-      - uses: redhat-actions/openshift-tools-installer@v1
+      - name: Install `oc` OpenShift tool from mirror
+        uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "latest"
           source: mirror
           skip_cache: true
 
-      - uses: redhat-actions/openshift-tools-installer@v1
+      - name: Install `preflight` OpenShift tool from GitHub
+        uses: redhat-actions/openshift-tools-installer@v1
         with:
           preflight: "latest"
           source: github

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Run preflight scan
         run: |
-          ./preflight-linux-amd64 check container ${RHEL_IMAGE} \
+          preflight check container ${RHEL_IMAGE} \
           --submit --pyxis-api-token=${RHEL_API_KEY} \
           --certification-project-id=${RHEL_PROJECT_ID} \
           --docker-config ~/.docker/config.json


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-docker/pull/850, we use the `openshift-tools-installer` to install OpenShift tools, but [following testing](https://hazelcast.slack.com/archives/C05LM8B80UT/p1736508941644619?thread_ts=1736438770.790189&cid=C05LM8B80UT) there were some issues:

- `preflight` and `oc` must be installed from _different_ mirrors as they are [not in the same one](https://github.com/redhat-actions/openshift-tools-installer?tab=readme-ov-file#supported-tools)
- `preflight` is installed with a different name vs when simply unpacked

Testing outputs:
- [Example action showing installation success](https://github.com/hazelcast/hazelcast-docker/actions/runs/12709131411/job/35427518232)
- [`5.3.8` deployed using these changes](https://github.com/hazelcast/hazelcast-docker/actions/runs/12712052672) (via [a branch](https://github.com/hazelcast/hazelcast-docker/tree/refs/heads/5.3.8-with-%60oc%60-fix))

Post-merge actions:
- [ ] backport to maintenance branches