### PR TITLE
Add application logs to RHEL action logging [DI-430]

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -272,6 +272,9 @@ jobs:
         run: |
           kubectl get events -n "${PROJECT_NAME}" > events.log
           kubectl describe pods > pods.log
+          kubectl get pods -n "${PROJECT_NAME}" --output json | jq -r '.items[].metadata.name' | while read pod; do
+             kubectl logs --all-containers "${pod}" -n "${PROJECT_NAME}" > "${pod}.log"
+          done      
 
       - name: Store OpenShift logs as artifact
         if: inputs.DRY_RUN != 'true'


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-docker/pull/883 we tried to gather more information on the status of the not-ready pod, but all we logged was:

```
  Normal   Pulled                  4m22s                  kubelet                  Successfully pulled image "registry.connect.redhat.com/hazelcast/management-center-5-rhel8:5.3.2" in 336ms (336ms including waiting). Image size: 1080645698 bytes.
  Warning  Unhealthy               3m30s (x6 over 4m50s)  kubelet                  Liveness probe failed: Get "http://10.129.3.146:8081/health": dial tcp 10.129.3.146:8081: connect: connection refused
  Normal   Killing                 3m30s (x2 over 4m30s)  kubelet                  Container test-13372462224-1-17-hazelcast-enterprise-mancenter failed liveness probe, will be restarted
  Normal   Pulling                 3m22s (x3 over 5m29s)  kubelet                  Pulling image "registry.connect.redhat.com/hazelcast/management-center-5-rhel8:5.3.2"
  Warning  Unhealthy               20s (x22 over 4m50s)   kubelet                  Readiness probe failed: dial tcp 10.129.3.146:8080: connect: connection refused
```

Hopefully, capturing the _application_ logs will tell us _why_.

[Example execution output](https://github.com/hazelcast/hazelcast-docker/actions/runs/13373694052):
<img width="358" alt="image" src="https://github.com/user-attachments/assets/e1bd007a-95a9-4257-93bc-889eec042a4e" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/1f309aef-86ca-4a23-845a-b2547f79321b" />

Fixes: [DI-430](https://hazelcast.atlassian.net/browse/DI-430)

Post-merge actions:
- [ ] backport
- [ ] retag

[DI-430]: https://hazelcast.atlassian.net/browse/DI-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ