### PR TITLE
Grant Write Permission for HZ_HOME [DEX-457]

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -58,8 +58,8 @@ RUN echo "Installing new packages" \
     && mv ${HZ_HOME}/tmp/*/* ${HZ_HOME}/ \
     && echo "Setting Pardot ID to 'docker'" \
     && echo 'hazelcastDownloadId=docker' > "${HZ_HOME}/lib/hazelcast-download.properties" \
-    && echo "Granting read permission to ${HZ_HOME}" \
-    && chmod -R +r ${HZ_HOME} \
+    && echo "Granting read&write&execute permissions to ${HZ_HOME}" \
+    && chmod -R a+rwX ${HZ_HOME} \
     && echo "Removing cached package data and unnecessary tools" \
     && microdnf -y remove zip unzip \
     && microdnf -y clean all \
@@ -71,9 +71,7 @@ COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml ${HZ_HOME}/c
 
 RUN echo "Adding non-root user" \
     && groupadd --system hazelcast \
-    && useradd --no-log-init --system --gid hazelcast --create-home ${USER_NAME} \
-    && echo "Changing owner of ${HZ_HOME} as ${USER_NAME}" \
-    && chown -R a+rwX ${USER_NAME}:${USER_NAME} ${HZ_HOME}
+    && useradd --no-log-init --system --gid hazelcast --create-home ${USER_NAME}
 
 WORKDIR ${HZ_HOME}
 

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -47,8 +47,8 @@ RUN echo "Upgrading APK packages" \
     && mv ${HZ_HOME}/tmp/*/* ${HZ_HOME}/ \
     && echo "Setting Pardot ID to 'docker'" \
     && echo 'hazelcastDownloadId=docker' > "${HZ_HOME}/lib/hazelcast-download.properties" \
-    && echo "Granting read permission to ${HZ_HOME}" \
-    && chmod -R +r ${HZ_HOME} \
+    && echo "Granting read&write&execute permission to ${HZ_HOME}" \
+    && chmod -R a+rwX ${HZ_HOME} \
     && echo "Cleaning APK packages and redundant files/folders" \
     && apk del libxml2-utils zip unzip \
     && rm -rf /var/cache/apk/* ${HZ_HOME}/maven.functions.sh ${HZ_HOME}/hazelcast-distribution.zip ${HZ_HOME}/tmp \
@@ -59,9 +59,7 @@ COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml ${HZ_HOME}/c
 
 WORKDIR ${HZ_HOME}
 
-RUN addgroup -S hazelcast && adduser -S hazelcast -G hazelcast \
-    && echo "Changing owner of ${HZ_HOME} as hazelcast" \
-    && chown -R a+rwX hazelcast:hazelcast ${HZ_HOME}
+RUN addgroup -S hazelcast && adduser -S hazelcast -G hazelcast
 USER hazelcast
 
 # Start Hazelcast server


### PR DESCRIPTION
The docker image fails to write diagnostics logs on default config. The default directory for logging output is `HZ_HOME` but it's missing the write permission. Apparently, the issue was there but it's catch during [DEX-320](https://hazelcast.atlassian.net/browse/DEX-320?atlOrigin=eyJpIjoiZDkzZWJhZGZiZTQ3NGYzMDk2MGRkNjMxODdhNjc0YWMiLCJwIjoiaiJ9) verifications.

[DEX-320]: https://hazelcast.atlassian.net/browse/DEX-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Unfortunately, I couldn't find a way to put proper testing on Docker containers.