### PR TITLE
Centralise `variants` matrix

### DIFF
--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -24,29 +24,22 @@ jobs:
         with:
           HZ_VERSION: '${{ inputs.HZ_VERSION }}'
 
+  distribution-variants:
+    uses: hazelcast/hazelcast-docker/.github/workflows/get-distribution-variants.yaml@centralise-variants
+
   push:
     runs-on: ubuntu-latest
-    needs: jdks
+    needs:
+      - jdks
+      - distribution-variants
     strategy:
       matrix:
         jdk: ${{ fromJSON(needs.jdks.outputs.jdks) }}
-        variant: [ 'slim','' ]
-        include:
-          - variant: slim
-          - variant: ''
+        variant: ${{ fromJSON(needs.distribution-variants.outputs.variants) }}
     env:
       DOCKER_ORG: hazelcast
       HZ_VERSION : ${{ inputs.HZ_VERSION }}
     steps:
-      - name: Compute Suffix
-        run: |
-          if [ -n "${{ matrix.variant }}" ]; then
-            SUFFIX=-${{ matrix.variant }}
-          else
-            SUFFIX=
-          fi
-          echo "SUFFIX=${SUFFIX}" >> $GITHUB_ENV
-
       - name: Checkout Code
         uses: actions/checkout@v4
 
@@ -68,7 +61,7 @@ jobs:
       - name: Get EE dist ZIP URL
         run: |
           . .github/scripts/ee-build.functions.sh
-          echo "HAZELCAST_EE_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${HZ_VERSION}")" >> $GITHUB_ENV
+          echo "HAZELCAST_EE_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant.classifier }}" "${HZ_VERSION}")" >> $GITHUB_ENV
 
       - name: Build Test EE image
         run: |
@@ -88,7 +81,7 @@ jobs:
       - name: Get docker logs
         if: ${{ always() }}
         run: |
-          DOCKER_LOG_FILE_EE=docker-${{ env.test_container_name_ee }}${{ env.SUFFIX }}-jdk${{ matrix.jdk }}.log
+          DOCKER_LOG_FILE_EE=docker-${{ env.test_container_name_ee }}${{ matrix.variant.suffix }}-jdk${{ matrix.jdk }}.log
           echo "DOCKER_LOG_FILE_EE=${DOCKER_LOG_FILE_EE}" >> $GITHUB_ENV
           docker logs "${{ env.test_container_name_ee }}" > "${DOCKER_LOG_FILE_EE}"
 
@@ -96,7 +89,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs${{ env.SUFFIX }}-${{ github.job }}-jdk${{ matrix.jdk }}
+          name: docker-logs${{ matrix.variant.suffix }}-${{ github.job }}-jdk${{ matrix.jdk }}
           path: |
             ${{ env.DOCKER_LOG_FILE_EE }}
 
@@ -120,7 +113,7 @@ jobs:
           IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast-enterprise
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
 
-          TAGS_TO_PUSH=$(augment_with_suffixed_tags "${VERSIONS[*]}" "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          TAGS_TO_PUSH=$(augment_with_suffixed_tags "${VERSIONS[*]}" "${{ matrix.variant.suffix }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}

--- a/.github/workflows/get-distribution-variants.yaml
+++ b/.github/workflows/get-distribution-variants.yaml
@@ -1,0 +1,17 @@
+name: Get distribution variants
+
+on:
+  workflow_call:
+    outputs:
+      variants:
+        value: ${{ jobs.get-distribution-variants.outputs.variants }}
+
+jobs:
+  get-distribution-variants:
+    runs-on: ubuntu-latest
+    outputs:
+      variants: ${{ steps.get-matrix.outputs.variants }}
+    steps:
+      - id: get-matrix
+        run: |
+          echo "variants=$(jq --null-input --compact-output '["slim", ""] | map({ classifier: ., suffix: (if . == "" then "" else "-\(.)" end) })')" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -24,17 +24,19 @@ jobs:
         with:
           HZ_VERSION: '${{ inputs.HZ_VERSION }}'
 
+  distribution-variants:
+    uses: hazelcast/hazelcast-docker/.github/workflows/get-distribution-variants.yaml@centralise-variants
+
   push:
     runs-on: ubuntu-latest
-    needs: jdks
+    needs:
+      - jdks
+      - distribution-variants
     strategy:
       fail-fast: false
       matrix:
         jdk: ${{ fromJSON(needs.jdks.outputs.jdks) }}
-        variant: [ 'slim','' ]
-        include:
-          - variant: slim
-          - variant: ''
+        variant: ${{ fromJSON(needs.distribution-variants.outputs.variants) }}
     env:
       DOCKER_REGISTRY: ${{ secrets.JFROG_REGISTRY }}
 
@@ -44,16 +46,6 @@ jobs:
 
       HZ_VERSION: ${{ inputs.HZ_VERSION }}
     steps:
-      - name: Compute Suffix
-        run: |
-          if [ -n "${{ matrix.variant }}" ]; then
-            SUFFIX=-${{ matrix.variant }}
-          else
-            SUFFIX=
-          fi
-          echo "SUFFIX=${SUFFIX}" >> $GITHUB_ENV
-          
-
       - name: Checkout Code
         uses: actions/checkout@v4
 
@@ -75,7 +67,7 @@ jobs:
       - name: Get OSS dist ZIP
         run: |
           . .github/scripts/oss-build.functions.sh
-          HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${HZ_VERSION}")
+          HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant.classifier }}" "${HZ_VERSION}")
         
           curl --fail --silent --show-error --location "$HAZELCAST_OSS_ZIP_URL" --output hazelcast-oss/hazelcast-distribution.zip;
 
@@ -94,7 +86,7 @@ jobs:
       - name: Get docker logs
         if: ${{ always() }}
         run: |
-          DOCKER_LOG_FILE_OSS=docker-${{ env.test_container_name_oss }}${{ env.SUFFIX }}-jdk${{ matrix.jdk }}.log
+          DOCKER_LOG_FILE_OSS=docker-${{ env.test_container_name_oss }}${{ matrix.variant.suffix }}-jdk${{ matrix.jdk }}.log
           echo "DOCKER_LOG_FILE_OSS=${DOCKER_LOG_FILE_OSS}" >> $GITHUB_ENV
           docker logs "${{ env.test_container_name_oss }}" > "${DOCKER_LOG_FILE_OSS}"
 
@@ -102,7 +94,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs${{ env.SUFFIX }}-${{ github.job }}-jdk${{ matrix.jdk }}
+          name: docker-logs${{ matrix.variant.suffix }}-${{ github.job }}-jdk${{ matrix.jdk }}
           path: |
             ${{ env.DOCKER_LOG_FILE_OSS }}
 
@@ -125,7 +117,7 @@ jobs:
           IMAGE_NAME=$DOCKER_REGISTRY/docker/hazelcast/hazelcast
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
 
-          TAGS_TO_PUSH=$(augment_with_suffixed_tags "${VERSIONS[*]}" "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
+          TAGS_TO_PUSH=$(augment_with_suffixed_tags "${VERSIONS[*]}" "${{ matrix.variant.suffix }}" "${{ matrix.jdk }}" "$DEFAULT_JDK")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -119,16 +119,19 @@ jobs:
         uses: hazelcast/docker-actions/get-supported-jdks@master
         with:
           HZ_VERSION: '${{ steps.derive-versions.outputs.HZ_VERSION }}'
+
+  distribution-variants:
+    uses: hazelcast/hazelcast-docker/.github/workflows/get-distribution-variants.yaml@centralise-variants
+
   push:
     runs-on: ubuntu-latest
-    needs: [ prepare ]
+    needs:
+      - prepare
+      - distribution-variants
     strategy:
       matrix:
         jdk: ${{ fromJSON(needs.prepare.outputs.jdks) }}
-        variant: [ 'slim','' ]
-        include:
-          - variant: slim
-          - variant: ''
+        variant: ${{ fromJSON(needs.distribution-variants.outputs.variants) }}
     env:
       DOCKER_ORG: hazelcast
       HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION }}
@@ -137,15 +140,8 @@ jobs:
 
       - name: Set environment variables
         run: |
-          if [ -n "${{ matrix.variant }}" ]; then
-            SUFFIX=-${{ matrix.variant }}
-          else
-            SUFFIX=
-          fi
-          echo "SUFFIX=${SUFFIX}" >> $GITHUB_ENV
-
-          echo "DOCKER_LOG_FILE_OSS=docker-${{ env.test_container_name_oss }}${SUFFIX}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
-          echo "DOCKER_LOG_FILE_EE=docker-${{ env.test_container_name_ee }}${SUFFIX}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
+          echo "DOCKER_LOG_FILE_OSS=docker-${{ env.test_container_name_oss }}${{ matrix.variant.suffix }}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
+          echo "DOCKER_LOG_FILE_EE=docker-${{ env.test_container_name_ee }}${{ matrix.variant.suffix }}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
 
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -178,7 +174,7 @@ jobs:
         if: needs.prepare.outputs.should_build_oss == 'yes'
         run: |
           . .github/scripts/oss-build.functions.sh
-          echo "HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}")" >> $GITHUB_ENV
+          echo "HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant.classifier }}" "${{ env.HZ_VERSION }}")" >> $GITHUB_ENV
 
       - name: Build Test OSS image
         if: needs.prepare.outputs.should_build_oss == 'yes'
@@ -199,7 +195,7 @@ jobs:
         if: needs.prepare.outputs.should_build_ee == 'yes'
         run: |
           . .github/scripts/ee-build.functions.sh
-          echo "HAZELCAST_EE_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant }}" "${{ env.HZ_VERSION }}")" >> $GITHUB_ENV
+          echo "HAZELCAST_EE_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant.classifier }}" "${{ env.HZ_VERSION }}")" >> $GITHUB_ENV
 
       - name: Build Test EE image
         if: needs.prepare.outputs.should_build_ee == 'yes'
@@ -229,7 +225,7 @@ jobs:
         if: ${{ always() && ( needs.prepare.outputs.should_build_ee == 'yes' || needs.prepare.outputs.should_build_oss == 'yes') }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs${{ env.SUFFIX }}-${{ github.job }}-jdk${{ matrix.jdk }}
+          name: docker-logs${{ matrix.variant.suffix }}-${{ github.job }}-jdk${{ matrix.jdk }}
           path: docker-*.log
 
       - name: Build and Push OSS image
@@ -244,7 +240,7 @@ jobs:
           
           # OSS has no LTS releases
           IS_LATEST_LTS=false
-          TAGS_TO_PUSH=$(get_tags_to_push "${{ env.RELEASE_VERSION }}" "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
+          TAGS_TO_PUSH=$(get_tags_to_push "${{ env.RELEASE_VERSION }}" "${{ matrix.variant.suffix }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}
@@ -287,7 +283,7 @@ jobs:
           DEFAULT_JDK="$(get_default_jdk $DOCKER_DIR)"
           
           IS_LATEST_LTS="${{ steps.is_latest_lts.outputs.is_latest_lts }}"
-          TAGS_TO_PUSH=$(get_tags_to_push "${{ env.RELEASE_VERSION }}" "${{ env.SUFFIX }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
+          TAGS_TO_PUSH=$(get_tags_to_push "${{ env.RELEASE_VERSION }}" "${{ matrix.variant.suffix }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -64,15 +64,18 @@ jobs:
           matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output 'split(",") + [""] | map(gsub("^\\s+|\\s+$"; ""))' )
           echo "jdk-image-variants-matrix=${matrix}" >> $GITHUB_OUTPUT
 
+  distribution-variants:
+    uses: hazelcast/hazelcast-docker/.github/workflows/get-distribution-variants.yaml@centralise-variants
+
   test:
     runs-on: ubuntu-latest
-    needs: set-matrix
+    needs:
+      - set-matrix
+      - distribution-variants
     strategy:
       fail-fast: false
       matrix:
-        variant: 
-          - ''
-          - 'slim'
+        variant: ${{ fromJSON(needs.distribution-variants.outputs.variants) }}
         distribution-type: ${{ fromJson(needs.set-matrix.outputs.distribution-type-matrix) }}
         jdk-image-variant: ${{ fromJson(needs.set-matrix.outputs.jdk-image-variants-matrix) }}
 
@@ -171,8 +174,8 @@ jobs:
           # To allow computing the required tag, store the elements in an array
           tag_elements=("${{ inputs.IMAGE_VERSION }}")
 
-          if [[ -n "${{ matrix.variant }}" ]]; then
-            tag_elements+=("${{ matrix.variant }}")
+          if [[ -n "${{ matrix.variant.classifier }}" ]]; then
+            tag_elements+=("${{ matrix.variant.classifier }}")
           fi
 
           if [[ -n "${{ matrix.jdk-image-variant }}" ]]; then
@@ -185,7 +188,7 @@ jobs:
 
           # Check additional EE repos
           # Only populated for default variant, not "slim"
-          if [[ "${{ matrix.distribution-type }}" == "ee" && -z "${{ matrix.variant }}" ]]; then
+          if [[ "${{ matrix.distribution-type }}" == "ee" && -z "${{ matrix.variant.classifier }}" ]]; then
             # NLC repo only populated for absolute versions - not "latest", "latest-lts" etc tags
             # Identify absolute version based on earlier parsing of version number
             if [[ -n "${{ steps.image-version.outputs.major }}" ]]; then


### PR DESCRIPTION
The `variants` matrix (describing available distribution `classifiers` - either `slim` or regular) is duplicated in 4 places and can be centralised - and at the same time can centralise the computation of the `suffix` derived from the `variant`.

Also removed the `include` matrix which _appears_ to duplicate `variant` but is unused.

This action _could_ have been externalised to `docker-actions` but seemed overengineered, instead access directly on `master` - but until merged, the builds will fail.