### PR TITLE
Consistently use `function` keyword

### DIFF
--- a/.github/scripts/cluster-verification.sh
+++ b/.github/scripts/cluster-verification.sh
@@ -6,7 +6,7 @@ set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
 . .github/scripts/logging.functions.sh
 
 #CHECK IF THE LAST MEMBER POD IS READY
-wait_for_last_member_initialization() {
+function wait_for_last_member_initialization() {
     local SIZE=$1
     local LAST_MEMBER=$(( $SIZE - 1 ))
     for i in `seq 1 10`; do
@@ -28,7 +28,7 @@ wait_for_last_member_initialization() {
 }
 
 #CHECK IF CLUSTER SIZE IS CORRECT
-verify_cluster_size() {
+function verify_cluster_size() {
     local SIZE=$1
     local LAST_MEMBER=$(( $SIZE - 1 ))
     for i in `seq 1 5`; do
@@ -51,7 +51,7 @@ verify_cluster_size() {
 
 
 #CHECK IF ALL MEMBERS CAN COMMUNICATE WITH MANAGEMENT CENTER
-verify_management_center() {
+function verify_management_center() {
     local SIZE=$1
     echo "Verifying Management Center"
     for i in `seq 1 5`; do

--- a/.github/scripts/generate-docker-hub-description.sh
+++ b/.github/scripts/generate-docker-hub-description.sh
@@ -2,7 +2,7 @@
 
 set -eEuo pipefail ${RUNNER_DEBUG:+-x}
 
-get_formatted_latest_docker_tags() {
+function get_formatted_latest_docker_tags() {
   local REPO_NAME=$1
   local PAGE=1
   local TAGS=""
@@ -29,7 +29,7 @@ get_formatted_latest_docker_tags() {
   echo "${LATEST_TAGS}"| jq -sr '.[] | " - " + (.tags | sort_by(.) | join(", "))' | sort -V
 }
 
-fill_readme_with_tags() {
+function fill_readme_with_tags() {
    local filename=$1
    local repo_name=$2
    local matching_line="$3"


### PR DESCRIPTION
A `function` keyword was missing and spotted in a [PR review](https://github.com/hazelcast/hazelcast-docker/pull/1021#discussion_r2215996945). We use it _almost_ everywhere, so fixing the couple missing for consistency.

Note - the [Google style guide](https://google.github.io/styleguide/shellguide.html#s7.1-function-names) has no opinion either way, but there are [positives and negatives](https://stackoverflow.com/q/7917018) to using it.

Note - skipping `log.functions`, as will be removed in https://github.com/hazelcast/hazelcast-docker/pull/1021