### PR TITLE
Remove shebang from `functions` scripts

### DIFF
--- a/.github/scripts/build.functions.sh
+++ b/.github/scripts/build.functions.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -euo pipefail ${RUNNER_DEBUG:+-x}
 
 # Checks if we should build the OSS docker image.

--- a/.github/scripts/docker.functions.sh
+++ b/.github/scripts/docker.functions.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 function get_default_jdk() {
   local DIR=$1
   awk -F= '/^ARG JDK_VERSION=/{print $2}' "$DIR/Dockerfile" | tr -d '"'

--- a/.github/scripts/ee-build.functions.sh
+++ b/.github/scripts/ee-build.functions.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -euo pipefail ${RUNNER_DEBUG:+-x}
 
 # This is a simple script imitating what maven does for snapshot versions. We are not using maven because currently Docker Buildx and QEMU on Github Actions

--- a/.github/scripts/log.functions.sh
+++ b/.github/scripts/log.functions.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 if command -v tput &>/dev/null && tty -s; then
   RED=$(tput setaf 1)
   GREEN=$(tput setaf 2)

--- a/.github/scripts/logging.functions.sh
+++ b/.github/scripts/logging.functions.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions
 
 # Prints the given message to stderr

--- a/.github/scripts/oss-build.functions.sh
+++ b/.github/scripts/oss-build.functions.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -euo pipefail ${RUNNER_DEBUG:+-x}
 
 function get_hz_dist_zip() {

--- a/.github/scripts/version.functions.sh
+++ b/.github/scripts/version.functions.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 function get_supported_versions() {
     local MINIMAL_VERSION=$1
     git tag | sort -V | grep '^v' | cut -c2- | sed -n "/^${MINIMAL_VERSION}.*\$/,\$p" | grep -v BETA | grep -v DEVEL

--- a/hazelcast-enterprise/maven.functions.sh
+++ b/hazelcast-enterprise/maven.functions.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -euo pipefail ${RUNNER_DEBUG:+-x}
 
 # THIS FILE IS DUPLICATED AND MUST BE KEPT IN SYNC MANUALLY

--- a/hazelcast-oss/maven.functions.sh
+++ b/hazelcast-oss/maven.functions.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -euo pipefail ${RUNNER_DEBUG:+-x}
 
 # THIS FILE IS DUPLICATED AND MUST BE KEPT IN SYNC MANUALLY


### PR DESCRIPTION
These scripts are never called directly and instead are `source`d during other scripts executions - as such we should be trusting the parent executions shell declaration rather than overriding it.