### PR TITLE
Prevent action-failure Slack notifications for non-automated actions [DI-464]

### DIFF
--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -129,6 +129,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Slack notification
         uses: ./.github/actions/slack-notification
-        if: failure()
+        if: failure() && github.event_name == 'schedule'
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -129,6 +129,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Slack notification
         uses: ./.github/actions/slack-notification
-        if: failure() && github.event_name == 'schedule'
+        if: failure() && github.event_name != 'workflow_dispatch'
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/ee-nlc-snapshot-push.yml
+++ b/.github/workflows/ee-nlc-snapshot-push.yml
@@ -121,6 +121,6 @@ jobs:
         uses: ./.github/actions/check-redhat-service-status
       - name: Slack notification
         uses: ./.github/actions/slack-notification
-        if: failure()
+        if: failure() && github.triggering_actor == 'devOpsHazelcast'
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -132,6 +132,6 @@ jobs:
         uses: ./.github/actions/check-redhat-service-status
       - name: Slack notification
         uses: ./.github/actions/slack-notification
-        if: failure()
+        if: failure() && github.triggering_actor == 'devOpsHazelcast'
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -130,6 +130,6 @@ jobs:
             --platform=${PLATFORMS} $DOCKER_DIR
       - name: Slack notification
         uses: ./.github/actions/slack-notification
-        if: failure()
+        if: failure() && github.triggering_actor == 'devOpsHazelcast'
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -133,6 +133,6 @@ jobs:
             --platform=${PLATFORMS} $DOCKER_DIR
       - name: Slack notification
         uses: ./.github/actions/slack-notification
-        if: failure()
+        if: failure() && github.triggering_actor == 'devOpsHazelcast'
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/rhel-smoke-test.yml
+++ b/.github/workflows/rhel-smoke-test.yml
@@ -150,9 +150,3 @@ jobs:
         run: |
           helm uninstall "${PROJECT_NAME}" --timeout 30s
           oc delete project "${PROJECT_NAME}"
-
-      - name: Slack notification
-        uses: ./.github/actions/slack-notification
-        if: failure()
-        with:
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -319,7 +319,7 @@ jobs:
 
       - name: Slack notification
         uses: ./.github/actions/slack-notification
-        if: failure()
+        if: failure() && github.triggering_actor == 'devOpsHazelcast'
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}
 

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -227,6 +227,6 @@ jobs:
 
       - name: Slack notification
         uses: ./.github/actions/slack-notification
-        if: failure()
+        if: failure() && github.triggering_actor == 'devOpsHazelcast'
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -40,6 +40,6 @@ jobs:
 
       - name: Slack notification
         uses: ./.github/actions/slack-notification
-        if: failure() && github.event_name == 'workflow_call'
+        if: failure() && github.event_name != 'workflow_dispatch'
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -40,6 +40,6 @@ jobs:
 
       - name: Slack notification
         uses: ./.github/actions/slack-notification
-        if: failure()
+        if: failure() && github.event_name == 'workflow_call'
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
When actions fail, they send a Slack notification - but this happens even for actions triggered via PR, which makes them noisy.

Updated to notify only for automated actions, where there is no real initiator - as otherwise the GitHub `actor` has _already_ been notified via email by GitHub.

For actions that run on a schedule or are triggered from other workflows, this change is trivial - but for those that are _always_ triggered "manually" via `workflow_dispatch`, we can only check the `actor` to reason if it's an automated action.

Removed notification entirely from `rhel-smoke-test` as this is _only ever_ triggered manually.

Fixes: [DI-464](https://hazelcast.atlassian.net/browse/DI-464)

[DI-464]: https://hazelcast.atlassian.net/browse/DI-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ