### PR TITLE
Fix `test_published_images.yml`

### DIFF
--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -34,6 +34,8 @@ jobs:
       distribution-type-matrix: ${{ steps.set-matrix.outputs.distribution-type-matrix }}
       jdk-image-variants-matrix: ${{ steps.set-matrix.outputs.jdk-image-variants-matrix }}
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
       - name: Parse input into matrix
         id: set-matrix
         run: |


### PR DESCRIPTION
Script was broken in https://github.com/hazelcast/hazelcast-docker/pull/842 where centralised function was being used without actually having the code checked out.