### PR TITLE
Fix `oss-build.functions_tests` formatting

### DIFF
--- a/.github/scripts/oss-build.functions_tests.sh
+++ b/.github/scripts/oss-build.functions_tests.sh
@@ -31,7 +31,6 @@ source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelca
 
 TESTS_RESULT=0
 
-
 function assert_get_hz_dist_zip {
   local hz_variant=$1
   local hz_version=$2


### PR DESCRIPTION
There is an extra blank line - I used this file as a template for my tests and the extra line [was critiqued](https://github.com/hazelcast/hazelcast-docker/pull/1021#discussion_r2215973564).

As such, remove from source.