### PR TITLE
Increase RHEL testing MC startup timeout [DI-435]

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -268,7 +268,7 @@ jobs:
           verify_cluster_size $CLUSTER_SIZE
 
           echo "Waiting for ${PROJECT_NAME}-${NAME}-mancenter-0 pod to be ready"
-          oc wait --for=condition=Ready --timeout=120s pod "${PROJECT_NAME}-${NAME}-mancenter-0"
+          oc wait --for=condition=Ready --timeout=300s pod "${PROJECT_NAME}-${NAME}-mancenter-0"
 
           verify_management_center $CLUSTER_SIZE
         env:


### PR DESCRIPTION
When testing RHEL images, [the tests often fail](https://github.com/hazelcast/hazelcast-docker/actions/workflows/tag_image_push_rhel.yml), most recently because the MC pod failed to start in time:
> error: timed out waiting for the condition on pods/test-13631969388-1-17-hazelcast-enterprise-mancenter-0

```
Conditions:
  Type                        Status
  PodReadyToStartContainers   True 
  Initialized                 True 
  Ready                       False 
  ContainersReady             False 
  PodScheduled                True 
{...}
  Warning  Unhealthy               2m13s (x6 over 4m13s)   kubelet                  Liveness probe failed: Get "http://10.131.0.66:8081/health": dial tcp 10.131.0.66:8081: connect: connection refused
```

I've done [lots of investigation to try to get more information](https://hazelcast.atlassian.net/browse/DI-435) without any success, but what I _have_ noticed is that even on [successful tests](https://github.com/hazelcast/hazelcast-docker/actions/runs/13631962459), we still have multiple failures before MC is up-and-running:
```
Conditions:
  Type                        Status
  PodReadyToStartContainers   True 
  Initialized                 True 
  Ready                       True 
  ContainersReady             True 
  PodScheduled                True 
{...}
  Warning  Unhealthy               101s (x2 over 111s)  kubelet                  Liveness probe failed: Get "http://10.131.0.61:8081/health": dial tcp 10.131.0.61:8081: connect: connection refused
```

My _assumption_ is that the timeout is too low (in fact, the timeout doesn't make sense at all due to the flakey nature) and as such the build failures are arbitrary - which increasing the timeout _partially_ addresses.

Fixes: [DI-435](https://hazelcast.atlassian.net/browse/DI-435)

Post-merge actions:
- [ ] backport
- [ ] retag

[DI-435]: https://hazelcast.atlassian.net/browse/DI-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ