### PR TITLE
Make RedHat publish serial [DI-570]

### DIFF
--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -49,6 +49,8 @@ jobs:
       NLC_IMAGE_NAME: ${{ secrets.NLC_IMAGE_NAME }}
     strategy:
       fail-fast: false
+      # RedHat does not support concurrent publishing, run sequentially
+      max-parallel: 1
       matrix: ${{ fromJSON(needs.get-latest-patch-versions.outputs.matrix) }}
     steps:
       - name: Checkout Code

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -70,10 +70,9 @@ jobs:
       HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION }}
       DOCKER_DIR: source_path/hazelcast-enterprise
     runs-on: ubuntu-latest
-    # RedHat does not support concurrent publishing, run sequentially
-    concurrency: rhel
     strategy:
       fail-fast: false
+      # RedHat does not support concurrent publishing, run sequentially
       max-parallel: 1
       matrix:
         jdk: ${{ fromJSON(needs.prepare.outputs.jdks) }}

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -69,10 +69,12 @@ jobs:
       RHEL_API_KEY: ${{ secrets.RHEL_API_KEY }}
       HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION }}
       DOCKER_DIR: source_path/hazelcast-enterprise
-
     runs-on: ubuntu-latest
+    # RedHat does not support concurrent publishing, run sequentially
+    concurrency: rhel
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         jdk: ${{ fromJSON(needs.prepare.outputs.jdks) }}
     steps:


### PR DESCRIPTION
The RedHat publish is intermittently failing, most recently [here](https://github.com/hazelcast/hazelcast-docker/actions/runs/16285479358).

Specifically, the publish as asynchronous - we submit a publish request and poll for publish completion, which _intermittently_ never happens.

Further investigation [in conjunction with RedHat support](https://connect.redhat.com/support/partner-acceleration-desk/#/case/04139855) identified that the reason they aren't getting published is that _something_ is subsequently requesting the image to be _un_published. This is _probably_ a `sync-tags` request which has the (server-side) side-effect of unpublishing any subsequently-orphaned images - i.e. if an image has had it's tags removed and is no longer "accessible", it is removed.

However, although we can hypothesise _how_ they are removed, we do not understand _why_ - the images do not overlap and it _appears_ to be a race condition on the RedHat backend. This issue is more prevalent with scheduled image rebuilds where we build many versions and images in parallel.

As such, we will no longer publish RedHat images in parallel, updated:
- `tag_image_push_rhel.yml` to build each variant (i.e. per JDK) sequentially
- `check-base-images.yml` to build each version (e.g. `5.4`, `5.5`) sequentially

This layered `max-parallel` approach was used instead of the (simpler) `concurrency` group set to restrict as [GitHub supports at most two jobs within the same concurrency group](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#using-concurrency-in-different-scenarios) (one running, one pending) and any additional jobs will be rejected - not queued as you might expect


Fixes: [DI-570](https://hazelcast.atlassian.net/browse/DI-570)

[DI-570]: https://hazelcast.atlassian.net/browse/DI-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ