### PR TITLE
Fix `publish-rhel` [5.3.8]

### DIFF
--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail ${RUNNER_DEBUG:+-x}
+set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
 
 # shellcheck source=../.github/scripts/logging.functions.sh
 . .github/scripts/logging.functions.sh
@@ -12,18 +12,23 @@ get_image()
     local IMAGE_ID=$3
     local RHEL_API_KEY=$4
 
-    if [[ $PUBLISHED == "published" ]]; then
+    case "${PUBLISHED}" in
+        "published")
         local PUBLISHED_FILTER="repositories.published==true"
-    elif [[ $PUBLISHED == "not_published" ]]; then
+        ;;
+        "not_published")
         local PUBLISHED_FILTER="repositories.published!=true"
-    else
-        echo "Need first parameter as 'published' or 'not_published'." ; return 1
-    fi
+        ;;
+        *)
+        echoerr "Need first parameter as 'published' or 'not_published', not '${PUBLISHED}'." ; return 1
+        ;;
+    esac
 
     local FILTER="filter=deleted==false;${PUBLISHED_FILTER};_id==${IMAGE_ID}"
     local INCLUDE="include=total,data.repositories,data.certified,data.container_grades,data._id,data.creation_date"
 
-    local RESPONSE=$( \
+    local RESPONSE
+    RESPONSE=$( \
         curl --silent \
              --request GET \
              --header "X-API-KEY: ${RHEL_API_KEY}" \
@@ -38,6 +43,9 @@ wait_for_container_scan()
     local IMAGE_ID=$2
     local RHEL_API_KEY=$3
     local TIMEOUT_IN_MINS=$4
+    
+    local IMAGE
+    local IS_PUBLISHED
 
     IMAGE=$(get_image published "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}")
     IS_PUBLISHED=$(echo "${IMAGE}" | jq -r '.total')
@@ -47,12 +55,12 @@ wait_for_container_scan()
         return 0
     fi
 
-    local NOF_RETRIES=$(( $TIMEOUT_IN_MINS / 2 ))
+    local NOF_RETRIES=$(( TIMEOUT_IN_MINS / 2 ))
     # Wait until the image is scanned
-    for i in `seq 1 ${NOF_RETRIES}`; do
-        local IMAGE=$(get_image not_published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}")
-        local SCAN_STATUS=$(echo "$IMAGE" | jq -r '.data[0].container_grades.status')
-        local IMAGE_CERTIFIED=$(echo "$IMAGE" | jq -r '.data[0].certified')
+    for i in $(seq 1 "${NOF_RETRIES}"); do
+        local IMAGE
+        local SCAN_STATUS
+        local IMAGE_CERTIFIED
 
         IMAGE=$(get_image not_published "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}")
         SCAN_STATUS=$(echo "${IMAGE}" | jq -r '.data[0].container_grades.status')
@@ -60,20 +68,23 @@ wait_for_container_scan()
 
         if [[ ${SCAN_STATUS} == "pending" ]]; then
             echo "Scanning pending, waiting..."
-        elif [[ $SCAN_STATUS == "in progress" ]]; then
+        elif [[ ${SCAN_STATUS} == "in progress" ]]; then
             echo "Scanning in progress, waiting..."
-        elif [[ $SCAN_STATUS == "null" ]];  then
+        elif [[ ${SCAN_STATUS} == "null" ]];  then
             echo "Image is still not present in the registry!"
-        elif [[ $SCAN_STATUS == "completed" && "$IMAGE_CERTIFIED" == "true" ]]; then
+        elif [[ ${SCAN_STATUS} == "completed" && "${IMAGE_CERTIFIED}" == "true" ]]; then
             echo "Scan passed!" ; return 0
         else
-            echo "Scan failed!" ; return 1
+            echoerr "Scan failed with '${SCAN_STATUS}!"
+            echoerr "${IMAGE}"
+            return 1
         fi
 
         sleep 120
 
-        if [[ $i == $NOF_RETRIES ]]; then
-            echo "Timeout! Scan could not be finished"
+        if [[ ${i} == "${NOF_RETRIES}" ]]; then
+            echoerr "Timeout! Scan could not be finished"
+            echoerr "${IMAGE}"
             return 42
         fi
     done
@@ -105,12 +116,12 @@ publish_the_image()
             return 1
         fi
     else
-        echo "Image you are trying to publish does not exist."
+        echoerr "Image you are trying to publish does not exist."
+        echoerr "${IMAGE}"
         return 1
     fi
 
     echo "Publishing the image ${IMAGE_ID}..."
-    # https://catalog.redhat.com/api/containers/docs/endpoints/RESTPostImageRequestByCertProjectId.html
     RESPONSE=$( \
         curl --silent \
             --retry 5 --retry-all-errors \
@@ -120,10 +131,9 @@ publish_the_image()
             --header 'Content-Type: application/json' \
             --data "{\"image_id\":\"${IMAGE_ID}\" , \"operation\" : \"publish\" }" \
             "https://catalog.redhat.com/api/containers/v1/projects/certification/id/${RHEL_PROJECT_ID}/requests/images")
-    echo "Response: $RESPONSE"
+    echo "Response: ${RESPONSE}"
     echo "Created a publish request, please check if the image is published."
 }
-
 
 sync_tags()
 {
@@ -145,7 +155,6 @@ sync_tags()
     fi
 
     echo "Syncing tags of the image ${IMAGE_ID}..."
-    # https://catalog.redhat.com/api/containers/docs/endpoints/RESTPostImageRequestByCertProjectId.html
     RESPONSE=$( \
         curl --silent \
             --retry 5 --retry-all-errors \
@@ -155,7 +164,7 @@ sync_tags()
             --header 'Content-Type: application/json' \
             --data "{\"image_id\":\"${IMAGE_ID}\" , \"operation\" : \"sync-tags\" }" \
             "https://catalog.redhat.com/api/containers/v1/projects/certification/id/${RHEL_PROJECT_ID}/requests/images")
-    echo "Response: $RESPONSE"
+    echo "Response: ${RESPONSE}"
     echo "Created a sync-tags request, please check if the tags image are in sync."
 }
 
@@ -166,10 +175,11 @@ wait_for_container_publish()
     local RHEL_API_KEY=$3
     local TIMEOUT_IN_MINS=$4
 
-    local NOF_RETRIES=$(( $TIMEOUT_IN_MINS * 2 ))
+    local NOF_RETRIES=$(( TIMEOUT_IN_MINS * 2 ))
     # Wait until the image is published
-    for i in `seq 1 ${NOF_RETRIES}`; do
-        local IS_PUBLISHED=$(get_image published "${RHEL_PROJECT_ID}" "${VERSION}" "${RHEL_API_KEY}" | jq -r '.total')
+    for i in $(seq 1 "${NOF_RETRIES}"); do
+        local IMAGE
+        local IS_PUBLISHED
 
         IMAGE=$(get_image published "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}")
         IS_PUBLISHED=$(echo "${IMAGE}" | jq -r '.total')
@@ -185,7 +195,6 @@ wait_for_container_publish()
 
         if [[ ${i} == "${NOF_RETRIES}" ]]; then
             echoerr "Timeout! Publish could not be finished"
-            echoerr "Image Status:"
             echoerr "${IMAGE}"
 
             # Add additional logging context if possible


### PR DESCRIPTION
The [action failed](https://github.com/hazelcast/hazelcast-docker/actions/runs/15868710042) with:
> .github/scripts/publish-rhel.sh: line 32: VERSION: unbound variable

The root cause was that when https://github.com/hazelcast/hazelcast-docker/pull/968 was backported, there were _additional_ `5.3.8`-specific changes it wasn't accounting for (e.g. https://github.com/hazelcast/hazelcast-docker/pull/799 which was _not_ backported from `5.3.z` -> `5.3.8`).

Fixed by copying _wholesale_ the `5.3.z` `publish-rhel` script.

[Example execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/15869851560).