### PR TITLE
Remove failing LTS check backported in error

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -117,13 +117,6 @@ jobs:
         run: |
           docker login ${SCAN_REGISTRY} -u ${SCAN_REGISTRY_USER} -p ${SCAN_REGISTRY_PASSWORD}
 
-      - name: Check if latest EE LTS release
-        id: is_latest_lts
-        uses: ./.github/actions/check-if-latest-lts-release
-        with:
-          release_version: ${{ env.RELEASE_VERSION }}
-          is_lts_override: ${{ inputs.IS_LTS_OVERRIDE }}
-
       - name: Build the Hazelcast Enterprise image
         run: |
           . .github/scripts/get-tags-to-push.sh 


### PR DESCRIPTION
The build [failed](https://github.com/hazelcast/hazelcast-docker/actions/runs/15551877941) because it was referencing a `check-if-latest-lts-release` action that doesn't exist.

This reference was introduced in https://github.com/hazelcast/hazelcast-docker/pull/980, but was an error in the backport and should not have been introduced.

Removed.

Post-merge actions:
- [ ] backport to `5.4.1`
- [ ] rebuild RHEL `5.4.1`