### PR TITLE
Upgrade `upload-artifact` from a non-deprecated version [DI-421]

### DIFF
--- a/.github/workflows/ee-nlc-snapshot-push.yml
+++ b/.github/workflows/ee-nlc-snapshot-push.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Store docker logs as artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-logs-jdk${{ matrix.jdk }}
           path: |

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Store docker logs as artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-logs-jdk${{ matrix.jdk }}
           path: |

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Store docker logs as artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-logs${{ env.SUFFIX }}-jdk${{ matrix.jdk }}
           path: |

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Store docker logs as artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-logs${{ env.SUFFIX }}-jdk${{ matrix.jdk }}
           path: |


### PR DESCRIPTION
(`5.3` builds are failing](https://github.com/hazelcast/hazelcast-docker/actions/runs/13172853058):
> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/