### PR TITLE
Rename `HZ_SNAPSHOT_INTERNAL_DOCKER_REGISTRY` secret

### DIFF
--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -28,7 +28,7 @@ jobs:
           - variant: slim
           - variant: ''
     env:
-      DOCKER_REGISTRY: ${{ secrets.JFROG_URL }}
+      DOCKER_REGISTRY: ${{ secrets.JFROG_REGISTRY }}
 
       # required by OSS get_hz_dist_zip function
       HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -28,7 +28,7 @@ jobs:
           - variant: slim
           - variant: ''
     env:
-      DOCKER_REGISTRY: ${{ secrets.HZ_SNAPSHOT_INTERNAL_DOCKER_REGISTRY }}
+      DOCKER_REGISTRY: ${{ secrets.JFROG_URL }}
 
       # required by OSS get_hz_dist_zip function
       HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}


### PR DESCRIPTION
The name of the secret is confusing - the registry is applicable to multiple repositories.

Name chosen as we authenticate with it using `JFROG`-labelled credentials: https://github.com/hazelcast/hazelcast-docker/blob/66909c17bff790e8eb9dc639693c9488728b3f42/.github/workflows/oss_latest_snapshot_push.yml#L101-L106

Raised from [PR feedback](https://github.com/hazelcast/hazelcast-docker/pull/991#discussion_r2140621328).

Post-merge actions:
- [ ] backport
- [x] rename the _actual_ secret
- [ ] update reference in https://github.com/hazelcast/hazelcast-docker/pull/991