### PR TITLE
Avoid unnecessary "external" reference to `hazelcast-docker` in `rhel-smoke-test.yml`

### DIFF
--- a/.github/workflows/rhel-smoke-test.yml
+++ b/.github/workflows/rhel-smoke-test.yml
@@ -33,7 +33,7 @@ jobs:
           version: ${{ steps.derive-versions.outputs.HZ_VERSION }}
 
       - name: Setup Docker
-        uses: hazelcast/hazelcast-docker/.github/actions/setup-docker@master
+        uses: ./.github/actions/setup-docker
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
The workflow is always run from `master`, accessing the workflow by specifying the org/repo/branch is unnecessary: https://github.com/hazelcast/hazelcast-docker/blob/d5246180fcad79a2305b0d6622a18f9165a57f14/.github/workflows/rhel-smoke-test.yml#L35-L36

Especially as we do it the other way earlier:
https://github.com/hazelcast/hazelcast-docker/blob/d5246180fcad79a2305b0d6622a18f9165a57f14/.github/workflows/rhel-smoke-test.yml#L24-L28