### PR TITLE
Delete unpublished RHEL images before publishing [DI-401][5.3.8]

### DIFF
--- a/.github/scripts/logging.functions.sh
+++ b/.github/scripts/logging.functions.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions
+
+# Prints the given message to stderr
+function echoerr() {
+  # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message
+  echo "::error::ERROR - $*" 1>&2;
+}
+
+# Create group
+function echo_group() {
+  # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines
+  local TITLE=$1
+  echo "::group::${TITLE}"
+}
+
+# Ends group after calling echo_group()
+function echo_group_end() {
+  # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines
+  echo "::endgroup::"
+}

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail ${RUNNER_DEBUG:+-x}
 
+# shellcheck source=../.github/scripts/logging.functions.sh
+. .github/scripts/logging.functions.sh
+
 get_image()
 {
     local PUBLISHED=$1
@@ -166,4 +169,74 @@ wait_for_container_publish()
             return 42
         fi
     done
+}
+
+# Marks unpublished images as deleted for given version and then verifies if they were truly deleted
+function delete_unpublished_images() {
+    local RHEL_PROJECT_ID=$1
+    local VERSION=$2
+    local RHEL_API_KEY=$3
+
+    local IMAGE
+    local IS_PUBLISHED
+
+    UNPUBLISHED_IMAGES=$(get_image not_published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}")
+    UNPUBLISHED_COUNT=$(echo "${UNPUBLISHED_IMAGES}" | jq -r '.total')
+
+    echo "Found '${UNPUBLISHED_COUNT}' unpublished images for '${VERSION}'"
+
+    # mark images as deleted
+    for ((idx = 0 ; idx < $((UNPUBLISHED_COUNT)) ; idx++));
+    do
+        local IMAGE_ID=$(echo "${UNPUBLISHED_IMAGES}" | jq -r .data[${idx}]._id)
+        delete_image "${RHEL_API_KEY}" "${IMAGE_ID}"
+    done
+
+    # verify we have actually deleted the images
+    if [[ ${UNPUBLISHED_COUNT} -gt 0 ]]; then
+        verify_no_unpublished_images "${RHEL_PROJECT_ID}" "{$VERSION}" "${RHEL_API_KEY}"
+    fi
+}
+
+# this will actually send request to delete a single unpublished image
+function delete_image() {
+    local RHEL_API_KEY=$1
+    local IMAGE_ID=$2
+
+    echo "Marking image with ID=${IMAGE_ID} as deleted"
+
+    # https://catalog.redhat.com/api/containers/docs/endpoints/RESTPatchImage.html
+    RESPONSE=$( \
+        curl --silent \
+            --retry 5 --retry-all-errors \
+            --request PATCH \
+            --header "accept: application/json" \
+            --header "Content-Type: application/json" \
+            --header "X-API-KEY: ${RHEL_API_KEY}" \
+            --data '{"deleted": true}' \
+            "https://catalog.redhat.com/api/containers/v1/images/id/${IMAGE_ID}")
+
+    echo "::debug::HTTP response after image deletion"
+    echo "::debug::${RESPONSE}"
+}
+
+# verifies there are no unblished images for given version
+function verify_no_unpublished_images() {
+    local RHEL_PROJECT_ID=$1
+    local VERSION=$2
+    local RHEL_API_KEY=$3
+
+    UNPUBLISHED_IMAGES=$(get_image not_published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}")
+    UNPUBLISHED_COUNT=$(echo "${UNPUBLISHED_IMAGES}" | jq -r '.total')
+
+    if [[ ${UNPUBLISHED_COUNT} == "0" ]]; then
+        echo "No unpublished images found for '${VERSION}' after cleanup"
+        return 0
+    else
+        echoerr "Exiting as found '${UNPUBLISHED_COUNT}' unpublished images for '${VERSION}'"
+        echo_group "Unpublished images"
+        echoerr "${UNPUBLISHED_IMAGES}"
+        echo_group_end
+        return 1
+    fi
 }

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Store docker logs as artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-logs
           path: |
@@ -112,7 +112,7 @@ jobs:
 
       - name: Store docker logs as artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-logs-jdk${{ matrix.jdk }}
           path: |

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -223,7 +223,7 @@ jobs:
 
       - name: Store OpenShift events as artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: openshift-events-jdk${{ matrix.jdk }}.log
           path: openshift-events-jdk${{ matrix.jdk }}.log

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       REQUIRED_HZ_MAJOR_VERSION: 5
       SCAN_REGISTRY: "quay.io"
-      TIMEOUT_IN_MINS: 60
+      TIMEOUT_IN_MINS: 240
       HZ_ENTERPRISE_LICENSE: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
       OCP_LOGIN_USERNAME: ${{ secrets.OCP_LOGIN_USERNAME }}
       OCP_LOGIN_PASSWORD: ${{ secrets.OCP_LOGIN_PASSWORD }}
@@ -113,6 +113,14 @@ jobs:
       - name: Log in to Red Hat Scan Registry
         run: |
           docker login ${SCAN_REGISTRY} -u ${SCAN_REGISTRY_USER} -p ${SCAN_REGISTRY_PASSWORD}
+
+      - name: Delete unpublished images
+        if: inputs.DRY_RUN != 'true'
+        run: |
+          VERSION=${RELEASE_VERSION}-jdk${{ matrix.jdk }}
+          source .github/scripts/publish-rhel.sh
+
+          delete_unpublished_images "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}"
 
       - name: Build the Hazelcast Enterprise image
         run: |


### PR DESCRIPTION
Backport https://github.com/hazelcast/hazelcast-docker/pull/868

Also merged `.github/scripts/logging.functions.sh` from master to avoid changing code

1. Tested on [5.3.8](https://github.com/hazelcast/hazelcast-docker/actions/runs/13072124259) first.
2. Updated to `actions/upload-artifact@v4` to fix build failure ([learn](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/))
3. [update actions/upload-artifact@v4 to fix PR builder](https://github.com/hazelcast/hazelcast-docker/pull/875/commits/791d925156ab34b9b850f31aa6202c879d1f96d2)

**TODO:** Update v5.3.8 tag as per [Slack](https://hazelcast.slack.com/archives/C05LM8B80UT/p1736500817490519?thread_ts=1736438770.790189&cid=C05LM8B80UT)

Fixes: [DI-401](https://hazelcast.atlassian.net/browse/DI-401)

[DI-401]: https://hazelcast.atlassian.net/browse/DI-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ