### PR TITLE
Update RHEL `preflight` command to avoid deprecated argument

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -195,7 +195,7 @@ jobs:
         run: |
           preflight check container "${RHEL_IMAGE}" \
           --submit --pyxis-api-token=${RHEL_API_KEY} \
-          --certification-project-id=${RHEL_PROJECT_ID} \
+          --certification-component-id=${RHEL_PROJECT_ID} \
           --docker-config ~/.docker/config.json
 
       - name: Wait for Scan to Complete


### PR DESCRIPTION
Since https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/1222, [the builds](https://github.com/hazelcast/hazelcast-docker/actions/runs/14753983763/job/41436681503) have reported:
> Flag --certification-project-id has been deprecated, please use --certification-component-id instead

Command updated.