### PR TITLE
Investigate Docker RHEL 5.5.2 build issue [DI-401]

### DIFF
--- a/.github/scripts/logging.functions.sh
+++ b/.github/scripts/logging.functions.sh
@@ -7,3 +7,16 @@ function echoerr() {
   # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message
   echo "::error::ERROR - $*" 1>&2;
 }
+
+# Create group
+function echo_group() {
+  # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines
+  local TITLE=$1
+  echo "::group::${TITLE}"
+}
+
+# Ends group after calling echo_group()
+function echo_group_end() {
+  # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines
+  echo "::endgroup::"
+}

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -282,7 +282,7 @@ function delete_unpublished_images() {
 }
 
 # this will actually send request to delete a single unpublished image
-function do_delete_unpublished_images() {
+function delete_image() {
     local RHEL_API_KEY=$1
     local IMAGE_ID=$2
 

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -314,8 +314,9 @@ function verify_no_unpublished_images() {
     return 1
 }
 
-# Starts timer with default timeout of 4h. See RedHat ticket https://connect.redhat.com/support/partner-acceleration-desk/#/case/04042093
-# The scan/publish can take from 2m to 3hrs but we set higher just in case
+# Starts timer with default timeout of 4h. The scan/publish can take
+# from 2mins to 3hrs (RedHat Case: 04042093) but we set it higher to
+# account for edge cases
 STOPWATCH_PID=-1
 STOPWATCH_DEFAULT_TIMEOUT=4h
 function _start_stopwatch() {

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -294,6 +294,9 @@ function do_delete_unpublished_images() {
             --header "X-API-KEY: ${RHEL_API_KEY}" \
             --data '{"deleted": true}' \
             "https://catalog.redhat.com/api/containers/v1/images/id/${IMAGE_ID}")
+
+    echo "::debug::HTTP response after image deletion"
+    echo "::debug::${RESPONSE}"
 }
 
 # verifies there are no unblished images for given version

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -44,8 +44,7 @@ wait_for_container_scan()
     local RHEL_PROJECT_ID=$1
     local VERSION=$2
     local RHEL_API_KEY=$3
-    local TIMEOUT_IN_MINS=$4
-    
+
     local IMAGE
     local IS_PUBLISHED
 
@@ -57,12 +56,15 @@ wait_for_container_scan()
         return 0
     fi
 
-    local NOF_RETRIES=$(( TIMEOUT_IN_MINS / 2 ))
-    # Wait until the image is scanned
-    for i in $(seq 1 "${NOF_RETRIES}"); do
+    # start timer
+    _start_stopwatch
+
+    while [ 1 ]
+    do
         local IMAGE
         local SCAN_STATUS
         local IMAGE_CERTIFIED
+        local RESULT=-1
 
         IMAGE=$(get_image not_published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}")
         SCAN_STATUS=$(echo "${IMAGE}" | jq -r '.data[0].container_grades.status')
@@ -75,20 +77,28 @@ wait_for_container_scan()
         elif [[ ${SCAN_STATUS} == "null" ]];  then
             echo "Image is still not present in the registry!"
         elif [[ ${SCAN_STATUS} == "completed" && "${IMAGE_CERTIFIED}" == "true" ]]; then
-            echo "Scan passed!" ; return 0
+            RESULT=0
+            echo "Scan passed!"
+        elif _is_stopwatch_expired; then
+            RESULT=42
+            echoerr "Timeout'! Scan could not be finished"
         else
+            RESULT=1
             echoerr "Scan failed with '${SCAN_STATUS}!"
-            echoerr "${IMAGE}"
-            return 1
         fi
 
+        if [[ $RESULT -ge 0 ]]; then
+            # cancel stopwatch if error or sucess
+            _cancel_stopwatch
+
+            if [[ $RESULT -gt 0 ]]; then
+                echoerr "${IMAGE}"
+            fi
+            return $RESULT
+        fi
+
+        # Wait a little before next retry
         sleep 120
-
-        if [[ ${i} == "${NOF_RETRIES}" ]]; then
-            echoerr "Timeout! Scan could not be finished"
-            echoerr "${IMAGE}"
-            return 42
-        fi
     done
 }
 
@@ -141,7 +151,6 @@ publish_the_image()
     echo "Created a publish request, please check if the image is published."
 }
 
-
 sync_tags()
 {
     local RHEL_PROJECT_ID=$1
@@ -184,44 +193,153 @@ wait_for_container_publish()
     local RHEL_PROJECT_ID=$1
     local VERSION=$2
     local RHEL_API_KEY=$3
-    local TIMEOUT_IN_MINS=$4
 
-    local NOF_RETRIES=$(( TIMEOUT_IN_MINS * 2 ))
-    # Wait until the image is published
-    for i in $(seq 1 "${NOF_RETRIES}"); do
+    # start timer
+    _start_stopwatch
+
+    while [ 1 ]
+    do
         local IMAGE
         local IS_PUBLISHED
+        local RESULT=-1
 
         IMAGE=$(get_image published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}")
         IS_PUBLISHED=$(echo "${IMAGE}" | jq -r '.total')
 
         if [[ ${IS_PUBLISHED} == "1" ]]; then
+            RESULT=0
             echo "Image is published, exiting."
-            return 0
+        elif _is_stopwatch_expired; then
+            RESULT=42
+            echoerr "Timeout! Publish could not be finished"
         else
             echo "Image is still not published, waiting..."
         fi
 
-        sleep 30
+        if [[ $RESULT -ge 0 ]]; then
+            # cancel stopwatch if error or sucess
+            _cancel_stopwatch
 
-        if [[ ${i} == "${NOF_RETRIES}" ]]; then
-            echoerr "Timeout! Publish could not be finished"
-            echoerr "Image Status:"
-            echoerr "${IMAGE}"
-
-            # Add additional logging context if possible
-            echoerr "Test Results:"
-            # https://catalog.redhat.com/api/containers/docs/endpoints/RESTGetTestResultsById.html
-            get_image not_published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}" | jq -r '.data[]._links.test_results.href' | while read -r TEST_RESULTS_ENDPOINT; do
-                local TEST_RESULTS
-                TEST_RESULTS=$(curl --silent \
-                    --request GET \
-                    --header "X-API-KEY: ${RHEL_API_KEY}" \
-                    "https://catalog.redhat.com/api/containers/${TEST_RESULTS_ENDPOINT}")
-                echoerr "${TEST_RESULTS}"
-            done
-
-            return 42
+            if [[ $RESULT -gt 0 ]]; then
+                echoerr "Image Status:"
+                echoerr "${IMAGE}"
+                print_test_results_on_error "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}"
+            fi
+            return $RESULT
         fi
+
+        # Wait a little before next retry
+        sleep 30
     done
 }
+
+# Prints test result for additional debug info after error
+function print_test_results_on_error() {
+    local RHEL_PROJECT_ID=$1
+    local VERSION=$2
+    local RHEL_API_KEY=$3
+
+    # Add additional logging context if possible
+    echoerr "Test Results:"
+    # https://catalog.redhat.com/api/containers/docs/endpoints/RESTGetTestResultsById.html
+    get_image not_published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}" | jq -r '.data[]._links.test_results.href' | while read -r TEST_RESULTS_ENDPOINT; do
+        local TEST_RESULTS
+        TEST_RESULTS=$(curl --silent \
+            --request GET \
+            --header "X-API-KEY: ${RHEL_API_KEY}" \
+            "https://catalog.redhat.com/api/containers/${TEST_RESULTS_ENDPOINT}")
+        echoerr "${TEST_RESULTS}"
+    done
+}
+
+# Marks unpublished images as deleted for given version and then verifies if they were truly deleted
+function delete_unpublished_images() {
+    local RHEL_PROJECT_ID=$1
+    local VERSION=$2
+    local RHEL_API_KEY=$3
+
+    local IMAGE
+    local IS_PUBLISHED
+
+    UNPUBLISHED_IMAGES=$(get_image not_published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}")
+    UNPUBLISHED_COUNT=$(echo "${UNPUBLISHED_IMAGES}" | jq -r '.total')
+
+    if [[ ${UNPUBLISHED_COUNT} == "0" ]]; then
+        echo "No unpublished images found for ${VERSION}"
+        return 0
+    fi
+
+    # mark images as deleted
+    echo "Found '${UNPUBLISHED_COUNT}' unpublished images for '${VERSION}'"
+    for ((idx = 0 ; idx < $((UNPUBLISHED_COUNT)) ; idx++));
+    do
+        local IMAGE_ID=$(echo "${UNPUBLISHED_IMAGES}" | jq -r .data[${idx}]._id)
+        do_delete_unpublished_images "${RHEL_API_KEY}" "${IMAGE_ID}"
+    done
+
+    # verify we have actually deleted the images. returning explictly to make it clearer
+    return $(verify_no_unpublished_images "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY")
+}
+
+# this will actually send request to delete a single unpublished image
+function do_delete_unpublished_images() {
+    local RHEL_API_KEY=$1
+    local IMAGE_ID=$2
+    echo "Marking image with ID=${IMAGE_ID} as deleted"
+
+    # https://catalog.redhat.com/api/containers/docs/endpoints/RESTPatchImage.html
+    RESPONSE=$( \
+        curl --silent \
+            --request PATCH \
+            --header "accept: application/json" \
+            --header "Content-Type: application/json" \
+            --header "X-API-KEY: ${RHEL_API_KEY}" \
+            --data '{"deleted": true}' \
+            "https://catalog.redhat.com/api/containers/v1/images/id/${IMAGE_ID}")
+
+    # TODO: PUT UNDER DEBUG?
+    #echo "${RESPONSE}"
+}
+
+# verifies there are no unblished images for given version
+function verify_no_unpublished_images() {
+    local RHEL_PROJECT_ID=$1
+    local VERSION=$2
+    local RHEL_API_KEY=$3
+
+    UNPUBLISHED_IMAGES=$(get_image not_published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}")
+    UNPUBLISHED_COUNT=$(echo "${UNPUBLISHED_IMAGES}" | jq -r '.total')
+
+    if [[ ${UNPUBLISHED_COUNT} == "0" ]]; then
+        echo "No unpublished images found for '${VERSION}' after cleanup"
+        return 0
+    fi
+
+    echoerr "Exiting as found '${UNPUBLISHED_COUNT}' unblished images for '${VERSION}'"
+    return 1
+}
+
+# Starts timer with default timeout of 4h. See RedHat ticket https://connect.redhat.com/support/partner-acceleration-desk/#/case/04042093
+# Only use this within this script as only designed for single use for now.
+# The stopwatch funstions start with '_' to denote them as private
+STOPWATCH_PID=-1
+STOPWATCH_DEFAULT_TIMEOUT=4h
+function _start_stopwatch() {
+    local timeout_secs="${1:-$STOPWATCH_DEFAULT_TIMEOUT}"
+    echo "Starting timeout timer for ${timeout_secs}"
+    sleep $timeout_secs &
+    STOPWATCH_PID=$!
+}
+
+# Private function to stop current stopwatch
+function _cancel_stopwatch() {
+    echo "Stoppping timeout timer"
+    kill $STOPWATCH_PID
+    STOPWATCH_PID=-1
+}
+
+# Private function to check if stopwatch timer is still running
+function _is_stopwatch_expired() {
+    ! kill -0 ${STOPWATCH_PID} > /dev/null 2>&1
+}
+

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -312,7 +312,10 @@ function verify_no_unpublished_images() {
         echo "No unpublished images found for '${VERSION}' after cleanup"
         return 0
     else
-        echoerr "Exiting as found '${UNPUBLISHED_COUNT}' unblished images for '${VERSION}'"
+        echoerr "Exiting as found '${UNPUBLISHED_COUNT}' unpublished images for '${VERSION}'"
+        echo_group "Unpublished images"
+        echoerr "${UNPUBLISHED_IMAGES}"
+        echo_group_end
         return 1
     fi
 }

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -72,7 +72,7 @@ wait_for_container_scan()
 
         if _is_stopwatch_expired; then
             RESULT=42
-            echo "Timeout'! Scan could not be finished"
+            echoerr "Timeout'! Scan could not be finished"
         elif [[ ${SCAN_STATUS} == "pending" ]]; then
             echo "Scanning pending, waiting..."
         elif [[ ${SCAN_STATUS} == "in progress" ]]; then
@@ -208,7 +208,7 @@ wait_for_container_publish()
 
         if _is_stopwatch_expired; then
             RESULT=42
-            echo "Timeout! Publish could not be finished"
+            echoerr "Timeout! Publish could not be finished"
         elif [[ ${IS_PUBLISHED} == "1" ]]; then
             RESULT=0
             echo "Image is published, exiting."

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -87,7 +87,7 @@ wait_for_container_scan()
             echoerr "Scan failed with '${SCAN_STATUS}!"
         fi
 
-        if [[ $RESULT -ge 0 ]]; then
+        if [[ ${RESULT} -ge 0 ]]; then
             # cancel stopwatch if error or sucess
             _cancel_stopwatch
 

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -327,12 +327,13 @@ function _start_stopwatch() {
     echo "Starting timeout timer for ${timeout}"
     sleep $timeout &
     STOPWATCH_PID=$!
+    echo "Stopwatch PID=${STOPWATCH_PID}"
 }
 
 # Private function to stop current stopwatch
 function _cancel_stopwatch() {
-    echo "Stoppping stopwatch timer"
-    kill $STOPWATCH_PID > /dev/null 2>&1 || true
+    echo "Stoppping stopwatch timer PID=${STOPWATCH_PID}"
+    kill ${STOPWATCH_PID} > /dev/null 2>&1 || true
     STOPWATCH_PID=-1
 }
 

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -91,10 +91,10 @@ wait_for_container_scan()
             # cancel stopwatch if error or sucess
             _cancel_stopwatch
 
-            if [[ $RESULT -gt 0 ]]; then
+            if [[ ${RESULT} -gt 0 ]]; then
                 echoerr "${IMAGE}"
             fi
-            return $RESULT
+            return ${RESULT}
         fi
 
         # Wait a little before next retry

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -146,6 +146,7 @@ publish_the_image()
             --header 'Content-Type: application/json' \
             --data "{\"image_id\":\"${IMAGE_ID}\" , \"operation\" : \"publish\" }" \
             "https://catalog.redhat.com/api/containers/v1/projects/certification/id/${RHEL_PROJECT_ID}/requests/images")
+
     echo "Response: ${RESPONSE}"
     echo "Created a publish request, please check if the image is published."
 }
@@ -183,6 +184,7 @@ sync_tags()
             --header 'Content-Type: application/json' \
             --data "{\"image_id\":\"${IMAGE_ID}\" , \"operation\" : \"sync-tags\" }" \
             "https://catalog.redhat.com/api/containers/v1/projects/certification/id/${RHEL_PROJECT_ID}/requests/images")
+
     echo "Response: ${RESPONSE}"
     echo "Created a sync-tags request, please check if the tags image are in sync."
 }
@@ -240,6 +242,7 @@ function print_test_results_on_error() {
 
     # Add additional logging context if possible
     echoerr "Test Results:"
+
     # https://catalog.redhat.com/api/containers/docs/endpoints/RESTGetTestResultsById.html
     get_image not_published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}" | jq -r '.data[]._links.test_results.href' | while read -r TEST_RESULTS_ENDPOINT; do
         local TEST_RESULTS
@@ -287,6 +290,7 @@ function do_delete_unpublished_images() {
     # https://catalog.redhat.com/api/containers/docs/endpoints/RESTPatchImage.html
     RESPONSE=$( \
         curl --silent \
+            --retry 5 --retry-all-errors \
             --request PATCH \
             --header "accept: application/json" \
             --header "Content-Type: application/json" \

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -59,7 +59,7 @@ wait_for_container_scan()
     # start timer
     _start_stopwatch
 
-    while [ 1 ]
+    while true
     do
         local IMAGE
         local SCAN_STATUS
@@ -197,7 +197,7 @@ wait_for_container_publish()
     # start timer
     _start_stopwatch
 
-    while [ 1 ]
+    while true
     do
         local IMAGE
         local IS_PUBLISHED

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -264,21 +264,19 @@ function delete_unpublished_images() {
     UNPUBLISHED_IMAGES=$(get_image not_published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}")
     UNPUBLISHED_COUNT=$(echo "${UNPUBLISHED_IMAGES}" | jq -r '.total')
 
-    if [[ ${UNPUBLISHED_COUNT} == "0" ]]; then
-        echo "No unpublished images found for ${VERSION}"
-        return 0
-    fi
+    echo "Found '${UNPUBLISHED_COUNT}' unpublished images for '${VERSION}'"
 
     # mark images as deleted
-    echo "Found '${UNPUBLISHED_COUNT}' unpublished images for '${VERSION}'"
     for ((idx = 0 ; idx < $((UNPUBLISHED_COUNT)) ; idx++));
     do
         local IMAGE_ID=$(echo "${UNPUBLISHED_IMAGES}" | jq -r .data[${idx}]._id)
         do_delete_unpublished_images "${RHEL_API_KEY}" "${IMAGE_ID}"
     done
 
-    # verify we have actually deleted the images. returning explictly to make it clearer
-    verify_no_unpublished_images "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
+    # verify we have actually deleted the images
+    if [[ ${UNPUBLISHED_COUNT} -gt 0 ]]; then
+        verify_no_unpublished_images "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
+    fi
 }
 
 # this will actually send request to delete a single unpublished image

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -285,6 +285,7 @@ function delete_unpublished_images() {
 function do_delete_unpublished_images() {
     local RHEL_API_KEY=$1
     local IMAGE_ID=$2
+
     echo "Marking image with ID=${IMAGE_ID} as deleted"
 
     # https://catalog.redhat.com/api/containers/docs/endpoints/RESTPatchImage.html

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -44,7 +44,6 @@ wait_for_container_scan()
     local RHEL_PROJECT_ID=$1
     local VERSION=$2
     local RHEL_API_KEY=$3
-
     local IMAGE
     local IS_PUBLISHED
 

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -216,16 +216,16 @@ wait_for_container_publish()
             echo "Image is still not published, waiting..."
         fi
 
-        if [[ $RESULT -ge 0 ]]; then
+        if [[ ${RESULT} -ge 0 ]]; then
             # cancel stopwatch if error or sucess
             _cancel_stopwatch
 
-            if [[ $RESULT -gt 0 ]]; then
+            if [[ ${RESULT} -gt 0 ]]; then
                 echoerr "Image Status:"
                 echoerr "${IMAGE}"
                 print_test_results_on_error "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}"
             fi
-            return $RESULT
+            return ${RESULT}
         fi
 
         # Wait a little before next retry

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -72,7 +72,7 @@ wait_for_container_scan()
 
         if _is_stopwatch_expired; then
             RESULT=42
-            echoerr "Timeout'! Scan could not be finished"
+            echoerr "Timeout! Scan could not be finished"
         elif [[ ${SCAN_STATUS} == "pending" ]]; then
             echo "Scanning pending, waiting..."
         elif [[ ${SCAN_STATUS} == "in progress" ]]; then

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -60,6 +60,7 @@ jobs:
         shell: bash
     env:
       SCAN_REGISTRY: "quay.io"
+      TIMEOUT_IN_MINS: 240
       RHEL_API_KEY: ${{ secrets.RHEL_API_KEY }}
       HZ_VERSION: ${{ inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
@@ -213,7 +214,7 @@ jobs:
           VERSION=${RELEASE_VERSION}-jdk${{ matrix.jdk }}
           source .github/scripts/publish-rhel.sh
 
-          wait_for_container_scan "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
+          wait_for_container_scan "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
 
       - name: Set MC version
         run: |
@@ -289,7 +290,7 @@ jobs:
           source .github/scripts/publish-rhel.sh
 
           publish_the_image "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
-          wait_for_container_publish "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
+          wait_for_container_publish "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
           sync_tags "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
 
       - name: Slack notification

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -147,7 +147,7 @@ jobs:
           VERSION=${RELEASE_VERSION}-jdk${{ matrix.jdk }}
           source .github/scripts/publish-rhel.sh
 
-          delete_unpublished_images "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
+          delete_unpublished_images "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}"
 
       - name: Build the Hazelcast Enterprise image
         run: |

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -60,7 +60,6 @@ jobs:
         shell: bash
     env:
       SCAN_REGISTRY: "quay.io"
-      TIMEOUT_IN_MINS: 60
       RHEL_API_KEY: ${{ secrets.RHEL_API_KEY }}
       HZ_VERSION: ${{ inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
@@ -142,6 +141,14 @@ jobs:
           release_version: ${{ env.RELEASE_VERSION }}
           is_lts_override: ${{ inputs.IS_LTS_OVERRIDE }}
 
+      - name: Delete unpublished images
+        if: inputs.DRY_RUN != 'true'
+        run: |
+          VERSION=${RELEASE_VERSION}-jdk${{ matrix.jdk }}
+          source .github/scripts/publish-rhel.sh
+
+          delete_unpublished_images "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
+
       - name: Build the Hazelcast Enterprise image
         run: |
           . .github/scripts/get-tags-to-push.sh 
@@ -206,7 +213,7 @@ jobs:
           VERSION=${RELEASE_VERSION}-jdk${{ matrix.jdk }}
           source .github/scripts/publish-rhel.sh
 
-          wait_for_container_scan "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
+          wait_for_container_scan "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
 
       - name: Set MC version
         run: |
@@ -282,7 +289,7 @@ jobs:
           source .github/scripts/publish-rhel.sh
 
           publish_the_image "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
-          wait_for_container_publish "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
+          wait_for_container_publish "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
           sync_tags "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
 
       - name: Slack notification


### PR DESCRIPTION
**Details**
This fixes RHEL publishing timeout issues raised with RedHat support [ticket](https://connect.redhat.com/support/partner-acceleration-desk/#/case/04042093). RH support confirmed the scan can take anything from a few mins to 3h. To account for this and to make script more robust, this PR introduces the following changes:

1. `delete_unpublished_images()` - deletes all unpublished images for a given version before scanning is requested.  After deletion, the script verifies the images are truly deleted, otherwise fails. We currently have to do this manually from RedHat console so this automates the task
2. Updated `TIMEOUT_IN_MINS` in YML to 240 which equates to 4hrs

**Testing**
I tested this on private 5.4.1 branch which actually got published. As part of testing, I tweaked the code to test failure scenarios as follows:

1. changed `--data '{"deleted": true}'` to `false` in `do_delete_unpublished_images` so unpublished images are not deleted. Subsequently `verify_no_unpublished_images` returned 1 which failed the build as expected
3. finally, reverted all temp change, ran the build to successful completion

**TODO**
- [ ] Backport 5.5.z/5.5.3
- [ ] Backport 5.4.z/5.4.1
- [ ] Backport 5.3.z/5.3.8
- [ ] Should I republish after backport 5.4.1, 5.3.8 and 5.5.3 (coming up so might be tested as part of release)?
- [ ] Close RedHat ticket

Fixes: [DI-401](https://hazelcast.atlassian.net/browse/DI-401)

[DI-401]: https://hazelcast.atlassian.net/browse/DI-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ