### PR TITLE
Remove redundant `checkout` following `get-supported-jdks` externalisation

### DIFF
--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -24,9 +24,6 @@ jobs:
       HZ_VERSION: ${{ steps.set_hz_version.outputs.HZ_VERSION }}
       jdks: ${{ steps.jdks.outputs.jdks }}
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
       - name: Set HZ version
         id: set_hz_version
         run: |

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -59,9 +59,6 @@ jobs:
       RELEASE_VERSION: ${{ steps.set_release_version.outputs.RELEASE_VERSION }}
       jdks: ${{ steps.jdks.outputs.jdks }}
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
       - name: Set HZ version
         id: set_hz_version
         run: |


### PR DESCRIPTION
The `get-supported-jdks` action was externalised from the repository in https://github.com/hazelcast/hazelcast-docker/pull/1012 - as such the `checkout` required to ensure it's availability is redundant and can be removed.