### PR TITLE
Fix `tag_image_push` for `push` triggers

### DIFF
--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -129,22 +129,18 @@ jobs:
       HZ_VERSION: ${{ inputs.HZ_VERSION }}
       RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
     steps:
+      - name: Set HZ version as environment variable
+        if: env.HZ_VERSION == ''
+        run: |
+          echo "HZ_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
+
+      - name: Set Release version as environment variable
+        if: env.RELEASE_VERSION == ''
+        run: |
+          echo "RELEASE_VERSION=${{ env.HZ_VERSION }}" >> $GITHUB_ENV
+
       - name: Set environment variables
         run: |
-          if [ -z "${{ env.HZ_VERSION }}" ]; then
-             HZ_VERSION=${GITHUB_REF:11}
-          else
-             HZ_VERSION=${{ env.HZ_VERSION }}
-          fi
-          echo "HZ_VERSION=${HZ_VERSION}" >> $GITHUB_ENV
-          
-          if [ -z "${{ env.RELEASE_VERSION }}" ]; then
-             RELEASE_VERSION=${{ env.HZ_VERSION }}
-          else
-             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
-          fi
-          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
-
           if [ -n "${{ matrix.variant }}" ]; then
             SUFFIX=-${{ matrix.variant }}
           else


### PR DESCRIPTION
The issue described in https://github.com/hazelcast/hazelcast-docker/pull/846 _also_ affects `tag_image_push`.

Specifically, when run on `push`, `RELEASE_VERSION` is empty - because it gets it value set to `${{ env.HZ_VERSION }}` which is _pre-parsed_ as an empty value and not updated when we update `HZ_VERSION` earlier.

This caused [release failures in `5.5.3`](https://github.com/hazelcast/hazelcast-docker/actions/runs/13286584060).

Post merge actions:
- [ ] backport