### PR TITLE
Fix `get-tags-to-push.sh` on OSX/ZSH

### DIFF
--- a/.github/scripts/get-tags-to-push.sh
+++ b/.github/scripts/get-tags-to-push.sh
@@ -22,7 +22,7 @@ function get_version_only_tags_to_push() {
     exit 1;
   fi
 
-  if [[ "$VERSION_TO_RELEASE" =~ .*(BETA|DEVEL).* ]]; then
+  if [[ "$VERSION_TO_RELEASE" =~ BETA|DEVEL ]]; then
     echo "$VERSION_TO_RELEASE"
     return
   fi

--- a/.github/scripts/get-tags-to-push.sh
+++ b/.github/scripts/get-tags-to-push.sh
@@ -22,7 +22,7 @@ function get_version_only_tags_to_push() {
     exit 1;
   fi
 
-  if [[ "$VERSION_TO_RELEASE" =~ .*BETA.*|.*DEVEL.* ]]; then
+  if [[ "$VERSION_TO_RELEASE" =~ .*(BETA|DEVEL).* ]]; then
     echo "$VERSION_TO_RELEASE"
     return
   fi


### PR DESCRIPTION
On OSX/ZSH:
```
% . .github/scripts/get-tags-to-push.sh
.github/scripts/get-tags-to-push.sh:24: parse error near `|'
```

[Escaping resolves this](https://stackoverflow.com/a/69099779).

(Covered by unit tests)