### PR TITLE
Update Docker test timeout

### DIFF
--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -127,7 +127,7 @@ jobs:
           password: ${{ env.REDHAT_CATALOG_REGISTRY_CONNECT_ROBOT_PASSWORD }}
 
       - name: Run smoke test against image
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
 


### PR DESCRIPTION
Docker testing [timed-out](https://github.com/hazelcast/hazelcast-docker/actions/runs/15978060413/job/45065583008#step:10:109) for `5.4.2` when fetching image so increasing timeout

See [Slack](https://hazelcast.slack.com/archives/C05LM8B80UT/p1751300593239939?thread_ts=1751298263.856939&cid=C05LM8B80UT)

