### PR TITLE
Make RedHat publish serial [DI-570]

### DIFF
--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -49,6 +49,8 @@ jobs:
       NLC_IMAGE_NAME: ${{ secrets.NLC_IMAGE_NAME }}
     strategy:
       fail-fast: false
+      # RedHat does not support concurrent publishing, run sequentially
+      max-parallel: 1
       matrix: ${{ fromJSON(needs.get-latest-patch-versions.outputs.matrix) }}
     steps:
       - name: Checkout Code
@@ -94,9 +96,32 @@ jobs:
         run: |
           echo "Rebuilding ${{ matrix.version }} EE image"
           gh workflow run tag_image_push.yml --ref v${{ matrix.version }} -f HZ_VERSION=${{ matrix.version }} -f RELEASE_TYPE=EE
-          gh workflow run tag_image_push_rhel.yml --ref v${{ matrix.version }} -f HZ_VERSION=${{ matrix.version }}
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Trigger rebuild ${{ matrix.version }} EE RHEL image
+        if: env.EE_NEEDS_REBUILD == 'yes'
+        # https://github.com/Codex-/return-dispatch/releases/tag/v2.1.0
+        uses: codex-/return-dispatch@72a3b5d4ff36e4319a7b1ab5b686c778ee02fa37
+        id: ee_rhel_rebuild_trigger
+        with:
+          token: ${{ secrets.GH_PAT }}
+          ref: v${{ matrix.version }}
+          repo: ${{ github.event.repository.name }}
+          owner: ${{ github.event.repository.owner.login }}
+          workflow: tag_image_push_rhel.yml
+          workflow_inputs: '{ "HZ_VERSION": "${{ matrix.version }}" }'
+          # Rely on timeout in calling job
+          workflow_timeout_seconds: 999999999
+          distinct_id: ${{ matrix.version }}
+      - name: Await rebuild ${{ matrix.version }} EE RHEL image
+        if: env.EE_NEEDS_REBUILD == 'yes'
+        # https://github.com/Codex-/await-remote-run/releases/tag/v1.13.0
+        uses: Codex-/await-remote-run@a56c556e6434d2d7ec9438dc656143b39532324e
+        with:
+          token: ${{ secrets.GH_PAT }}
+          repo: ${{ github.event.repository.name }}
+          owner: ${{ github.event.repository.owner.login }}
+          run_id: ${{ steps.ee_rhel_rebuild_trigger.outputs.run_id }}
       - name: Rebuild ${{ matrix.version }} EE NLC image
         if: env.EE_NLC_NEEDS_REBUILD == 'yes'
         run: |

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -96,8 +96,12 @@ jobs:
       RELEASE_VERSION: ${{ needs.prepare.outputs.RELEASE_VERSION }}
 
     runs-on: ubuntu-latest
+
+    # Workaround _suspected_ race conditions on the RedHat server-side publish
+    concurrency: rhel
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         jdk: ${{ fromJSON(needs.prepare.outputs.jdks) }}
     steps:

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -97,7 +97,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # Workaround _suspected_ race conditions on the RedHat server-side publish
+    # RedHat does not support concurrent publishing, run sequentially
     concurrency: rhel
     strategy:
       fail-fast: false


### PR DESCRIPTION
The RedHat publish is intermittently failing, most recently [here](https://github.com/hazelcast/hazelcast-docker/actions/runs/16285479358).

Specifically, the publish as asynchronous - we submit a publish request and poll for publish completion, which _intermittently_ never happens.

Further investigation [in conjunction with RedHat support](https://connect.redhat.com/support/partner-acceleration-desk/#/case/04139855) identified that the reason they aren't getting published is that _something_ is subsequently requesting the image to be _un_published. This is _probably_ a `sync-tags` request which has the (server-side) side-effect of unpublishing any subsequently-orphaned images - i.e. if an image has had it's tags removed and is no longer "accessible", it is removed.

However, although we can hypothesise _how_ they are removed, we do not understand _why_ - the images do not overlap and it _appears_ to be a race condition on the RedHat backend. This issue is more prevalent with scheduled image rebuilds where we build many versions and images in parallel.

As such, we will no longer publish RedHat images in parallel.

We have multiple layers of concurrency:
- per-JDK
   - we build JDK variants (`17`, `21` etc) of the _same_ version in parallel in the matrix
   - `max-parallel` set to restrict this
- per-version
   - multiple versions (`5.4`, `5.5`) are triggered in parallel by the scheduled image rebuild, or manually
   - `concurrency` group set to restrict this - [note that GitHub supports at most two jobs within the same concurrency group](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#using-concurrency-in-different-scenarios) (one running, one pending) and any additional jobs will be rejected - not queued as you might expect. This is acceptable as we _currently_ only have two versions _in_ RedHat, but _if_ that increased we may need to consider an alternative solution, additional restrictions etc.

Fixes: [DI-570](https://hazelcast.atlassian.net/browse/DI-570)

Post-merge actions:
- [ ] backport

[DI-570]: https://hazelcast.atlassian.net/browse/DI-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ