### PR TITLE
Disable `build` `provenance` to fix RHEL publish

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -162,7 +162,9 @@ jobs:
             output=--push
           fi
 
+          # provenance disabled as causes RedHat publish failure 
           docker buildx build ${output} \
+            --provenance=false \
             --build-arg HZ_VERSION=${{ env.HZ_VERSION }} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
             --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "" "${{ env.HZ_VERSION }}") \


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-docker/pull/1041, `buildx` was upgraded.

[`v10` introduced a breaking change](https://github.com/docker/buildx/releases/tag/v0.10.0), the introduction of `provenance` - this caused the [RedHat publish requests to fail](https://github.com/hazelcast/hazelcast-docker/actions/runs/17074139914/job/48411435645):
```
+ echo 'Publishing the image 68a4987ed81a02dbf3d1a549...'
++ curl --fail --silent --show-error --retry 5 --retry-all-errors --request POST --header 'X-API-KEY: ***' --header 'Cache-Control: no-cache' --header 'Content-Type: application/json' --data '{"image_id":"68a4987ed81a02dbf3d1a549" , "operation" : "publish" }' https://catalog.redhat.com/api/containers/v1/projects/certification/id/***/requests/images
Publishing the image 68a4987ed81a02dbf3d1a549...
curl: (22) The requested URL returned error: 400
```

Disabling `provenance` addresses this issue.

The root cause of the issue with `provenance` has not been investigated further.

[Example execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/17083589973/job/48443063887).