### PR TITLE
Fix RedHat `Image you are trying to publish did not pass the certification test` error [DI-469]

### DIFF
--- a/.github/scripts/logging.functions.sh
+++ b/.github/scripts/logging.functions.sh
@@ -6,6 +6,12 @@ function echoerr() {
   echo "::error::ERROR - $*" 1>&2;
 }
 
+# Prints the given message to debug logs, _if enabled_
+function echodebug() {
+  # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-debug-message
+  echo "::debug::$*" 1>&2;
+}
+
 # Create group
 function echo_group() {
   # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -187,21 +187,21 @@ jobs:
         run: |
           source .github/scripts/logging.functions.sh
 
-          preflight_output=$(preflight check container "${RHEL_IMAGE}" \
+          PRELIGHT_OUTPUT=$(preflight check container "${RHEL_IMAGE}" \
             --submit --pyxis-api-token=${RHEL_API_KEY} \
             --certification-component-id=${RHEL_PROJECT_ID} \
             --docker-config ~/.docker/config.json \
             2>&1)
 
-          echodebug "${preflight_output}"
+          echodebug "${PRELIGHT_OUTPUT}"
 
-          image_id=$(grep --perl-regexp --only-matching "image id is: \K[a-f0-9]+" <<< "${preflight_output}" || true)
+          image_id=$(grep --perl-regexp --only-matching "image id is: \K[a-f0-9]+" <<< "${PRELIGHT_OUTPUT}" || true)
 
           if [[ -n "${image_id}" ]]; then
             echo "IMAGE_ID=${image_id}" >> $GITHUB_ENV
           else
             echoerr "Unable to extract image ID from preflight output:"
-            echoerr "${preflight_output}"
+            echoerr "${PRELIGHT_OUTPUT}"
             exit 1
           fi
 

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -139,14 +139,6 @@ jobs:
           release_version: ${{ env.RELEASE_VERSION }}
           is_lts_override: ${{ inputs.IS_LTS_OVERRIDE }}
 
-      - name: Delete unpublished images
-        if: inputs.DRY_RUN != 'true'
-        run: |
-          VERSION=${RELEASE_VERSION}-jdk${{ matrix.jdk }}
-          source .github/scripts/publish-rhel.sh
-
-          delete_unpublished_images "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}"
-
       - name: Build the Hazelcast Enterprise image
         run: |
           . .github/scripts/get-tags-to-push.sh 
@@ -193,28 +185,40 @@ jobs:
       - name: Run preflight scan
         if: inputs.DRY_RUN != 'true'
         run: |
-          preflight check container "${RHEL_IMAGE}" \
-          --submit --pyxis-api-token=${RHEL_API_KEY} \
-          --certification-component-id=${RHEL_PROJECT_ID} \
-          --docker-config ~/.docker/config.json
+          source .github/scripts/logging.functions.sh
+
+          preflight_output=$(preflight check container "${RHEL_IMAGE}" \
+            --submit --pyxis-api-token=${RHEL_API_KEY} \
+            --certification-component-id=${RHEL_PROJECT_ID} \
+            --docker-config ~/.docker/config.json \
+            2>&1)
+
+          echo "::debug::${preflight_output}"
+
+          image_id=$(grep --perl-regexp --only-matching "image id is: \K[a-f0-9]+" <<< "${preflight_output}" || true)
+
+          if [[ -n "${image_id}" ]]; then
+            echo "IMAGE_ID=${image_id}" >> $GITHUB_ENV
+          else
+            echoerr "Unable to extract image ID from preflight output:"
+            echoerr "${preflight_output}"
+          fi
 
       - name: Wait for Scan to Complete
         if: inputs.DRY_RUN != 'true'
         run: |
-          VERSION=${RELEASE_VERSION}-jdk${{ matrix.jdk }}
           source .github/scripts/publish-rhel.sh
 
-          wait_for_container_scan "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
+          wait_for_container_scan "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}" "${TIMEOUT_IN_MINS}"
 
       - name: Publish the Hazelcast Enterprise image
         if: inputs.DRY_RUN != 'true'
         run: |
-          VERSION=${RELEASE_VERSION}-jdk${{ matrix.jdk }}
           source .github/scripts/publish-rhel.sh
 
-          publish_the_image "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
-          wait_for_container_publish "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
-          sync_tags "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
+          publish_the_image "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}"
+          wait_for_container_publish "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}" "${TIMEOUT_IN_MINS}"
+          sync_tags "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}"
 
       - name: Slack notification
         uses: ./.github/actions/slack-notification

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -187,21 +187,21 @@ jobs:
         run: |
           source .github/scripts/logging.functions.sh
 
-          PRELIGHT_OUTPUT=$(preflight check container "${RHEL_IMAGE}" \
+          PREFLIGHT_OUTPUT=$(preflight check container "${RHEL_IMAGE}" \
             --submit --pyxis-api-token=${RHEL_API_KEY} \
             --certification-component-id=${RHEL_PROJECT_ID} \
             --docker-config ~/.docker/config.json \
             2>&1)
 
-          echodebug "${PRELIGHT_OUTPUT}"
+          echodebug "${PREFLIGHT_OUTPUT}"
 
-          image_id=$(grep --perl-regexp --only-matching "image id is: \K[a-f0-9]+" <<< "${PRELIGHT_OUTPUT}" || true)
+          IMAGE_ID=$(grep --perl-regexp --only-matching "image id is: \K[a-f0-9]+" <<< "${PREFLIGHT_OUTPUT}" || true)
 
-          if [[ -n "${image_id}" ]]; then
-            echo "IMAGE_ID=${image_id}" >> $GITHUB_ENV
+          if [[ -n "${IMAGE_ID}" ]]; then
+            echo "IMAGE_ID=${IMAGE_ID}" >> $GITHUB_ENV
           else
             echoerr "Unable to extract image ID from preflight output:"
-            echoerr "${PRELIGHT_OUTPUT}"
+            echoerr "${PREFLIGHT_OUTPUT}"
             exit 1
           fi
 

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -193,7 +193,7 @@ jobs:
             --docker-config ~/.docker/config.json \
             2>&1)
 
-          echo "::debug::${preflight_output}"
+          echodebug "${preflight_output}"
 
           image_id=$(grep --perl-regexp --only-matching "image id is: \K[a-f0-9]+" <<< "${preflight_output}" || true)
 

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -202,6 +202,7 @@ jobs:
           else
             echoerr "Unable to extract image ID from preflight output:"
             echoerr "${preflight_output}"
+            exit 1
           fi
 
       - name: Wait for Scan to Complete


### PR DESCRIPTION
Since removing the smoke test in https://github.com/hazelcast/hazelcast-docker/pull/938, the build has become less stable due to exposing unreliable behaviour.

Specifically, when querying the state of the image in RedHat, we _assume_ that as we've deleted `unpublished` images, when we query for (say) `5.5.1-jdk17`, that _must_ be the one were trying to publish.

However, the "unpublishing" doesn't work as expected, which means the image we get when querying isn't what we expect and the rest of the process goes awry.
More specifically, an _existing_ published image (`5.5.1-jdk17`) has data _like_:
```
{
  "total": 1,
  "data": [
    {
      "repositories": [
        {
          "published": false,
          "push_date": "2025-05-10T10:39:48+00:00"
          }
        },
        {
          "published": true,
          "published_date": "2025-05-10T10:44:16.083000+00:00",
          "push_date": "2025-05-10T10:44:16.083000+00:00"
        }
      ]
    }
  ]
}
```

That's one _image_ with _both_ published and not published. So when we request to delete any unpublished images via the API, were going to delete any image that _contains_ an unpublished component - which _may_ help explain why _published_ images are going missing.

Instead, we should _explicitly_ provide the ID of the image we want to query the state for - and this sidesteps the requirement to delete unpublished images as part of the build altogether.

Changes:
- stop removing unpublished images before doing anything
- extract the `IMAGE_ID` from the preflight output
- use `IMAGE_ID` over `VERSION` (effectively the tag name)
- remove sort of `get_image` result
   - should only be one result
   - _assuming_ the first item in a list is the one you want is always going to be racey regardless of how you sort it

[Example (debug) execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/14944560112/job/41986227335).

Closes: https://github.com/hazelcast/hazelcast-docker/pull/967 (would cause too many conflicts)
Fixes: [DI-469](https://hazelcast.atlassian.net/browse/DI-469)

Post-merge items:
- [ ] backport

[DI-469]: https://hazelcast.atlassian.net/browse/DI-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ