### PR TITLE
Fix `version.functions_tests.sh`

### DIFF
--- a/.github/scripts/version.functions_tests.sh
+++ b/.github/scripts/version.functions_tests.sh
@@ -90,7 +90,6 @@ assert_latest_patch_versions_not_contain "5.3" "$LATEST_5_4_DEVEL"
 
 log_header "Tests for get_last_version_with_file"
 assert_get_last_version_with_file ".github/containerscan/allowedlist.yaml" "5.3.1" # it was removed in 5.3.2
-assert_get_last_version_with_file ".github/actions/install-xmllint/action.yml" "5.4.1" # it was removed in 5.4.2
 assert_get_last_version_with_file "dummy-non-existing-file" ""
 
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"


### PR DESCRIPTION
The assertion says that `xmllint` was removed in `5.4.2`, but [it wasn't](https://github.com/hazelcast/hazelcast-docker/blob/v5.4.2/.github/actions/install-xmllint/action.yml) so it fails.

I'm not sure what the assertion is testing, but we already have coverage for the positive case of `get_last_version_with_file` so I think it's ok to remove.

Raised from https://github.com/hazelcast/hazelcast-docker/pull/1006#issuecomment-3024007418