### PR TITLE
Support non-`amd64` platforms in RedHat

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -169,7 +169,7 @@ jobs:
 
           output=
 
-          PLATFORMS="linux/amd64"
+          PLATFORMS="$(get_ubi_supported_platforms "${{ matrix.jdk }}")"
 
           if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
             echo "DRY RUN: Skipping push for platforms ${PLATFORMS} and tags: ${TAGS_TO_PUSH}"


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-docker/pull/694 (more specifically, https://github.com/hazelcast/hazelcast-docker/commit/d428943aef7e12dfd6514046c0344f96f5f1874e), the logic of assigning a `platform` to an image was centralised and managed by OS - e.g. all `ubi` images got the same set of `platform` tags.

It _appears_ as though the RHEL images were missed and therefore stuck on _only_ `amd64`.