### PR TITLE
Fix missing `build.functions.sh` script [5.3.z]

### DIFF
--- a/.github/scripts/build.functions.sh
+++ b/.github/scripts/build.functions.sh
@@ -1,0 +1,25 @@
+@ -0,0 +1,24 @@
+set -euo pipefail ${RUNNER_DEBUG:+-x}
+
+# Checks if we should build the OSS artefacts.
+# Returns "yes" if we should build it or "no" if we shouldn't.
+function should_build_oss() {
+
+  local release_type=$1
+  if [[ $release_type =~ ^(ALL|OSS)$ ]]; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}
+
+# Checks if we should build EE artefacts.
+function should_build_ee() {
+
+  local release_type=$1
+  if [[ $release_type =~ ^(ALL|EE)$ ]]; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}


### PR DESCRIPTION
[The `push` fails because the file is missing](https://github.com/hazelcast/hazelcast-docker/actions/runs/15588959428/job/43902664508).

This looks to have been a backport error in https://github.com/hazelcast/hazelcast-docker/pull/789.

Including the latest file from `master`.

[Example execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/15589239205).