### PR TITLE
Add support for LTS versions [5.5.5]

### DIFF
--- a/.github/actions/check-if-latest-lts-release/action.yml
+++ b/.github/actions/check-if-latest-lts-release/action.yml
@@ -1,0 +1,47 @@
+name: Check if latest EE LTS release
+description: Check if latest EE LTS release
+inputs:
+  release_version:
+    description: Version to be released
+    required: true
+  is_lts_override:
+    description: Override is LTS release or not
+    required: true
+outputs:
+  is_latest_lts:
+    value: ${{ steps.is_latest_lts.outputs.is_latest_lts }}
+    description: Returns 'true' if the release if the latest LTS
+runs:
+  using: "composite"
+  steps:
+    - name: Set Environment Variables
+      shell: bash
+      run: |
+        echo "IS_LTS_FILE=.github/lts" >> $GITHUB_ENV
+
+    - name: Check if EE LTS release
+      shell: bash
+      run: |
+        if [ -n "${{inputs.is_lts_override}}" ]; then
+            echo "IS_LTS overridden to '${{inputs.is_lts_override}}'"
+            echo "IS_LTS=${{inputs.is_lts_override}}" >> $GITHUB_ENV
+        elif [ -f $IS_LTS_FILE ]; then
+            echo "IS_LTS=true" >> $GITHUB_ENV
+            echo "File '$IS_LTS_FILE' exists. Assuming LTS release"
+        else
+            echo "File '$IS_LTS_FILE' does not exist. Assuming non-LTS release"
+        fi
+
+    - name: Check if latest EE LTS release
+      if: env.IS_LTS == 'true'
+      id: is_latest_lts
+      shell: bash
+      run: |
+        . .github/scripts/version.functions.sh
+        CURRENT_LATEST_LTS_VERSION=$(get_last_version_with_file "$IS_LTS_FILE")
+        RELEASE_VERSION="${{ inputs.release_version }}"
+        if version_less_or_equal "$CURRENT_LATEST_LTS_VERSION" "$RELEASE_VERSION"; then
+           echo "is_latest_lts=true" >> $GITHUB_OUTPUT
+        else 
+           echo "is_latest_lts=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/scripts/get-tags-to-push.sh
+++ b/.github/scripts/get-tags-to-push.sh
@@ -9,15 +9,16 @@ function get_latest_version() {
   find_last_matching_version ""
 }
 
-function verlte() {
+function version_less_or_equal() {
   [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
 }
 
 function get_version_only_tags_to_push() {
   local VERSION_TO_RELEASE=$1
+  local IS_LATEST_LTS=$2
 
-  if [ "$#" -ne 1 ]; then
-    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} VERSION_TO_RELEASE"
+  if [ "$#" -ne 2 ]; then
+    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} VERSION_TO_RELEASE IS_LATEST_LTS"
     exit 1;
   fi
 
@@ -35,16 +36,19 @@ function get_version_only_tags_to_push() {
 
   local TAGS_TO_PUSH+=($VERSION_TO_RELEASE)
 
-  if verlte "$LATEST_FOR_MINOR" "$VERSION_TO_RELEASE"; then
+  if version_less_or_equal "$LATEST_FOR_MINOR" "$VERSION_TO_RELEASE"; then
     TAGS_TO_PUSH+=($MINOR_VERSION_TO_RELEASE)
   fi
 
-  if verlte "$LATEST_FOR_MAJOR" "$VERSION_TO_RELEASE"; then
+  if version_less_or_equal "$LATEST_FOR_MAJOR" "$VERSION_TO_RELEASE"; then
     TAGS_TO_PUSH+=($MAJOR_VERSION_TO_RELEASE)
   fi
 
-  if verlte "$LATEST" "$VERSION_TO_RELEASE"; then
-    TAGS_TO_PUSH+=(latest)
+  if version_less_or_equal "$LATEST" "$VERSION_TO_RELEASE"; then
+    TAGS_TO_PUSH+=("latest")
+  fi
+  if [ "$IS_LATEST_LTS" == "true" ] ; then
+    TAGS_TO_PUSH+=("latest-lts")
   fi
 
   echo "${TAGS_TO_PUSH[@]}"
@@ -52,8 +56,8 @@ function get_version_only_tags_to_push() {
 
 function get_tags_to_push() {
 
-  if [ "$#" -ne 4 ]; then
-    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} VERSION_TO_RELEASE SUFFIX CURRENT_JDK DEFAULT_JDK"
+  if [ "$#" -ne 5 ]; then
+    echo "Error: Incorrect number of arguments. Usage: ${FUNCNAME[0]} VERSION_TO_RELEASE SUFFIX CURRENT_JDK DEFAULT_JDK IS_LATEST_LTS"
     exit 1;
   fi
 
@@ -61,7 +65,8 @@ function get_tags_to_push() {
   local SUFFIX=$2
   local CURRENT_JDK=$3
   local DEFAULT_JDK=$4
-  local VERSION_ONLY_TAGS_TO_PUSH=$(get_version_only_tags_to_push "$VERSION_TO_RELEASE")
+  local IS_LATEST_LTS=$5
+  local VERSION_ONLY_TAGS_TO_PUSH=$(get_version_only_tags_to_push "$VERSION_TO_RELEASE" "$IS_LATEST_LTS")
   augment_with_suffixed_tags "${VERSION_ONLY_TAGS_TO_PUSH[*]}" "$SUFFIX" "$CURRENT_JDK" "$DEFAULT_JDK"
 }
 

--- a/.github/scripts/get-tags-to-push_tests.sh
+++ b/.github/scripts/get-tags-to-push_tests.sh
@@ -2,39 +2,23 @@
 
 set -eu
 
-function findScriptDir() {
-  CURRENT=$PWD
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
-  DIR=$(dirname "$0")
-  cd "$DIR" || exit
-  TARGET_FILE=$(basename "$0")
-
-  # Iterate down a (possible) chain of symlinks
-  while [ -L "$TARGET_FILE" ]
-  do
-      TARGET_FILE=$(readlink "$TARGET_FILE")
-      DIR=$(dirname "$TARGET_FILE")
-      cd "$DIR" || exit
-      TARGET_FILE=$(basename "$TARGET_FILE")
-  done
-
-  SCRIPT_DIR=$(pwd -P)
-  # Restore current directory
-  cd "$CURRENT" || exit
-}
-
-findScriptDir
-
-. "$SCRIPT_DIR"/assert.sh/assert.sh
+# Source the latest version of assert.sh unit testing library and include in current shell
+assert_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)
+# shellcheck source=/dev/null
+. <(echo "${assert_script_content}")
 . "$SCRIPT_DIR"/get-tags-to-push.sh
 
 TESTS_RESULT=0
 
 function assert_get_version_only_tags_to_push {
   local VERSION_TO_RELEASE=$1
-  local EXPECTED_TAGS_TO_PUSH=$2
-  local ACTUAL_TAGS_TO_PUSH=$(get_version_only_tags_to_push "$VERSION_TO_RELEASE")
-  assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "Tags to push for version $VERSION_TO_RELEASE should be equal to $EXPECTED_TAGS_TO_PUSH " || TESTS_RESULT=$?
+  local IS_LTS=$2
+  local EXPECTED_TAGS_TO_PUSH=$3
+  local ACTUAL_TAGS_TO_PUSH=$(get_version_only_tags_to_push "$VERSION_TO_RELEASE" "$IS_LTS")
+  local MSG="Tags to push for version $VERSION_TO_RELEASE and is_lts = '$IS_LTS' should be equal to $EXPECTED_TAGS_TO_PUSH"
+  assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
 }
 
 function assert_augment_with_suffixed_tags {
@@ -44,7 +28,8 @@ function assert_augment_with_suffixed_tags {
   local DEFAULT_JDK=$4
   local EXPECTED_TAGS_TO_PUSH=$5
   local ACTUAL_TAGS_TO_PUSH=$(augment_with_suffixed_tags "${INITIAL_TAGS[*]}" "$SUFFIX" "$CURRENT_JDK" "$DEFAULT_JDK")
-  assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "Suffixed tags to push for (tags=$INITIAL_TAGS suffix=$SUFFIX current_jdk=$CURRENT_JDK default_jdk=$DEFAULT_JDK) should be equal to: $EXPECTED_TAGS_TO_PUSH " || TESTS_RESULT=$?
+  local MSG="Suffixed tags to push for (tags=$INITIAL_TAGS suffix=$SUFFIX current_jdk=$CURRENT_JDK default_jdk=$DEFAULT_JDK) should be equal to: $EXPECTED_TAGS_TO_PUSH"
+  assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
 }
 
 function assert_get_tags_to_push {
@@ -52,21 +37,25 @@ function assert_get_tags_to_push {
   local SUFFIX=$2
   local CURRENT_JDK=$3
   local DEFAULT_JDK=$4
-  local EXPECTED_TAGS_TO_PUSH=$5
-  local ACTUAL_TAGS_TO_PUSH=$(get_tags_to_push "$VERSION_TO_RELEASE" "$SUFFIX" "$CURRENT_JDK" "$DEFAULT_JDK")
-  assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "Tags to push for (version_to_release=$VERSION_TO_RELEASE suffix=$SUFFIX current_jdk=$CURRENT_JDK default_jdk=$DEFAULT_JDK) should be equal to: $EXPECTED_TAGS_TO_PUSH " || TESTS_RESULT=$?
+  local IS_LATEST_LTS=$5
+  local EXPECTED_TAGS_TO_PUSH=$6
+  local ACTUAL_TAGS_TO_PUSH=$(get_tags_to_push "$VERSION_TO_RELEASE" "$SUFFIX" "$CURRENT_JDK" "$DEFAULT_JDK" "$IS_LATEST_LTS")
+  local MSG="Tags to push for (version_to_release=$VERSION_TO_RELEASE suffix=$SUFFIX current_jdk=$CURRENT_JDK default_jdk=$DEFAULT_JDK is_latest_lts=$IS_LATEST_LTS) should be equal to: $EXPECTED_TAGS_TO_PUSH "
+  assert_eq "$EXPECTED_TAGS_TO_PUSH" "$ACTUAL_TAGS_TO_PUSH" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
 }
 
 log_header "Tests for get_version_only_tags_to_push"
-assert_get_version_only_tags_to_push "5.2.0" "5.2.0"
-assert_get_version_only_tags_to_push "5.2.1" "5.2.1"
-assert_get_version_only_tags_to_push "5.1.99" "5.1.99 5.1"
-assert_get_version_only_tags_to_push "4.99.0" "4.99.0 4.99 4"
-assert_get_version_only_tags_to_push "99.0.0" "99.0.0 99.0 99 latest"
-assert_get_version_only_tags_to_push "5.3.0-BETA-1" "5.3.0-BETA-1"
-assert_get_version_only_tags_to_push "5.4.0-DEVEL-9" "5.4.0-DEVEL-9"
-assert_get_version_only_tags_to_push "5.99.0-BETA-1" "5.99.0-BETA-1"
-assert_get_version_only_tags_to_push "99.0.0-BETA-1" "99.0.0-BETA-1"
+assert_get_version_only_tags_to_push "5.2.0" "false" "5.2.0"
+assert_get_version_only_tags_to_push "5.2.1" "false" "5.2.1"
+assert_get_version_only_tags_to_push "5.1.99" "false" "5.1.99 5.1"
+assert_get_version_only_tags_to_push "4.99.0" "false" "4.99.0 4.99 4"
+assert_get_version_only_tags_to_push "99.0.0" "false" "99.0.0 99.0 99 latest"
+assert_get_version_only_tags_to_push "5.3.0-BETA-1" "false" "5.3.0-BETA-1"
+assert_get_version_only_tags_to_push "5.4.0-DEVEL-9" "false" "5.4.0-DEVEL-9"
+assert_get_version_only_tags_to_push "5.99.0-BETA-1" "false" "5.99.0-BETA-1"
+assert_get_version_only_tags_to_push "99.0.0-BETA-1" "false" "99.0.0-BETA-1"
+assert_get_version_only_tags_to_push "99.0.0" "true" "99.0.0 99.0 99 latest latest-lts"
+assert_get_version_only_tags_to_push "5.2.0" "true" "5.2.0 latest-lts"
 
 log_header "Tests for augment_with_suffixed_tags"
 assert_augment_with_suffixed_tags "1.2.3" "" "11" "11" "1.2.3 1.2.3-jdk11"
@@ -76,14 +65,17 @@ assert_augment_with_suffixed_tags "1.2.3 latest" "" "17" "11" "1.2.3-jdk17 lates
 assert_augment_with_suffixed_tags "1.2.3" "-slim" "11" "11" "1.2.3-slim 1.2.3-slim-jdk11"
 assert_augment_with_suffixed_tags "1.2.3" "-slim" "17" "11" "1.2.3-slim-jdk17"
 assert_augment_with_suffixed_tags "1.2.3 latest" "-slim" "17" "11" "1.2.3-slim-jdk17 latest-slim-jdk17"
+assert_augment_with_suffixed_tags "1.2.3 latest-lts" "-slim" "17" "11" "1.2.3-slim-jdk17 latest-lts-slim-jdk17"
 tags_array=(1.2.3 latest)
 assert_augment_with_suffixed_tags "${tags_array[*]}" "-slim" "17" "11" "1.2.3-slim-jdk17 latest-slim-jdk17"
 assert_augment_with_suffixed_tags "1.2.3 1.2" "-slim" "17" "11" "1.2.3-slim-jdk17 1.2-slim-jdk17"
 
 log_header "Tests for get_tags_to_push"
-assert_get_tags_to_push "5.2.0" "" "11" "11" "5.2.0 5.2.0-jdk11"
-assert_get_tags_to_push "99.0.0" "" "11" "11" "99.0.0 99.0.0-jdk11 99.0 99.0-jdk11 99 99-jdk11 latest latest-jdk11"
-assert_get_tags_to_push "99.0.0-BETA-1" "" "17" "11" "99.0.0-BETA-1-jdk17"
-assert_get_tags_to_push "5.4.0-DEVEL-9" "-slim" "17" "11" "5.4.0-DEVEL-9-slim-jdk17"
+assert_get_tags_to_push "5.2.0" "" "11" "11" "false" "5.2.0 5.2.0-jdk11"
+assert_get_tags_to_push "99.0.0" "" "11" "11" "false" "99.0.0 99.0.0-jdk11 99.0 99.0-jdk11 99 99-jdk11 latest latest-jdk11"
+assert_get_tags_to_push "99.0.0-BETA-1" "" "17" "11" "false" "99.0.0-BETA-1-jdk17"
+assert_get_tags_to_push "5.4.0-DEVEL-9" "-slim" "17" "false" "11" "5.4.0-DEVEL-9-slim-jdk17"
+assert_get_tags_to_push "5.2.0" "" "11" "11" "true" "5.2.0 5.2.0-jdk11 latest-lts latest-lts-jdk11"
+assert_get_tags_to_push "99.0.0" "" "11" "11" "true" "99.0.0 99.0.0-jdk11 99.0 99.0-jdk11 99 99-jdk11 latest latest-jdk11 latest-lts latest-lts-jdk11"
 
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/.github/scripts/version.functions_tests.sh
+++ b/.github/scripts/version.functions_tests.sh
@@ -1,27 +1,6 @@
 #!/usr/bin/env bash
 
-function findScriptDir() {
-  CURRENT=$PWD
-
-  DIR=$(dirname "$0")
-  cd "$DIR" || exit
-  TARGET_FILE=$(basename "$0")
-
-  # Iterate down a (possible) chain of symlinks
-  while [ -L "$TARGET_FILE" ]
-  do
-      TARGET_FILE=$(readlink "$TARGET_FILE")
-      DIR=$(dirname "$TARGET_FILE")
-      cd "$DIR" || exit
-      TARGET_FILE=$(basename "$TARGET_FILE")
-  done
-
-  SCRIPT_DIR=$(pwd -P)
-  # Restore current directory
-  cd "$CURRENT" || exit
-}
-
-findScriptDir
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 . "$SCRIPT_DIR"/assert.sh/assert.sh
 . "$SCRIPT_DIR"/version.functions.sh
@@ -64,6 +43,13 @@ function assert_latest_patch_versions_not_contain {
   assert_not_contain "$ACTUAL_LATEST_PATCH_VERSIONS" "$EXPECTED_VERSION" "Latest patch versions starting from $MINIMAL_SUPPORTED_VERSION should NOT contain $EXPECTED_VERSION " || TESTS_RESULT=$?
 }
 
+function assert_get_last_version_with_file {
+  local FILE=$1
+  local EXPECTED_LAST_VERSION=$2
+  local ACTUAL_LAST_VERSION=$(get_last_version_with_file "$FILE")
+  assert_eq "$ACTUAL_LAST_VERSION" "$EXPECTED_LAST_VERSION" "Last version of $FILE should be ${EXPECTED_LAST_VERSION:-<none>} " || TESTS_RESULT=$?
+}
+
 log_header "Tests for get_latest_patch_version"
 assert_latest_patch_version "4.2.1" "4.2.8"
 assert_latest_patch_version "4.2" "4.2.8"
@@ -94,5 +80,10 @@ assert_latest_patch_versions_not_contain "4.2" "3.9.4"
 assert_latest_patch_versions_not_contain "4.2" "4.1.10"
 LATEST_5_4_DEVEL="$(git tag | sort -V | grep 'v5.4.0-DEVEL-' | tail -n 1 | cut -c2-)"
 assert_latest_patch_versions_not_contain "5.3" "$LATEST_5_4_DEVEL"
+
+log_header "Tests for get_last_version_with_file"
+assert_get_last_version_with_file ".github/containerscan/allowedlist.yaml" "5.3.1" # it was removed in 5.3.2
+assert_get_last_version_with_file ".github/actions/install-xmllint/action.yml" "5.4.1" # it was removed in 5.4.2
+assert_get_last_version_with_file "dummy-non-existing-file" ""
 
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -23,6 +23,22 @@ on:
           - ALL
           - OSS
           - EE
+      IS_LTS_OVERRIDE:
+        description: 'Override is LTS release'
+        required: false
+        type: choice
+        default: ''
+        options:
+          - ''
+          - 'false'
+          - 'true'
+      DRY_RUN:
+        description: 'Skip pushing the images to remote registry'
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 env:
   test_container_name_oss: hazelcast-oss-test
   test_container_name_ee: hazelcast-ee-test
@@ -108,7 +124,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.1.0
+        uses: docker/setup-qemu-action@v3.2.0
 
       - name:  Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -193,7 +209,9 @@ jobs:
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
           
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          # OSS has no LTS releases
+          IS_LATEST_LTS=false
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}
@@ -202,11 +220,22 @@ jobs:
           done
           
           PLATFORMS="$(get_alpine_supported_platforms "${{ matrix.jdk }}")"
-          docker buildx build --push \
-            --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
-            ${TAGS_ARG} \
-            --platform=${PLATFORMS} $DOCKER_DIR
+          if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
+            echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
+          else
+            docker buildx build --push \
+              --build-arg JDK_VERSION=${{ matrix.jdk }} \
+              --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
+              ${TAGS_ARG} \
+              --platform=${PLATFORMS} $DOCKER_DIR
+          fi
+
+      - name: Check if latest EE LTS release
+        id: is_latest_lts
+        uses: ./.github/actions/check-if-latest-lts-release
+        with:
+          release_version: ${{ env.RELEASE_VERSION }}
+          is_lts_override: ${{ inputs.IS_LTS_OVERRIDE }}
 
       - name: Build/Push EE image
         if: needs.prepare.outputs.should_build_ee == 'yes'
@@ -219,7 +248,8 @@ jobs:
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast-enterprise
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
           
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          IS_LATEST_LTS="${{ steps.is_latest_lts.outputs.is_latest_lts }}"
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}
@@ -228,12 +258,16 @@ jobs:
           done
           
           PLATFORMS="$(get_ubi_supported_platforms "${{ matrix.jdk }}")"
-          docker buildx build --push \
-            --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
-            --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
-            ${TAGS_ARG} \
-            --platform=${PLATFORMS} $DOCKER_DIR
+          if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
+            echo "DRY RUN: Build and push for platforms ${PLATFORMS} and tags: $TAGS_TO_PUSH"
+          else
+            docker buildx build --push \
+              --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
+              --build-arg JDK_VERSION=${{ matrix.jdk }} \
+              --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
+              ${TAGS_ARG} \
+              --platform=${PLATFORMS} $DOCKER_DIR
+          fi
 
       - name: Slack notification
         uses: ./.github/actions/slack-notification

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -15,6 +15,15 @@ on:
       RELEASE_VERSION:
         description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         required: false
+      IS_LTS_OVERRIDE:
+        description: 'Override is LTS release'
+        required: false
+        type: choice
+        default: ''
+        options:
+          - ''
+          - 'false'
+          - 'true'
 jobs:
   jdks:
     uses: ./.github/workflows/get-supported-jdks.yaml
@@ -88,7 +97,7 @@ jobs:
           echo "RHEL_IMAGE=${SCAN_REPOSITORY}:${RELEASE_VERSION}-jdk${{ matrix.jdk }}" >> $GITHUB_ENV
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.1.0
+        uses: docker/setup-qemu-action@v3.2.0
 
       - name:  Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -114,6 +123,13 @@ jobs:
         run: |
           docker login ${SCAN_REGISTRY} -u ${SCAN_REGISTRY_USER} -p ${SCAN_REGISTRY_PASSWORD}
 
+      - name: Check if latest EE LTS release
+        id: is_latest_lts
+        uses: ./.github/actions/check-if-latest-lts-release
+        with:
+          release_version: ${{ env.RELEASE_VERSION }}
+          is_lts_override: ${{ inputs.IS_LTS_OVERRIDE }}
+
       - name: Delete unpublished images
         run: |
           VERSION=${RELEASE_VERSION}-jdk${{ matrix.jdk }}
@@ -131,7 +147,8 @@ jobs:
           IMAGE_NAME=${SCAN_REPOSITORY}
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
 
-          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          IS_LATEST_LTS="${{ steps.is_latest_lts.outputs.is_latest_lts }}"
+          TAGS_TO_PUSH=$(get_tags_to_push ${{ env.RELEASE_VERSION }} "" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/808

Fixes: https://hazelcast.atlassian.net/browse/DI-258

The previous LTS approach had an issue that it wouldn't work when we automatically rebuild previous LTS releases (due to CVE fixes etc). It would result with two concurrent LTS builds (e.g. 5.5 and 6.5) both overwriting `latest-lts` tag. 

This PR changes the logic that before overwriting the tag we make sure that the current version is the newest LTS. It's done by looking for the latest released version containing `.github/lts` file. 

Whenever a `.github/lts` file exists the workflow will check if we're building a latest LTS version and if so it will add `latest-lts` tags and its variants (e.g. `latest-lts-jdk21`,`latest-lts-slim`, `latest-lts-slim-jdk21`, etc)

For manual runs you need to use `IS_LTS` input. It will overwrite checking the existence of the file.

Additionally added `DRY_RUN` flag to manual runs to be able test the `tag_image_push.yml` workflow in more safer way, instead of actual push you'll see something like:
```
DRY RUN: Build and push for platforms linux/arm64,linux/amd64,linux/s390x,linux/ppc64le and tags: 5.5.1 5.5.1-jdk21 5.5 5.5-jdk21 5 5-jdk21 latest latest-jdk21 latest-lts latest-lts-jdk21
```

Test runs:
- https://github.com/hazelcast/hazelcast-docker/actions/runs/14893680002
- https://github.com/hazelcast/hazelcast-docker/actions/runs/14893530645
