### PR TITLE
Fix `oss_latest_snapshot_push`

### DIFF
--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -57,6 +57,8 @@ jobs:
       DOCKER_DIR: source_path/hazelcast-oss
     steps:
       - uses: actions/checkout@v5
+
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.SOURCE_REF }}
           path: source_path


### PR DESCRIPTION
Since https://github.com/hazelcast/hazelcast-docker/pull/1039, the [build is failing](https://github.com/hazelcast/hazelcast-docker/actions/runs/17086295156/job/48465368301) due to a missing step - only affected OS, not EE `SNAPSHOT`s.