### PR TITLE
Ensure `curl` failures properly reported [DI-569] [5.5.6]

### DIFF
--- a/.github/scripts/generate-docker-hub-description.sh
+++ b/.github/scripts/generate-docker-hub-description.sh
@@ -7,7 +7,11 @@ get_formatted_latest_docker_tags() {
   local PAGE=1
   local TAGS=""
   while true; do
-    local RESPONSE=$(curl -s "https://hub.docker.com/v2/repositories/$REPO_NAME/tags/?page=${PAGE}&page_size=100")
+    local RESPONSE=$( \
+      curl --fail \
+        --silent \
+        --show-error \
+        "https://hub.docker.com/v2/repositories/$REPO_NAME/tags/?page=${PAGE}&page_size=100")
     local CURRENT_TAGS=$(echo "${RESPONSE}" | jq -r '.results | group_by(.full_size) | .[] | {image: .[0].name, tags: [.[].name]}')
     local TAGS="${TAGS}${CURRENT_TAGS}"
     local  HAS_NEXT=$(echo "${RESPONSE}" | jq -r '.next')

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -29,8 +29,9 @@ get_image()
 
     local RESPONSE
     RESPONSE=$( \
-        curl --silent \
-             --request GET \
+        curl --fail \
+             --silent \
+             --show-error \
              --header "X-API-KEY: ${RHEL_API_KEY}" \
              "https://catalog.redhat.com/api/containers/v1/projects/certification/id/${RHEL_PROJECT_ID}/images?${FILTER}&${INCLUDE}")
 
@@ -123,7 +124,9 @@ publish_the_image()
 
     echo "Publishing the image ${IMAGE_ID}..."
     RESPONSE=$( \
-        curl --silent \
+        curl --fail \
+             --silent \
+             --show-error \
             --retry 5 --retry-all-errors \
             --request POST \
             --header "X-API-KEY: ${RHEL_API_KEY}" \
@@ -157,7 +160,9 @@ sync_tags()
 
     echo "Syncing tags of the image ${IMAGE_ID}..."
     RESPONSE=$( \
-        curl --silent \
+        curl --fail \
+             --silent \
+             --show-error \
             --retry 5 --retry-all-errors \
             --request POST \
             --header "X-API-KEY: ${RHEL_API_KEY}" \
@@ -203,7 +208,9 @@ wait_for_container_publish()
             # https://catalog.redhat.com/api/containers/docs/endpoints/RESTGetTestResultsById.html
             get_image not_published "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}" | jq -r '.data[]._links.test_results.href' | while read -r TEST_RESULTS_ENDPOINT; do
                 local TEST_RESULTS
-                TEST_RESULTS=$(curl --silent \
+                TEST_RESULTS=$(curl --fail \
+                    --silent \
+                    --show-error \
                     --request GET \
                     --header "X-API-KEY: ${RHEL_API_KEY}" \
                     "https://catalog.redhat.com/api/containers/${TEST_RESULTS_ENDPOINT}")


### PR DESCRIPTION
Backports https://github.com/hazelcast/hazelcast-docker/pull/1011