### PR TITLE
Refactor RHEL publish

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -205,21 +205,10 @@ jobs:
             exit 1
           fi
 
-      - name: Wait for Scan to Complete
-        if: inputs.DRY_RUN != 'true'
-        run: |
-          source .github/scripts/publish-rhel.sh
-
-          wait_for_container_scan "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}" "${TIMEOUT_IN_MINS}"
-
       - name: Publish the Hazelcast Enterprise image
         if: inputs.DRY_RUN != 'true'
         run: |
-          source .github/scripts/publish-rhel.sh
-
-          publish_the_image "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}"
-          wait_for_container_publish "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}" "${TIMEOUT_IN_MINS}"
-          sync_tags "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}"
+          .github/scripts/publish-rhel.sh "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}" "${TIMEOUT_IN_MINS}"
 
       - name: Check RedHat service status
         if: failure()


### PR DESCRIPTION
The `publish_rhel` script is very long and although split out into functions, _I found_ it difficult to reason exactly what it _does_.

Refactored by:
- updated `tag_image_push_rhel` to call the script directly rather than `source`-ing them and calling _bits_ of them
- tidied up some repeated variables at the same time
- re-ordered function declarations by usage

This PR changes _nothing else_ and doesn't fix anything, it's purely a refactor.

[Example execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/15019136196).