### PR TITLE
Upgrade `upload-artifact` from a non-deprecated version #2 [DI-421][5.3.8]

### DIFF
--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Store docker logs as artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-logs${{ matrix.suffix }}-jdk${{ matrix.jdk }}
           path: | 


### PR DESCRIPTION
When the original fix was cherry-picked into `5.3.8` - https://github.com/hazelcast/hazelcast-docker/pull/878 - an additional usage - _only present in `5.3.8` - was missed.