### PR TITLE
Fix JFrog EE repository credentials [5.3.z]

### DIFF
--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -148,8 +148,8 @@ jobs:
       - name: Get EE dist ZIP URL
         run: |
           . .github/scripts/ee-build.functions.sh
-          export JFROG_USERNAME=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
-          export JFROG_PASSWORD=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
+          export JFROG_USERNAME=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
+          export JFROG_PASSWORD=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
           echo "HAZELCAST_EE_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}")" >> $GITHUB_ENV
 
       - name: Build Test EE image


### PR DESCRIPTION
The username/password added in https://github.com/hazelcast/hazelcast-docker/pull/991 were reversed.

[Example execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/15900441703).