### PR TITLE
Refactor how `assert.sh` is downloaded for tests

### DIFF
--- a/.github/scripts/build.functions_tests.sh
+++ b/.github/scripts/build.functions_tests.sh
@@ -5,10 +5,7 @@ set -eu ${RUNNER_DEBUG:+-x}
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-assert_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)
-# shellcheck source=/dev/null
-. <(echo "${assert_script_content}")
-. "$SCRIPT_DIR"/build.functions.sh
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 TESTS_RESULT=0
 

--- a/.github/scripts/build.functions_tests.sh
+++ b/.github/scripts/build.functions_tests.sh
@@ -7,6 +7,8 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 # Source the latest version of assert.sh unit testing library and include in current shell
 source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
+. "$SCRIPT_DIR"/build.functions.sh
+
 TESTS_RESULT=0
 
 function assert_should_build_oss {

--- a/.github/scripts/ee-build.functions_tests.sh
+++ b/.github/scripts/ee-build.functions_tests.sh
@@ -25,10 +25,7 @@ function find_script_dir() {
 SCRIPT_DIR=$(find_script_dir)
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-assert_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)
-# shellcheck source=/dev/null
-. <(echo "${assert_script_content}")
-. "$SCRIPT_DIR"/ee-build.functions.sh
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 TESTS_RESULT=0
 

--- a/.github/scripts/ee-build.functions_tests.sh
+++ b/.github/scripts/ee-build.functions_tests.sh
@@ -27,6 +27,8 @@ SCRIPT_DIR=$(find_script_dir)
 # Source the latest version of assert.sh unit testing library and include in current shell
 source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
+. "$SCRIPT_DIR"/ee-build.functions.sh
+
 TESTS_RESULT=0
 
 function assert_get_hz_dist_zip {

--- a/.github/scripts/get-tags-to-push_tests.sh
+++ b/.github/scripts/get-tags-to-push_tests.sh
@@ -6,10 +6,7 @@ set -eu ${RUNNER_DEBUG:+-x}
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-assert_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)
-# shellcheck source=/dev/null
-. <(echo "${assert_script_content}")
-. "$SCRIPT_DIR"/get-tags-to-push.sh
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 TESTS_RESULT=0
 

--- a/.github/scripts/get-tags-to-push_tests.sh
+++ b/.github/scripts/get-tags-to-push_tests.sh
@@ -8,6 +8,8 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 # Source the latest version of assert.sh unit testing library and include in current shell
 source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
+. "$SCRIPT_DIR"/get-tags-to-push.sh
+
 TESTS_RESULT=0
 
 function assert_get_version_only_tags_to_push {

--- a/.github/scripts/maven.functions_tests.sh
+++ b/.github/scripts/maven.functions_tests.sh
@@ -25,10 +25,7 @@ function find_script_dir() {
 SCRIPT_DIR=$(find_script_dir)
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-assert_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)
-# shellcheck source=/dev/null
-. <(echo "${assert_script_content}")
-
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 TESTS_RESULT=0
 
 # Functions overlap, so likely only testing one implementation - but as are duplicated, *shouldn't* be an issue

--- a/.github/scripts/maven.functions_tests.sh
+++ b/.github/scripts/maven.functions_tests.sh
@@ -26,6 +26,7 @@ SCRIPT_DIR=$(find_script_dir)
 
 # Source the latest version of assert.sh unit testing library and include in current shell
 source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+
 TESTS_RESULT=0
 
 # Functions overlap, so likely only testing one implementation - but as are duplicated, *shouldn't* be an issue

--- a/.github/scripts/oss-build.functions_tests.sh
+++ b/.github/scripts/oss-build.functions_tests.sh
@@ -27,6 +27,8 @@ SCRIPT_DIR=$(find_script_dir)
 # Source the latest version of assert.sh unit testing library and include in current shell
 source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
+. "$SCRIPT_DIR"/oss-build.functions.sh
+
 TESTS_RESULT=0
 
 

--- a/.github/scripts/oss-build.functions_tests.sh
+++ b/.github/scripts/oss-build.functions_tests.sh
@@ -25,10 +25,7 @@ function find_script_dir() {
 SCRIPT_DIR=$(find_script_dir)
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-assert_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)
-# shellcheck source=/dev/null
-. <(echo "${assert_script_content}")
-. "$SCRIPT_DIR"/oss-build.functions.sh
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 TESTS_RESULT=0
 

--- a/.github/scripts/version.functions_tests.sh
+++ b/.github/scripts/version.functions_tests.sh
@@ -3,10 +3,7 @@
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-assert_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)
-# shellcheck source=/dev/null
-. <(echo "${assert_script_content}")
-. "$SCRIPT_DIR"/version.functions.sh
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 TESTS_RESULT=0
 

--- a/.github/scripts/version.functions_tests.sh
+++ b/.github/scripts/version.functions_tests.sh
@@ -5,6 +5,8 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 # Source the latest version of assert.sh unit testing library and include in current shell
 source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
+. "$SCRIPT_DIR"/version.functions.sh
+
 TESTS_RESULT=0
 
 function assert_minor_versions_contain {


### PR DESCRIPTION
We can simplify as discussed [here](https://github.com/hazelcast/docker-actions/pull/1#discussion_r2149451062).