### PR TITLE
Ensure RHEL action logs are retained on `workflow_dispatch` [DI-455]

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -275,7 +275,7 @@ jobs:
           CLUSTER_SIZE: 3
 
       - name: Get OpenShift logs
-        if: ${{ !always() && inputs.DRY_RUN != 'true' }}
+        if: ${{ always() && inputs.DRY_RUN != 'true' }}
         run: |
           kubectl get events -n "${PROJECT_NAME}" > events.log
           kubectl describe pods > pods.log
@@ -284,7 +284,7 @@ jobs:
           done      
 
       - name: Store OpenShift logs as artifact
-        if: ${{ !always() && inputs.DRY_RUN != 'true' }}
+        if: ${{ always() && inputs.DRY_RUN != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: openshift-logs-${{ github.job }}-jdk${{ matrix.jdk }}

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -275,7 +275,7 @@ jobs:
           CLUSTER_SIZE: 3
 
       - name: Get OpenShift logs
-        if: inputs.DRY_RUN != 'true'
+        if: ${{ !always() && inputs.DRY_RUN != 'true' }}
         run: |
           kubectl get events -n "${PROJECT_NAME}" > events.log
           kubectl describe pods > pods.log
@@ -284,7 +284,7 @@ jobs:
           done      
 
       - name: Store OpenShift logs as artifact
-        if: inputs.DRY_RUN != 'true'
+        if: ${{ !always() && inputs.DRY_RUN != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: openshift-logs-${{ github.job }}-jdk${{ matrix.jdk }}


### PR DESCRIPTION
The action _should_ always save the pod logs as an artifact, but this only seems to be working for [`push` events](https://github.com/hazelcast/hazelcast-docker/actions/runs/14509209616/job/40704149787), but [not `workflow_dispatch`](https://github.com/hazelcast/hazelcast-docker/actions/runs/14629659767/job/41049298059).

Updated to be consistent with how [we do the docker logs](https://github.com/hazelcast/hazelcast-docker/blob/5db07f32540697db42470704372d26bdff2440a7/.github/workflows/tag_image_push.yml#L220-L231).

[Example `workflow_dispatch` execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/14638499440).

Post-merge actions:
- [ ] backport

_Partially addresses_: [DI-455](https://hazelcast.atlassian.net/browse/DI-455)

[DI-455]: https://hazelcast.atlassian.net/browse/DI-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ