### PR TITLE
Increase instance size used for RHEL tests [DI-435]

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -67,7 +67,8 @@ jobs:
       RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
       PROJECT_NAME: test-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.jdk }}
 
-    runs-on: ubuntu-latest
+    # Deliberately use a faster instance to avoids timeouts during smoke test
+    runs-on: ubicloud-standard-4
     needs: jdks
     strategy:
       fail-fast: false


### PR DESCRIPTION
The RHEL smoke test regularly fails due to:
> error: timed out waiting for the condition on pods/test-13631969388-1-17-hazelcast-enterprise-mancenter-0

After extensive investigation, I _believe_ the root cause is an inadequate instance size.

Specifically, my hypothesis is:
- MC [regularly takes ~30 seconds to start, even if ultimately successful](https://github.com/hazelcast/hazelcast-docker/actions/runs/13631962459) on our current instances - locally this is <5 seconds
- In the Helm chart, [we allow 30 seconds before beginning liveness probes](https://github.com/hazelcast/charts/blob/7cf90413100187335332ebccefd58781873fd696/stable/hazelcast-enterprise/values.yaml#L499)
- If a liveness probe fails (i.e. it's still starting), the instance is restarted
- This leads to regular MC test instance restarts - normally eventually _an_ invocation starts up quick enough, but sometimes not.

Due to this transient behaviour it's difficult to be certain, but tested:
- with the existing runner, [failed after 3 re-runs](https://github.com/hazelcast/hazelcast-docker/actions/runs/13783658071/job/38574527022)
- with a faster runner, [did not fail _with this error_ after 8 re-runs](https://github.com/hazelcast/hazelcast-docker/actions/runs/13792764938)

Fixes: [DI-435](https://hazelcast.atlassian.net/browse/DI-435)

Post-merge:
- [ ] backport
- [ ] retag