### PR TITLE
Fix RHEL build failure due to backport error [5.4.1]

### DIFF
--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -43,6 +43,9 @@ wait_for_container_scan()
     local IMAGE_ID=$2
     local RHEL_API_KEY=$3
     local TIMEOUT_IN_MINS=$4
+    
+    local IMAGE
+    local IS_PUBLISHED
 
     IMAGE=$(get_image published "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}")
     IS_PUBLISHED=$(echo "${IMAGE}" | jq -r '.total')
@@ -52,12 +55,12 @@ wait_for_container_scan()
         return 0
     fi
 
-    local NOF_RETRIES=$(( $TIMEOUT_IN_MINS / 2 ))
+    local NOF_RETRIES=$(( TIMEOUT_IN_MINS / 2 ))
     # Wait until the image is scanned
-    for i in `seq 1 ${NOF_RETRIES}`; do
-        local IMAGE=$(get_image not_published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}")
-        local SCAN_STATUS=$(echo "$IMAGE" | jq -r '.data[0].container_grades.status')
-        local IMAGE_CERTIFIED=$(echo "$IMAGE" | jq -r '.data[0].certified')
+    for i in $(seq 1 "${NOF_RETRIES}"); do
+        local IMAGE
+        local SCAN_STATUS
+        local IMAGE_CERTIFIED
 
         IMAGE=$(get_image not_published "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}")
         SCAN_STATUS=$(echo "${IMAGE}" | jq -r '.data[0].container_grades.status')
@@ -65,20 +68,23 @@ wait_for_container_scan()
 
         if [[ ${SCAN_STATUS} == "pending" ]]; then
             echo "Scanning pending, waiting..."
-        elif [[ $SCAN_STATUS == "in progress" ]]; then
+        elif [[ ${SCAN_STATUS} == "in progress" ]]; then
             echo "Scanning in progress, waiting..."
-        elif [[ $SCAN_STATUS == "null" ]];  then
+        elif [[ ${SCAN_STATUS} == "null" ]];  then
             echo "Image is still not present in the registry!"
-        elif [[ $SCAN_STATUS == "completed" && "$IMAGE_CERTIFIED" == "true" ]]; then
+        elif [[ ${SCAN_STATUS} == "completed" && "${IMAGE_CERTIFIED}" == "true" ]]; then
             echo "Scan passed!" ; return 0
         else
-            echo "Scan failed!" ; return 1
+            echoerr "Scan failed with '${SCAN_STATUS}!"
+            echoerr "${IMAGE}"
+            return 1
         fi
 
         sleep 120
 
-        if [[ $i == $NOF_RETRIES ]]; then
-            echo "Timeout! Scan could not be finished"
+        if [[ ${i} == "${NOF_RETRIES}" ]]; then
+            echoerr "Timeout! Scan could not be finished"
+            echoerr "${IMAGE}"
             return 42
         fi
     done


### PR DESCRIPTION
There was a [RHEL build failure](https://github.com/hazelcast/hazelcast-docker/actions/runs/15559031202) caused by an error introduced into _only_ `5.4.1` due to a backport conflict.

Addressed by copying the problematic functions from the `5.4.z` script.

[Example (successful) execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/15564480718).