### PR TITLE
Ensure RHEL tests use a valid version of Management Center [DI-422]

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -216,9 +216,15 @@ jobs:
 
           wait_for_container_scan "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
 
-      - name: Set MC version
+      - name: Set Management Center Version to be used in the tests
         run: |
-          echo "HZ_MC_VERSION=${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}" >> $GITHUB_ENV
+          # Find the latest, non BETA or otherwise suffix-ed tag in the repo
+          LATEST_TAG=$(gh api repos/hazelcast/management-center/tags \
+            --paginate \
+            --jq '[.[].name | select(test("^v'"${HZ_MAJOR_VERSION}"'") and (test("BETA") | not) and (test("-") | not))] | sort | last' \
+          )
+          echo ${LATEST_TAG}
+          echo "HZ_MC_VERSION=${LATEST_TAG:1}" >> $GITHUB_ENV
 
       - uses: redhat-actions/oc-login@v1
         with:
@@ -233,16 +239,16 @@ jobs:
         run: |
           WORKDIR=$(pwd)/.github/scripts
           .github/scripts/smoke-test.sh \
-                        "$WORKDIR" \
-                        "$PROJECT_NAME"  \
-                        "$SCAN_REGISTRY_USER" \
-                        "$SCAN_REGISTRY_PASSWORD" \
-                        "$SCAN_REPOSITORY" \
-                        "$RELEASE_VERSION" \
-                        "$CLUSTER_SIZE" \
-                        "$HZ_ENTERPRISE_LICENSE" \
-                        "$HZ_MC_VERSION" \
-                        "$SCAN_REGISTRY"
+                        "${WORKDIR}" \
+                        "${PROJECT_NAME}"  \
+                        "${SCAN_REGISTRY_USER}" \
+                        "${SCAN_REGISTRY_PASSWORD}" \
+                        "${SCAN_REPOSITORY}" \
+                        "${RELEASE_VERSION}" \
+                        "${CLUSTER_SIZE}" \
+                        "${HZ_ENTERPRISE_LICENSE}" \
+                        "${HZ_MC_VERSION}" \
+                        "${SCAN_REGISTRY}"
 
         env:
           CLUSTER_SIZE: 3


### PR DESCRIPTION
The RHEL publish tests the build by connecting an Management Center instance to it.

In https://github.com/hazelcast/hazelcast-docker/pull/847 this was changed to use a _matching_ version of Hazelcast & Management Center - which isn't correct in all cases (e.g. `5.5.2` Hazelcast & `5.6.0` Management Center)

Before this change, it used the latest version of Management Center - derived by inspecting the tags of the (archived) https://github.com/hazelcast/management-center-openshift repo - but the last tag here was `5.3.2` so it wasn't really the latest at all.

In [consultation with the Management Center team](https://hazelcast.slack.com/archives/C9S7BV74Z/p1738850975557879), latest is the best option.

Changes:
- rolls back to something _inspired_ by the previous implementation - choses latest based on tags
- tags are scraped from the `hazelcast/management-center` repo
- tags are queried using the `gh` cli tool to avoid checking out the whole repo

I don't think we should backport this change, as while it's not correct in earlier versions, it doesn't cause an issues.

Fixes: [DI-422](https://hazelcast.atlassian.net/browse/DI-422)