### PR TITLE
Make `inputs` consistent between workflows

### DIFF
--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -8,6 +8,7 @@ on:
     inputs:
       BRANCH_NAME:
         description: The branch to recreate the tag from
+        required: true
 
 jobs:
   retag:

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -28,14 +28,15 @@ on:
       IS_LTS_OVERRIDE:
         description: 'Override is LTS release'
         required: false
-        type: choice
         default: ''
+        type: choice
         options:
           - ''
           - 'false'
           - 'true'
       DRY_RUN:
         description: 'Skip pushing the images to remote registry'
+        required: false
         default: 'false'
         type: choice
         options:
@@ -44,13 +45,13 @@ on:
   workflow_call:
     inputs:
       HZ_VERSION:
-        type: string
         description: 'Version of Hazelcast to build the image for, e.g. 5.1.1, 5.0.1, 4.2.3'
         required: true
-      RELEASE_VERSION:
         type: string
+      RELEASE_VERSION:
         description: 'Version to tag the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         required: false
+        type: string
       RELEASE_TYPE:
         description: 'What should be built'
         required: true
@@ -59,10 +60,11 @@ on:
       IS_LTS_OVERRIDE:
         description: 'Override is LTS release'
         required: false
-        type: string
         default: ''
+        type: string
       DRY_RUN:
         description: 'Skip pushing the images to remote registry'
+        required: false
         default: 'false'
         type: string
 

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -19,14 +19,15 @@ on:
       IS_LTS_OVERRIDE:
         description: 'Override is LTS release'
         required: false
-        type: choice
         default: ''
+        type: choice
         options:
           - ''
           - 'false'
           - 'true'
       DRY_RUN:
         description: 'Skip pushing the images to remote registry'
+        required: false
         default: 'false'
         type: choice
         options:
@@ -35,20 +36,21 @@ on:
   workflow_call:
     inputs:
       HZ_VERSION:
-        type: string
         description: 'Version of Hazelcast to build the image for, e.g. 5.1.1, 5.0.1'
         required: true
-      RELEASE_VERSION:
         type: string
+      RELEASE_VERSION:
         description: 'Version to tag the docker image e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         required: false
+        type: string
       IS_LTS_OVERRIDE:
         description: 'Override is LTS release'
         required: false
-        type: string
         default: ''
+        type: string
       DRY_RUN:
         description: 'Skip pushing the images to remote registry'
+        required: false
         default: 'false'
         type: string
 jobs:

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -4,25 +4,25 @@ on:
   workflow_dispatch:
     inputs:
       IMAGE_VERSION:
-        required: true
         description: The version/label of the image e.g. `5.4.1`, `latest` etc
+        required: true
       EXPECTED_HZ_VERSION:
         description: The expected Hazelcast version (fully-qualified), e.g. `5.4.1`
         required: true
       DISTRIBUTION_TYPE:
-        required: true
         description: The distribution(s) to test
+        required: true
         type: choice
         options:
           - oss
           - ee
           - all
       EXPECTED_DEFAULT_JAVA_VERSION:
-        required: true
         description: The expected Java major version (e.g. `21`, `8`) used by default in the image
-      OTHER_JDKS:
         required: true
+      OTHER_JDKS:
         description: The other Java variant images to test (e.g. `5-jdk21`) - supplied as a comma-separated list of major Java versions (e.g. `8, 11, 17`)
+        required: true
 
 env:
   CONTAINER_NAME: my-container


### PR DESCRIPTION
- Most (but not all!) workflows expicitly specify whether an `input` is `required`
   - added for all
- consistently ordered each `input`s configuration based on the [GitHub documentation](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/workflows-and-actions/workflow-syntax#example-of-onworkflow_dispatchinputs) which was _mostly_ already being done