### PR TITLE
Revert "Increase instance size used for RHEL tests [DI-435]"

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -67,8 +67,7 @@ jobs:
       RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
       PROJECT_NAME: test-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.jdk }}
 
-    # Deliberately use a faster instance to avoid timeouts during smoke test
-    runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     needs: jdks
     strategy:
       fail-fast: false


### PR DESCRIPTION
Reverts hazelcast/hazelcast-docker#917

Despite testing being unable to reproduce the issue, as soon as merged [it failed in the same way as before](https://github.com/hazelcast/hazelcast-docker/actions/runs/13858020706) showing this fix does nothing.