### PR TITLE
Relabel `master` from `6.0-SNAPSHOT` to `5.6-SNAPSHOT` [CTT-504]

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -3,7 +3,7 @@ FROM redhat/ubi9-minimal:9.6
 # Used for image metadata only
 # Describes the version of the Dockerfile, *not* the version of the bundled Hazelcast binary as this is/can be controlled externally
 # Dockerfile needs some concept of versioning so that the release pipeline can tag/archive with an appropriate label
-ARG HZ_VERSION=6.0.0-SNAPSHOT
+ARG HZ_VERSION=5.6.0-SNAPSHOT
 ARG JDK_VERSION="21"
 
 # Build constants

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3
 
 # Describes the version of the Dockerfile, *not* the version of the bundled Hazelcast binary as this is/can be controlled externally
 # Dockerfile needs some concept of versioning so that the release pipeline can tag/archive with an appropriate label
-ARG HZ_VERSION=6.0.0-SNAPSHOT
+ARG HZ_VERSION=5.6.0-SNAPSHOT
 
 # Build constants
 ARG HZ_HOME="/opt/hazelcast"


### PR DESCRIPTION
Renames the version on `master` from `6.0-SNAPSHOT` to `5.6-SNAPSHOT`.

Supports https://github.com/hazelcast/hazelcast-mono/pull/4852

Fixes: [CTT-504](https://hazelcast.atlassian.net/browse/CTT-504)