### PR TITLE
Delete unpublished RHEL images before publishing [DI-401][5.3.z]

### DIFF
--- a/.github/scripts/logging.functions.sh
+++ b/.github/scripts/logging.functions.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions
+
+# Prints the given message to stderr
+function echoerr() {
+  # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message
+  echo "::error::ERROR - $*" 1>&2;
+}
+
+# Create group
+function echo_group() {
+  # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines
+  local TITLE=$1
+  echo "::group::${TITLE}"
+}
+
+# Ends group after calling echo_group()
+function echo_group_end() {
+  # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines
+  echo "::endgroup::"
+}

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       REQUIRED_HZ_MAJOR_VERSION: 5
       SCAN_REGISTRY: "quay.io"
-      TIMEOUT_IN_MINS: 60
+      TIMEOUT_IN_MINS: 240
       RHEL_API_KEY: ${{ secrets.RHEL_API_KEY }}
       HZ_VERSION: ${{ github.event.inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
@@ -124,6 +124,14 @@ jobs:
       - name: Log in to Red Hat Scan Registry
         run: |
           docker login ${SCAN_REGISTRY} -u ${SCAN_REGISTRY_USER} -p ${SCAN_REGISTRY_PASSWORD}
+
+      - name: Delete unpublished images
+        if: inputs.DRY_RUN != 'true'
+        run: |
+          VERSION=${RELEASE_VERSION}-jdk${{ matrix.jdk }}
+          source .github/scripts/publish-rhel.sh
+
+          delete_unpublished_images "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}"
 
       - name: Build the Hazelcast Enterprise image
         run: |

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -230,7 +230,7 @@ jobs:
 
       - name: Store OpenShift events as artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: openshift-events-jdk${{ matrix.jdk }}.log
           path: openshift-events-jdk${{ matrix.jdk }}.log


### PR DESCRIPTION
Backport https://github.com/hazelcast/hazelcast-docker/pull/868

Also merged `.github/scripts/logging.functions.sh` from master to avoid changing code

1. Tested on [5.3.8](https://github.com/hazelcast/hazelcast-docker/actions/runs/13072124259) first.
2. Updated to `actions/upload-artifact@v4` to fix build failure ([learn](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/))

Fixes: [DI-401](https://hazelcast.atlassian.net/browse/DI-401)

[DI-401]: https://hazelcast.atlassian.net/browse/DI-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ