### PR TITLE
Automate retagging process when release branches change [5.3.8]

### DIFF
--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -1,0 +1,60 @@
+name: Recreate tags on release branch change
+
+on:
+  push:
+    branches:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      BRANCH_NAME:
+        description: The branch to recreate the tag from
+
+jobs:
+  retag:
+    runs-on: ubuntu-latest
+    env:
+      BRANCH_NAME: ${{ inputs.BRANCH_NAME }}
+    steps:
+      - name: Set branch name
+        if: env.BRANCH_NAME == ''
+        run: |
+          echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> ${GITHUB_ENV}
+
+      - name: Calculate tag name
+        run: |
+          echo "TAG_NAME=v${BRANCH_NAME}" >> ${GITHUB_ENV}
+
+      - name: Check `${{ env.TAG_NAME }}` tag exists
+        run: |
+          if ! gh release view --repo ${GITHUB_REPOSITORY} ${TAG_NAME}; then
+            echo "::notice::\"${TAG_NAME}\" tag not found to replace, skipping" 
+            echo "SKIP=true" >> ${GITHUB_ENV}
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - uses: actions/checkout@v4
+        if: ${{ env.SKIP != 'true' }}
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+          fetch-depth: 0
+
+      - name: List tags
+        if: runner.debug == '1'
+        run: |
+          git tag --list
+
+      - name: Recreate `${{ env.TAG_NAME }}` tag
+        if: ${{ env.SKIP != 'true' }}
+        run: |
+          # Delete local tag
+          git tag -d ${TAG_NAME}
+
+          # Create local tag
+          git tag ${TAG_NAME} origin/${BRANCH_NAME}
+
+          # Delete remote tag
+          git push origin :refs/tags/${TAG_NAME}
+
+          # Create remote tag
+          git push origin ${TAG_NAME}


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/955

When a release branch (`5.5.5`) is changed, the corresponding tag needs to be recreated also - which is a manual step.

Instead, we can automate this process via a GitHub action that:
- identifies if the `push` is to a release branch (not a maintenance branch)
- checks a tag _already_ exists (the scope of this action is to retag, not to _release_ a branch)
- perform the existing retagging procedure

Note - this is a sticking-plaster over an imperfect process.

Testing performed in a scratch-repo:
- skipping:
   - [`main`](https://github.com/JackPGreen/backport-test/actions/runs/14894149859)
   - [maintenance branch](https://github.com/JackPGreen/backport-test/actions/runs/14894189254)
- [retagging on `5.5.6` release branch](https://github.com/JackPGreen/backport-test/actions/runs/14894111197/job/41832985389)