### PR TITLE
Improve RedHat publish timeout logging

### DIFF
--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -22,7 +22,6 @@ get_image()
     esac
 
     local FILTER="filter=deleted==false;${PUBLISHED_FILTER};_id==${IMAGE_ID}"
-    local INCLUDE="include=total,data.repositories,data.certified,data.container_grades,data._id,data.creation_date"
 
     local RESPONSE
     # https://catalog.redhat.com/api/containers/docs/endpoints/RESTGetImagesForCertProjectById.html
@@ -31,7 +30,7 @@ get_image()
              --silent \
              --show-error \
              --header "X-API-KEY: ${RHEL_API_KEY}" \
-             "https://catalog.redhat.com/api/containers/v1/projects/certification/id/${RHEL_PROJECT_ID}/images?${FILTER}&${INCLUDE}")
+             "https://catalog.redhat.com/api/containers/v1/projects/certification/id/${RHEL_PROJECT_ID}/images?${FILTER}")
 
     echo "${RESPONSE}"
 }
@@ -150,6 +149,8 @@ wait_for_container_publish()
         sleep 30
 
         if [[ ${i} == "${NOF_RETRIES}" ]]; then
+            IMAGE=$(get_image not_published)
+
             echoerr "Timeout! Publish could not be finished"
             echoerr "Image Status:"
             echoerr "${IMAGE}"
@@ -157,7 +158,7 @@ wait_for_container_publish()
             # Add additional logging context if possible
             echoerr "Test Results:"
             # https://catalog.redhat.com/api/containers/docs/endpoints/RESTGetTestResultsById.html
-            get_image not_published | jq -r '.data[]._links.test_results.href' | while read -r TEST_RESULTS_ENDPOINT; do
+            echo "${IMAGE}" | jq -r '.data[]._links.test_results.href' | while read -r TEST_RESULTS_ENDPOINT; do
                 local TEST_RESULTS
                 TEST_RESULTS=$(curl --fail \
                     --silent \


### PR DESCRIPTION
When the publish of an image fails (more specifically - does not complete / times out), we log the status of the API when querying the state of the tests.

This has a couple of issues:
- when we query the image status (`get_image`), we filter by certain fields - but this means we aren't including other fields such as `status_message`. By default all fields are returned, we should log all available information
- in the event of a publish failure - where the results of querying for `published` images returns nothing - we log the images returned... of which there are none. We should instead log information on the `unpublished` images, whose tests results we subsequently check

Post-merge actions:
- [ ] backport