### PR TITLE
Recut 5.5.3 from 5.5.z [REL-438][5.5.z] 

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -3,7 +3,7 @@ FROM redhat/ubi9-minimal:9.3
 # Used for image metadata only
 # Describes the version of the Dockerfile, *not* the version of the bundled Hazelcast binary as this is/can be controlled externally
 # Dockerfile needs some concept of versioning so that the release pipeline can tag/archive with an appropriate label
-ARG HZ_VERSION=5.5.4-SNAPSHOT
+ARG HZ_VERSION=5.5.3-SNAPSHOT
 ARG JDK_VERSION="21"
 
 # Build constants

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3
 
 # Describes the version of the Dockerfile, *not* the version of the bundled Hazelcast binary as this is/can be controlled externally
 # Dockerfile needs some concept of versioning so that the release pipeline can tag/archive with an appropriate label
-ARG HZ_VERSION=5.5.4-SNAPSHOT
+ARG HZ_VERSION=5.5.3-SNAPSHOT
 
 # Build constants
 ARG HZ_HOME="/opt/hazelcast"


### PR DESCRIPTION
We are recutting 5.5.3 from 5.5.z which needs to go back 1 version so new branch will have the correct version. I have deleted previous 5.5.3 branch

Manually updated the files

Fixes [REL-438](https://hazelcast.atlassian.net/browse/REL-438)

[REL-438]: https://hazelcast.atlassian.net/browse/REL-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ