### PR TITLE
Fix tag_image_push.yml [5.4.z]

### DIFF
--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -60,8 +60,8 @@ jobs:
           
           release_type=${{ env.RELEASE_TYPE }}
           triggered_by=${{ github.event_name }}
-          should_build_oss = $(should_build_oss "$release_type")
-          should_build_ee = $(should_build_ee "$release_type")
+          should_build_oss=$(should_build_oss "$release_type")
+          should_build_ee=$(should_build_ee "$release_type")
           echo "should_build_ee=${should_build_ee}" >> $GITHUB_OUTPUT
           echo "should_build_oss=${should_build_oss}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Backports https://github.com/hazelcast/hazelcast-docker/pull/751 to address a [build failure](https://github.com/hazelcast/hazelcast-docker/actions/runs/15977003206).

[Example execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/15977824401).

[Slack discussion](https://hazelcast.slack.com/archives/C05LM8B80UT/p1751298263856939).