### PR TITLE
Centralise `derive-versions` logic

### DIFF
--- a/.github/actions/derive-versions/action.yml
+++ b/.github/actions/derive-versions/action.yml
@@ -1,0 +1,36 @@
+name: Derive versions
+description: Calculates appropriate HZ_VERSION and RELEASE_VERSION
+inputs:
+  hz_version:
+    description: 'Version of Hazelcast to build the image for, e.g. 5.1.1, 5.0.1'
+    required: false
+  release_version:
+    description: 'Version to tag the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
+    required: false
+outputs:
+  hz_version:
+    value: ${{ steps.set_hz_version.outputs.HZ_VERSION }}
+  release_version:
+    value: ${{ steps.set_release_version.outputs.RELEASE_VERSION }}
+runs:
+  using: composite
+  steps:
+    - name: Set HZ version
+      shell: bash
+      id: set_hz_version
+      run: |
+        if [ -n "${{ inputs.HZ_VERSION }}" ]; then
+          echo "HZ_VERSION=${{ inputs.HZ_VERSION }}" >> ${GITHUB_OUTPUT}
+        else
+          echo "HZ_VERSION=${GITHUB_REF:11}" >> ${GITHUB_OUTPUT}
+        fi
+
+    - name: Set Release version
+      shell: bash
+      id: set_release_version
+      run: |
+        if [ -n "${{ inputs.RELEASE_VERSION }}" ]; then
+            echo "RELEASE_VERSION=${{ inputs.RELEASE_VERSION }}" >> ${GITHUB_OUTPUT}
+        else
+            echo "RELEASE_VERSION=${{ steps.set_hz_version.outputs.HZ_VERSION }}" >> ${GITHUB_OUTPUT}
+        fi

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -21,26 +21,22 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      HZ_VERSION: ${{ steps.set_hz_version.outputs.HZ_VERSION }}
+      HZ_VERSION: ${{ steps.derive-versions.outputs.HZ_VERSION }}
       jdks: ${{ steps.jdks.outputs.jdks }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Set HZ version
-        id: set_hz_version
-        run: |
-          if [ -n "${{ inputs.HZ_VERSION }}" ]; then
-            echo "HZ_VERSION=${{ inputs.HZ_VERSION }}" >> $GITHUB_OUTPUT
-          else
-            echo "HZ_VERSION=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
-          fi
+      - id: derive-versions
+        uses: ./.github/actions/derive-versions
+        with:
+          hz_version: ${{ inputs.HZ_VERSION }}
 
       - name: Get supported JDKs
         id: jdks
         uses: hazelcast/docker-actions/get-supported-jdks@master
         with:
-          HZ_VERSION: '${{ steps.set_hz_version.outputs.HZ_VERSION }}'
+          HZ_VERSION: '${{ steps.derive-versions.outputs.HZ_VERSION }}'
 
   push:
     runs-on: ubuntu-latest

--- a/.github/workflows/rhel-smoke-test.yml
+++ b/.github/workflows/rhel-smoke-test.yml
@@ -7,36 +7,30 @@ on:
         description: 'Version of Hazelcast to build the image for, e.g. 5.1.1, 5.0.1'
         required: true
       RELEASE_VERSION:
-        description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
+        description: 'Version to tag the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         required: false
 
 jobs:
   test:
     env:
       SCAN_REGISTRY: "quay.io"
-      HZ_VERSION: ${{ inputs.HZ_VERSION }}
-      RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
       PROJECT_NAME: test-${{ github.run_id }}-${{ github.run_attempt }}
 
     runs-on: ubuntu-latest
     steps:
-      - name: Set HZ version as environment variable
-        if: env.HZ_VERSION == ''
-        run: |
-          echo "HZ_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
-
-      - name: Set Release version as environment variable
-        if: env.RELEASE_VERSION == ''
-        run: |
-          echo "RELEASE_VERSION=${{ env.HZ_VERSION }}" >> $GITHUB_ENV
-
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - id: derive-versions
+        uses: ./.github/actions/derive-versions
+        with:
+          hz_version: ${{ inputs.HZ_VERSION }}
+          release_version: ${{ inputs.RELEASE_VERSION }}
 
       - uses: madhead/semver-utils@latest
         id: version
         with:
-          version: ${{ env.HZ_VERSION }}
+          version: ${{ steps.derive-versions.outputs.HZ_VERSION }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.6.0
@@ -104,7 +98,7 @@ jobs:
 
           helm install "${PROJECT_NAME}" "${CHART}" \
             --set image.repository="registry.connect.redhat.com/hazelcast/hazelcast-enterprise-${{ steps.version.outputs.major }}-rhel8" \
-            --set image.tag="${RELEASE_VERSION}" \
+            --set image.tag="${{ steps.derive-versions.outputs.RELEASE_VERSION }}" \
             --set image.pullPolicy="Always" \
             --set hazelcast.licenseKeySecretName="hz-license-secret" \
             --set securityContext.enabled=false \

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -14,7 +14,7 @@ on:
         description: 'Version of Hazelcast to build the image for, e.g. 5.1.1, 5.0.1, 4.2.3'
         required: true
       RELEASE_VERSION:
-        description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
+        description: 'Version to tag the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         required: false
       RELEASE_TYPE:
         description: 'What should be built'
@@ -49,7 +49,7 @@ on:
         required: true
       RELEASE_VERSION:
         type: string
-        description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
+        description: 'Version to tag the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         required: false
       RELEASE_TYPE:
         description: 'What should be built'
@@ -78,8 +78,8 @@ jobs:
     outputs:
       should_build_oss: ${{ steps.which_editions.outputs.should_build_oss }}
       should_build_ee: ${{ steps.which_editions.outputs.should_build_ee }}
-      HZ_VERSION: ${{ steps.set_hz_version.outputs.HZ_VERSION }}
-      RELEASE_VERSION: ${{ steps.set_release_version.outputs.RELEASE_VERSION }}
+      HZ_VERSION: ${{ steps.derive-versions.outputs.HZ_VERSION }}
+      RELEASE_VERSION: ${{ steps.derive-versions.outputs.RELEASE_VERSION }}
       jdks: ${{ steps.jdks.outputs.jdks }}
     steps:
       - name: Checkout Code
@@ -108,29 +108,17 @@ jobs:
           echo "should_build_ee=${should_build_ee}" >> $GITHUB_OUTPUT
           echo "should_build_oss=${should_build_oss}" >> $GITHUB_OUTPUT
 
-      - name: Set HZ version
-        id: set_hz_version
-        run: |
-          if [ -n "${{ inputs.HZ_VERSION }}" ]; then
-            echo "HZ_VERSION=${{ inputs.HZ_VERSION }}" >> $GITHUB_OUTPUT
-          else
-            echo "HZ_VERSION=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Set Release version
-        id: set_release_version
-        run: |
-            if [ -n "${{ inputs.RELEASE_VERSION }}" ]; then
-                echo "RELEASE_VERSION=${{ inputs.RELEASE_VERSION }}" >> $GITHUB_OUTPUT
-            else
-                echo "RELEASE_VERSION=${{ steps.set_hz_version.outputs.HZ_VERSION }}" >> $GITHUB_OUTPUT
-            fi
+      - id: derive-versions
+        uses: ./.github/actions/derive-versions
+        with:
+          hz_version: ${{ inputs.HZ_VERSION }}
+          release_version: ${{ inputs.RELEASE_VERSION }}
 
       - name: Get supported JDKs
         id: jdks
         uses: hazelcast/docker-actions/get-supported-jdks@master
         with:
-          HZ_VERSION: '${{ steps.set_hz_version.outputs.HZ_VERSION }}'
+          HZ_VERSION: '${{ steps.derive-versions.outputs.HZ_VERSION }}'
   push:
     runs-on: ubuntu-latest
     needs: [ prepare ]

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -14,7 +14,7 @@ on:
         description: 'Version of Hazelcast to build the image for, e.g. 5.1.1, 5.0.1'
         required: true
       RELEASE_VERSION:
-        description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
+        description: 'Version to tag the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         required: false
       IS_LTS_OVERRIDE:
         description: 'Override is LTS release'
@@ -40,7 +40,7 @@ on:
         required: true
       RELEASE_VERSION:
         type: string
-        description: 'Version of the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
+        description: 'Version to tag the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         required: false
       IS_LTS_OVERRIDE:
         description: 'Override is LTS release'
@@ -55,36 +55,24 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      HZ_VERSION: ${{ steps.set_hz_version.outputs.HZ_VERSION }}
-      RELEASE_VERSION: ${{ steps.set_release_version.outputs.RELEASE_VERSION }}
+      HZ_VERSION: ${{ steps.derive-versions.outputs.HZ_VERSION }}
+      RELEASE_VERSION: ${{ steps.derive-versions.outputs.RELEASE_VERSION }}
       jdks: ${{ steps.jdks.outputs.jdks }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Set HZ version
-        id: set_hz_version
-        run: |
-          if [ -n "${{ inputs.HZ_VERSION }}" ]; then
-            echo "HZ_VERSION=${{ inputs.HZ_VERSION }}" >> $GITHUB_OUTPUT
-          else
-            echo "HZ_VERSION=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Set Release version
-        id: set_release_version
-        run: |
-          if [ -n "${{ inputs.RELEASE_VERSION }}" ]; then
-              echo "RELEASE_VERSION=${{ inputs.RELEASE_VERSION }}" >> $GITHUB_OUTPUT
-          else
-              echo "RELEASE_VERSION=${{ steps.set_hz_version.outputs.HZ_VERSION }}" >> $GITHUB_OUTPUT
-          fi
+      - id: derive-versions
+        uses: ./.github/actions/derive-versions
+        with:
+          hz_version: ${{ inputs.HZ_VERSION }}
+          release_version: ${{ inputs.RELEASE_VERSION }}
 
       - name: Get supported JDKs
         id: jdks
         uses: hazelcast/docker-actions/get-supported-jdks@master
         with:
-          HZ_VERSION: '${{ steps.set_hz_version.outputs.HZ_VERSION }}'
+          HZ_VERSION: '${{ steps.derive-versions.outputs.HZ_VERSION }}'
 
   build:
     needs: prepare


### PR DESCRIPTION
The logic to derive `HZ_VERSION` & `RELEASE_VERSION` is duplicated and should be consolidated.

[Example execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/16457323572) (shows `RELEASE_VERSION` derived as expected, not necessarily that the tests pass).

Closes https://github.com/hazelcast/hazelcast-docker/pull/1030 (the `checkout` is no longer redundant).