### PR TITLE
Fix `README` `Management Center Hello World` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Whether you started the Hazelcast or Hazelcast Enterprise cluster, you could use
 
 ```
 docker run \
-  -e MC_INIT_CMD="./mc-conf.sh cluster add -H=/data -ma <host_ip>:5701 -cn dev" \
+  -e MC_INIT_CMD=".bin/hz-mc conf cluster add -H=/data -ma <host_ip>:5701 -cn dev" \
   -p 8080:8080 hazelcast/management-center:$MANAGEMENT_CENTER_VERSION
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Whether you started the Hazelcast or Hazelcast Enterprise cluster, you could use
 
 ```
 docker run \
-  -e MC_INIT_CMD=".bin/hz-mc conf cluster add -H=/data -ma <host_ip>:5701 -cn dev" \
+  -e MC_INIT_CMD="./bin/hz-mc conf cluster add -H=/data -ma <host_ip>:5701 -cn dev" \
   -p 8080:8080 hazelcast/management-center:$MANAGEMENT_CENTER_VERSION
 ```
 


### PR DESCRIPTION
When the current command is run:
```
/opt/hazelcast/management-center/bin/hz-mc: line 97: ./mc-conf.sh: No such file or directory
```

Updated to use new location, and avoids deprecated `mc-conf.sh` as well (https://github.com/hazelcast/hazelcast-docker/issues/909).

Example successful output:
```
Executing command specified by MC_INIT_CMD.
Successfully added Cluster Config.
+ exec java -server -Dloader.path=/opt/hazelcast/management-center/bin/user-lib --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED -Dhazelcast.mc.home=/data -Djava.net.preferIPv4Stack=true -XX:+UseContainerSupport -XX:MaxRAMPercentage=80 -cp /opt/hazelcast/management-center/bin/../hazelcast-management-center-5.7.1.jar org.springframework.boot.loader.launch.PropertiesLauncher
```

Fixes: https://github.com/hazelcast/hazelcast-docker/issues/909