### PR TITLE
Don't call `vulnerability_scan` when PRs are _edited_

### DIFF
--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    types: [ opened, synchronize, edited ]
 
 jobs:
     trigger-vulnerability-scan-master:


### PR DESCRIPTION
Updating the _description_ of https://github.com/hazelcast/hazelcast-docker/pull/1039 triggered the `vulnerability_scan` action unneccesarily - the triggers should match those in the PR builder: https://github.com/hazelcast/hazelcast-docker/blob/d5246180fcad79a2305b0d6622a18f9165a57f14/.github/workflows/build-pr.yml#L2-L5