### PR TITLE
Support secrets in PR Builder

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,7 +1,6 @@
 name: Build PR
 
 on:
-  workflow_dispatch:
   pull_request_target:
 
 env:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -2,7 +2,7 @@ name: Build PR
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
 
 env:
   test_container_name_oss: hazelcast-oss-test
@@ -11,8 +11,23 @@ env:
   docker_log_file_ee: docker-hazelcast-ee-test.log
 
 jobs:
+  check_for_membership:
+    runs-on: ubuntu-latest
+    name: Check PR author membership
+    outputs:
+      check-result: ${{ steps.composite.outputs.check-result }}
+    steps: 
+      - name: Action for membership check
+        id: composite
+        uses: hazelcast/hazelcast-tpm/membership@main
+        with:
+          organization-name: 'hazelcast'
+          member-name: ${{ github.actor }}
+          token: ${{ secrets.GH_TOKEN }}
+
   prepare:
     runs-on: ubuntu-latest
+    needs: check_for_membership
     name: Prepare environment
     outputs:
       HZ_VERSION_OSS: ${{ steps.get_oss_vars.outputs.HZ_VERSION_OSS }}
@@ -20,9 +35,16 @@ jobs:
       LAST_RELEASED_HZ_VERSION_OSS: ${{ steps.get_oss_vars.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
       HAZELCAST_EE_ZIP_URL: ${{ steps.get_ee_vars.outputs.HAZELCAST_EE_ZIP_URL }}
     steps:
+      - name: Detect untrusted community PR
+        if: ${{ needs.check_for_membership.outputs.check-result == 'false' }}
+        run: |
+          echo "::error::ERROR: Untrusted external PR. Must be reviewed and executed by Hazelcast" 1>&2;
+          exit 1
+
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
 
       - name: Forbid .github/release_type file
@@ -64,6 +86,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
 
       - name: Set up Docker
@@ -141,6 +164,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
 
       - name: Set up Docker


### PR DESCRIPTION
The [PR builder is failing](https://github.com/hazelcast/hazelcast-docker/actions/runs/14442489819/job/40495592032?pr=932) because some of the steps required credentials [not accessible to Dependabot](https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544).

Fixed by updating to `pull_request_target` and [using the Hazelcast guard as added to `hazelcast-code-samples`](https://github.com/hazelcast/hazelcast-code-samples/blob/master/.github/workflows/builder.yaml).