### PR TITLE
Centralise supported maintenance branch definition _within `hazelcast-docker`_ [DI-349]

### DIFF
--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -2,6 +2,10 @@ name: Check base images
 
 on:
   workflow_dispatch:
+    inputs:
+      MINIMAL_SUPPORTED_VERSION:
+        description: 'Minimal supported version from which we should start checking images, e.g. 5.1, 5.0.1, 4.2.3. Default derived from supported maintenance versions'
+        required: false
   schedule:
     - cron: '0 6 * * *'
 
@@ -15,19 +19,22 @@ jobs:
     needs: get-maintenance-versions
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+    env:
+      MINIMAL_SUPPORTED_VERSION: ${{ inputs.MINIMAL_SUPPORTED_VERSION }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Calculate minimal supported version
-        run: echo "MINIMAL_SUPPORTED_VERSION=$(echo '${{ needs.get-maintenance-versions.outputs.versions }}' | jq '.[0]')" >> $GITHUB_ENV
+        run: echo "DEFAULT_MINIMAL_SUPPORTED_VERSION=$(echo '${{ needs.get-maintenance-versions.outputs.versions }}' | jq '.[0]')" >> $GITHUB_ENV
       - id: set-matrix
         name: Get latest patch versions
         run: |
           . .github/scripts/version.functions.sh
-          echo "Getting latest patch versions starting from ${MINIMAL_SUPPORTED_VERSION}"
-          versions=$(printf '%s\n' $(get_latest_patch_versions "${MINIMAL_SUPPORTED_VERSION}") | jq -R . | jq -c -s .)
+          MIN_VERSION=${MINIMAL_SUPPORTED_VERSION:-$DEFAULT_MINIMAL_SUPPORTED_VERSION}
+          echo "Getting latest patch versions starting from $MIN_VERSION"
+          versions=$(printf '%s\n' $(get_latest_patch_versions "${MIN_VERSION}") | jq -R . | jq -c -s .)
           echo "Found latest patch versions: $versions"
           echo "matrix={\"version\":$versions}" >> $GITHUB_OUTPUT
       - name: Slack notification

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -2,22 +2,30 @@ name: Check base images
 
 on:
   workflow_dispatch:
-    inputs:
-      MINIMAL_SUPPORTED_VERSION:
-        description: 'Minimal supported version from which we should start checking images, e.g. 5.1, 5.0.1, 4.2.3. Default values is 5.3'
-        required: false
   schedule:
     - cron: '0 6 * * *'
 
 jobs:
+  get-maintenance-versions:
+      uses: ./.github/workflows/get-supported-maintenance-versions.yaml
+
+  get-minimal-version:
+    runs-on: ubuntu-latest
+    needs: get-maintenance-versions
+    outputs:
+      minimal: ${{ steps.get-first.outputs.minimal }}
+    steps:
+      - id: get-first
+        run: echo "minimal=$(echo '${{ needs.get-maintenance-versions.outputs.versions }}' | jq '.[0]')" >> ${GITHUB_OUTPUT}
+
   get-latest-patch-versions:
     runs-on: ubuntu-latest
     name: Get latest patch versions
+    needs: get-minimal-version
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     env:
-      MINIMAL_SUPPORTED_VERSION: ${{ inputs.MINIMAL_SUPPORTED_VERSION }}
-      DEFAULT_MINIMAL_SUPPORTED_VERSION: 5.3
+      MINIMAL_SUPPORTED_VERSION: ${{ needs.get-minimal-version.outputs.minimal }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -27,9 +35,8 @@ jobs:
         name: Get latest patch versions
         run: |
           . .github/scripts/version.functions.sh
-          MIN_VERSION=${MINIMAL_SUPPORTED_VERSION:-$DEFAULT_MINIMAL_SUPPORTED_VERSION}
-          echo "Getting latest patch versions starting from $MIN_VERSION"
-          versions=$(printf '%s\n' $(get_latest_patch_versions "${MIN_VERSION}") | jq -R . | jq -c -s .)
+          echo "Getting latest patch versions starting from ${MINIMAL_SUPPORTED_VERSION}"
+          versions=$(printf '%s\n' $(get_latest_patch_versions "${MINIMAL_SUPPORTED_VERSION}") | jq -R . | jq -c -s .)
           echo "Found latest patch versions: $versions"
           echo "matrix={\"version\":$versions}" >> $GITHUB_OUTPUT
       - name: Slack notification

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -7,30 +7,21 @@ on:
 
 jobs:
   get-maintenance-versions:
-      uses: ./.github/workflows/get-supported-maintenance-versions.yaml
-
-  get-minimal-version:
-    runs-on: ubuntu-latest
-    needs: get-maintenance-versions
-    outputs:
-      minimal: ${{ steps.get-first.outputs.minimal }}
-    steps:
-      - id: get-first
-        run: echo "minimal=$(echo '${{ needs.get-maintenance-versions.outputs.versions }}' | jq '.[0]')" >> ${GITHUB_OUTPUT}
+    uses: ./.github/workflows/get-supported-maintenance-versions.yaml
 
   get-latest-patch-versions:
     runs-on: ubuntu-latest
     name: Get latest patch versions
-    needs: get-minimal-version
+    needs: get-maintenance-versions
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-    env:
-      MINIMAL_SUPPORTED_VERSION: ${{ needs.get-minimal-version.outputs.minimal }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Calculate minimal supported version
+        run: echo "MINIMAL_SUPPORTED_VERSION=$(echo '${{ needs.get-maintenance-versions.outputs.versions }}' | jq '.[0]')" >> $GITHUB_ENV
       - id: set-matrix
         name: Get latest patch versions
         run: |

--- a/.github/workflows/get-supported-maintenance-versions.yaml
+++ b/.github/workflows/get-supported-maintenance-versions.yaml
@@ -1,0 +1,15 @@
+name: Get supported maintenance versions
+
+on:
+  workflow_call:
+    outputs:
+      versions:
+        value: ${{ jobs.get-maintenance-versions.outputs.versions }}
+
+jobs:
+  get-maintenance-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: "['5.3', '5.4', '5.5']"
+    steps:
+      - run: exit 0

--- a/.github/workflows/scheduled_vulnerability_scan.yml
+++ b/.github/workflows/scheduled_vulnerability_scan.yml
@@ -9,23 +9,18 @@ jobs:
     get-maintenance-versions:
         uses: ./.github/workflows/get-supported-maintenance-versions.yaml
 
-    get-maintenance-branches:
-        runs-on: ubuntu-latest
-        needs: get-maintenance-versions
-        outputs:
-            branches: ${{ steps.branches.outputs.maintenance_branches }}
-        steps:
-          - id: branches
-            run: echo "maintenance_branches=$(echo '${{ needs.get-maintenance-versions.outputs.versions }}' | jq --compact-output 'map(. | tostring + ".z")')" >> ${GITHUB_OUTPUT}
-
     get-branches-to-scan:
         runs-on: ubuntu-latest
-        needs: get-maintenance-branches
+        needs: get-maintenance-versions
         outputs:
             branches: ${{ steps.branches.outputs.branches }}
         steps:
           - id: branches
-            run: echo "branches=$(echo '${{ needs.get-maintenance-branches.outputs.branches }}' | jq --compact-output '. as $b | ["master"] + $b')" >> ${GITHUB_OUTPUT}
+            run: |
+                # Convert maintenance versions -> Docker branches
+                maintenance_branches=$(jq --compact-output 'map(. | tostring + ".z")' <<< '${{ needs.get-maintenance-versions.outputs.versions }}')
+                # Add `master`, too
+                echo "branches=$(jq --compact-output '. as $b | ["master"] + $b' <<< "$maintenance_branches")" >> ${GITHUB_OUTPUT}
 
     trigger-vulnerability-scan:
         needs: get-branches-to-scan

--- a/.github/workflows/scheduled_vulnerability_scan.yml
+++ b/.github/workflows/scheduled_vulnerability_scan.yml
@@ -17,10 +17,8 @@ jobs:
         steps:
           - id: branches
             run: |
-                # Convert maintenance versions -> Docker branches
-                maintenance_branches=$(jq --compact-output 'map(. | tostring + ".z")' <<< '${{ needs.get-maintenance-versions.outputs.versions }}')
-                # Add `master`, too
-                echo "branches=$(jq --compact-output '. as $b | ["master"] + $b' <<< "$maintenance_branches")" >> ${GITHUB_OUTPUT}
+                # Convert maintenance versions -> Docker branches, and check `master`, too
+                echo "branches=$(jq --compact-output 'map(. | tostring + ".z")  + ["master"]' <<< '${{ needs.get-maintenance-versions.outputs.versions }}')" >> ${GITHUB_OUTPUT}
 
     trigger-vulnerability-scan:
         needs: get-branches-to-scan

--- a/.github/workflows/scheduled_vulnerability_scan.yml
+++ b/.github/workflows/scheduled_vulnerability_scan.yml
@@ -6,12 +6,34 @@ on:
         - cron: '0 2 * * *'
 
 jobs:
+    get-maintenance-versions:
+        uses: ./.github/workflows/get-supported-maintenance-versions.yaml
+
+    get-maintenance-branches:
+        runs-on: ubuntu-latest
+        needs: get-maintenance-versions
+        outputs:
+            branches: ${{ steps.branches.outputs.maintenance_branches }}
+        steps:
+          - id: branches
+            run: echo "maintenance_branches=$(echo '${{ needs.get-maintenance-versions.outputs.versions }}' | jq --compact-output 'map(. | tostring + ".z")')" >> ${GITHUB_OUTPUT}
+
+    get-branches-to-scan:
+        runs-on: ubuntu-latest
+        needs: get-maintenance-branches
+        outputs:
+            branches: ${{ steps.branches.outputs.branches }}
+        steps:
+          - id: branches
+            run: echo "branches=$(echo '${{ needs.get-maintenance-branches.outputs.branches }}' | jq --compact-output '. as $b | ["master"] + $b')" >> ${GITHUB_OUTPUT}
+
     trigger-vulnerability-scan:
+        needs: get-branches-to-scan
         name: Scan ${{ matrix.ref }}
         strategy:
             fail-fast: false
             matrix:
-                ref: [ 'master', '5.5.z', '5.4.z', '5.3.z' ]
+                ref: ${{ fromJSON(needs.get-branches-to-scan.outputs.branches) }}
         uses: ./.github/workflows/vulnerability_scan_subworkflow.yml
         with:
             ref: ${{ matrix.ref }}


### PR DESCRIPTION
Extracts existing centralised version definition to a separate file so that it's not duplicated _within `hazelcast-docker`_.

We can use this a stepping-stone to de-duplicate across other repos.

Example executions showing success:
- [`check-base-images.yml`](https://github.com/hazelcast/hazelcast-docker/actions/runs/14354399113)
- [`scheduled_vulnerability_scan.yml`](https://github.com/hazelcast/hazelcast-docker/actions/runs/14333050299)

_Partially addresses_: [DI-349](https://hazelcast.atlassian.net/browse/DI-349)

[DI-349]: https://hazelcast.atlassian.net/browse/DI-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ