### PR TITLE
Ensure `curl` failures properly reported [DI-569]

### DIFF
--- a/.github/scripts/generate-docker-hub-description.sh
+++ b/.github/scripts/generate-docker-hub-description.sh
@@ -7,7 +7,7 @@ get_formatted_latest_docker_tags() {
   local PAGE=1
   local TAGS=""
   while true; do
-    local RESPONSE=$(curl -s "https://hub.docker.com/v2/repositories/$REPO_NAME/tags/?page=${PAGE}&page_size=100")
+    local RESPONSE=$(curl --fail --silent --show-error "https://hub.docker.com/v2/repositories/$REPO_NAME/tags/?page=${PAGE}&page_size=100")
     local CURRENT_TAGS=$(echo "${RESPONSE}" | jq -r '.results | group_by(.full_size) | .[] | {image: .[0].name, tags: [.[].name]}')
     local TAGS="${TAGS}${CURRENT_TAGS}"
     local  HAS_NEXT=$(echo "${RESPONSE}" | jq -r '.next')

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -27,8 +27,9 @@ get_image()
     local RESPONSE
     # https://catalog.redhat.com/api/containers/docs/endpoints/RESTGetImagesForCertProjectById.html
     RESPONSE=$( \
-        curl --silent \
-             --request GET \
+        curl --fail \
+             --silent \
+             --show-error \
              --header "X-API-KEY: ${RHEL_API_KEY}" \
              "https://catalog.redhat.com/api/containers/v1/projects/certification/id/${RHEL_PROJECT_ID}/images?${FILTER}&${INCLUDE}")
 
@@ -113,7 +114,9 @@ publish_the_image()
     echo "Publishing the image ${IMAGE_ID}..."
     # https://catalog.redhat.com/api/containers/docs/endpoints/RESTPostImageRequestByCertProjectId.html
     RESPONSE=$( \
-        curl --silent \
+        curl --fail \
+             --silent \
+             --show-error \
             --retry 5 --retry-all-errors \
             --request POST \
             --header "X-API-KEY: ${RHEL_API_KEY}" \
@@ -156,7 +159,9 @@ wait_for_container_publish()
             # https://catalog.redhat.com/api/containers/docs/endpoints/RESTGetTestResultsById.html
             get_image not_published | jq -r '.data[]._links.test_results.href' | while read -r TEST_RESULTS_ENDPOINT; do
                 local TEST_RESULTS
-                TEST_RESULTS=$(curl --silent \
+                TEST_RESULTS=$(curl --fail \
+                    --silent \
+                    --show-error \
                     --request GET \
                     --header "X-API-KEY: ${RHEL_API_KEY}" \
                     "https://catalog.redhat.com/api/containers/${TEST_RESULTS_ENDPOINT}")
@@ -186,7 +191,9 @@ sync_tags()
     echo "Syncing tags of the image ${IMAGE_ID}..."
     # https://catalog.redhat.com/api/containers/docs/endpoints/RESTPostImageRequestByCertProjectId.html
     RESPONSE=$( \
-        curl --silent \
+        curl --fail \
+             --silent \
+             --show-error \
             --retry 5 --retry-all-errors \
             --request POST \
             --header "X-API-KEY: ${RHEL_API_KEY}" \


### PR DESCRIPTION
An API reponse error [was missed](https://github.com/hazelcast/hazelcast-docker/actions/runs/16141947481/job/45553664874) as _by default_, `curl` returns a 0-exit code regardless of the response and so we get a "successful" build, example:

```
% curl https://mock.httpstatus.io/409; echo "Error is $?"
Error is 0
```

In _some_ places we already specify the [`--fail` option](https://curl.se/docs/manpage.html#-f) to handle this:

```
% curl -f https://mock.httpstatus.io/409; echo "Error is $?"
Error is 56
```

Updated to add to the rest of the places where failure is unexpected.

Post-merge actions:
- [ ] backport