### PR TITLE
Refactor `HZ_VERSION` generation in `ee-nlc-tag-push`

### DIFF
--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -37,13 +37,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set HZ version
+        if: env.HZ_VERSION == ''
         run: |
-          if [ -z "${{ env.HZ_VERSION }}" ]; then
-             HZ_VERSION=${GITHUB_REF:11}
-          else
-             HZ_VERSION=${{ env.HZ_VERSION }}
-          fi
-          echo "HZ_VERSION=${HZ_VERSION}" >> $GITHUB_ENV
+          echo "HZ_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
 
       - name: Set NLC zip URL
         run: |


### PR DESCRIPTION
We only need to update `env.HZ_VERSION` if it's _not already set_, rather than overwriting it every time regardless.

Updated to make it consistent with the change in https://github.com/hazelcast/hazelcast-docker/commit/1561d8e147e655e95c019cc61ba5868a3861b6b7.