### PR TITLE
Increase verbosity of RHEL logging artifacts [DI-424]

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -266,17 +266,18 @@ jobs:
         env:
           CLUSTER_SIZE: 3
 
-      - name: Get OpenShift events
+      - name: Get OpenShift logs
         if: inputs.DRY_RUN != 'true'
         run: |
-          kubectl get events -n ${PROJECT_NAME} > openshift-events-jdk${{ matrix.jdk }}.log
+          kubectl get events -n ${PROJECT_NAME} > events.log
+          kubectl describe pods > pods.log
 
-      - name: Store OpenShift events as artifact
+      - name: Store OpenShift logs as artifact
         if: inputs.DRY_RUN != 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: openshift-events-${{ github.job }}-jdk${{ matrix.jdk }}.log
-          path: openshift-events-${{ github.job }}-jdk${{ matrix.jdk }}.log
+          name: openshift-logs-${{ github.job }}-jdk${{ matrix.jdk }}
+          path: '*.log'
 
       - name: Clean up After Test
         if: inputs.DRY_RUN != 'true'


### PR DESCRIPTION
The [RHEL builds are intermittently failing](https://github.com/hazelcast/hazelcast-docker/actions/runs/13279148921) with:
> Waiting for test-13279148921-1-21-hazelcast-enterprise-mancenter-0 pod to be ready
error: timed out waiting for the condition on pods/test-13279148921-1-21-hazelcast-enterprise-mancenter-0

But while we are recording it wasn't ready, we aren't capturing _why_ it wasn't ready (e.g. `kubectl describe pods`).

Changes:
- [Log output of `kubectl describe pods`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_describe/)
- Capture _all_ log files into the artefact bundle (we also get the preflight logs for free this way)
 
[Example execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/13282820070):
<img width="529" alt="image" src="https://github.com/user-attachments/assets/4479c437-bd94-4469-8a65-a89ec7d3f95c" />
<img width="327" alt="image" src="https://github.com/user-attachments/assets/74c8413e-d2e1-42e8-af68-ddba46e68b37" />


Fixes: [DI-424](https://hazelcast.atlassian.net/browse/DI-424)

Post-merge actions:
- [ ] backport
- [ ] retag

[DI-424]: https://hazelcast.atlassian.net/browse/DI-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ