### PR TITLE
Check RedHat service status on `push` failure [5.4.z]

### DIFF
--- a/.github/actions/check-redhat-service-status/action.yml
+++ b/.github/actions/check-redhat-service-status/action.yml
@@ -1,0 +1,19 @@
+name: Check RedHat Service Status
+runs:
+  using: "composite"
+  steps:
+    - name: Check RedHat status
+      shell: bash
+      run: |
+        # shellcheck source=../.github/scripts/logging.functions.sh
+        . .github/scripts/logging.functions.sh
+
+        # https://status.redhat.com/api
+        STATUS=$(curl --silent https://status.redhat.com/api/v2/status.json)
+
+        if jq --exit-status '.status.indicator != "none"' <<< "${STATUS}"; then
+          echoerr "❌ RedHat service status"
+          echoerr "$(jq '.status' <<< ${STATUS})"
+          echoerr "$(curl --silent https://status.redhat.com/api/v2/incidents/unresolved.json | jq)"
+          exit 1
+        fi

--- a/.github/scripts/logging.functions.sh
+++ b/.github/scripts/logging.functions.sh
@@ -5,7 +5,8 @@
 # Prints the given message to stderr
 function echoerr() {
   # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message
-  echo "::error::ERROR - $*" 1>&2;
+  # Support multi-line strings by replacing line separator with GitHub Actions compatible one
+  echo "::error::ERROR - ${*//$'\n'/%0A}" 1>&2;
 }
 
 # Create group

--- a/.github/workflows/check-redhat-service-status.yml
+++ b/.github/workflows/check-redhat-service-status.yml
@@ -1,0 +1,12 @@
+name: Redhat status test
+# Entry point to debug the `check-redhat-service-status` action
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/check-redhat-service-status

--- a/.github/workflows/ee-nlc-snapshot-push.yml
+++ b/.github/workflows/ee-nlc-snapshot-push.yml
@@ -118,6 +118,9 @@ jobs:
             --label hazelcast.ee.revision=${{ github.event.inputs.HZ_EE_REVISION }} \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR
+      - name: Check RedHat service status
+        if: failure()
+        uses: ./.github/actions/check-redhat-service-status
       - name: Slack notification
         uses: ./.github/actions/slack-notification
         if: failure()

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -131,6 +131,9 @@ jobs:
             --build-arg HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL} \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} $DOCKER_DIR
+      - name: Check RedHat service status
+        if: failure()
+        uses: ./.github/actions/check-redhat-service-status
       - name: Slack notification
         uses: ./.github/actions/slack-notification
         if: failure()

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -180,6 +180,10 @@ jobs:
           wait_for_container_publish "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
           sync_tags "$RHEL_PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
 
+      - name: Check RedHat service status
+        if: failure()
+        uses: ./.github/actions/check-redhat-service-status
+
       - name: Slack notification
         uses: ./.github/actions/slack-notification
         if: failure()


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-docker/pull/970

The `push` [was failing](https://hazelcast.slack.com/archives/C06EQG13Z7H/p1747148998201369) but it took a while for us to realise the problem was [upstream](https://status.redhat.com/incidents/k7kvfvgfrbdf):
> Quay.io has been moved to read-only mode while we work to implement a fix. During this time Pulls will continue to work, however, Pushes will be disabled until a fix is implemented. There is currently no timeline for Push restoration

We can use the [RedHat status API](https://status.redhat.com/api) to query the status and give a heads-up if this is likely to be related.

[Example output](https://github.com/hazelcast/hazelcast-docker/actions/runs/15001432702):
![image](https://github.com/user-attachments/assets/9d8f3ac0-faba-447f-a430-0de5b5959de2)