### PR TITLE
Remove redundant `sed` in RHEL `smoke-test.sh`

### DIFF
--- a/.github/scripts/smoke-test.sh
+++ b/.github/scripts/smoke-test.sh
@@ -28,7 +28,6 @@ helm repo update
 
 sed -i "s|SCAN_REPOSITORY|\"${SCAN_REPOSITORY}\"|g" ${WORKDIR}/values.yaml
 sed -i "s/RELEASE_VERSION/\"${RELEASE_VERSION}\"/g" ${WORKDIR}/values.yaml
-sed -i "s/PULL_SECRET/hz-pull-secret/g" ${WORKDIR}/values.yaml
 sed -i "s/HAZELCAST_CLUSTER_SIZE/${HAZELCAST_CLUSTER_SIZE}/g" ${WORKDIR}/values.yaml
 sed -i "s/HZ_ENTERPRISE_LICENSE/${HZ_ENTERPRISE_LICENSE}/g" ${WORKDIR}/values.yaml
 sed -i "s/HZ_MC_VERSION/\"${HZ_MC_VERSION}\"/g" ${WORKDIR}/values.yaml

--- a/.github/scripts/values.yaml
+++ b/.github/scripts/values.yaml
@@ -3,7 +3,7 @@ image:
   tag: RELEASE_VERSION
   pullPolicy: Always
   pullSecrets:
-    - PULL_SECRET
+    - hz-pull-secret
 cluster:
   memberCount: HAZELCAST_CLUSTER_SIZE
 hazelcast:


### PR DESCRIPTION
The RHEL `smoke-test.sh` overwrites placeholder values with dynamically computed ones (secrets etc) - but one of these values is actually a hardcoded replacement (`PULL_SECRET` -> `hz-pull-secret`) so might as well be hardcoded to the correct value.