### PR TITLE
Execute `tag_image_push` actions from `master` [DI-581] [5.5.z]

### DIFF
--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -1,11 +1,6 @@
 name: Build EE NLC tag image
 
 on:
-  push:
-    branches:
-      - "!*"
-    tags:
-      - "v5.*"
   workflow_dispatch:
     inputs:
       HZ_VERSION:

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -1,11 +1,6 @@
 name: Build OS and EE image
 
 on:
-  push:
-    branches:
-      - "!*"
-    tags:
-      - "v5.*"
   workflow_dispatch:
     inputs:
       HZ_VERSION:

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -1,12 +1,6 @@
 name: Build EE RHEL image
 
 on:
-  push:
-    branches:
-      - "!*"
-    tags:
-      - "v4.*"
-      - "v5.*"
   workflow_dispatch:
     inputs:
       HZ_VERSION:


### PR DESCRIPTION
_Partially_ backports https://github.com/hazelcast/hazelcast-docker/pull/1039 - specifically, removes the `push` triggers from the `push` actions now that they are triggered from `master`.