### PR TITLE
Fix `check-base-images`

### DIFF
--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -127,7 +127,7 @@ jobs:
         version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD }}
     uses: ./.github/workflows/tag_image_push.yml
     with:
-      SOURCE_REF: ${{ matrix.version }}
+      SOURCE_REF: v${{ matrix.version }}
     secrets: inherit
 
   rebuild-rhel:
@@ -141,7 +141,7 @@ jobs:
         version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD }}
     uses: ./.github/workflows/tag_image_push_rhel.yml
     with:
-      SOURCE_REF: ${{ matrix.version }}
+      SOURCE_REF: v${{ matrix.version }}
     secrets: inherit
 
   rebuild-nlc:
@@ -153,7 +153,7 @@ jobs:
         version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD }}
     uses: ./.github/workflows/ee-nlc-tag-push.yml
     with:
-      SOURCE_REF: ${{ matrix.version }}
+      SOURCE_REF: v${{ matrix.version }}
     secrets: inherit
 
   failure-notifications:

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -103,7 +103,7 @@ jobs:
     if: ${{ needs.convert-rebuilds-to-matrix.outputs.rebuild-ee-matrix != null }}
     strategy:
       matrix:
-        version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD }}
+        version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.rebuild-ee-matrix) }}
     uses: ./.github/workflows/tag_image_push.yml
     with:
       SOURCE_REF: v${{ matrix.version }}

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -35,11 +35,6 @@ jobs:
           versions=$(printf '%s\n' $(get_latest_patch_versions "${MIN_VERSION}") | jq --raw-input . | jq --compact-output --slurp .)
           echo "Found latest patch versions: $versions"
           echo "matrix={\"version\":$versions}" >> $GITHUB_OUTPUT
-      - name: Slack notification
-        uses: hazelcast/docker-actions/slack-notification@master
-        if: failure()
-        with:
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}
 
   calculate-rebuilds:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -64,10 +64,10 @@ jobs:
 
             echo "Checking ${label} image"
             if base_image_outdated_from_dockerfile "${image}" "${dockerfile}"; then
-              echo "${label}_NEEDS_REBUILD" >> ${{ matrix.version }}
+              echo "${{ matrix.version }}" >> rebuild-${label}-${{ matrix.version }}
               echonotice "Image ${label} needs rebuild"
             elif packages_updatable_ee "${image}"; then
-              echo "${label}_NEEDS_REBUILD" >> ${{ matrix.version }}
+              echo "${{ matrix.version }}" >> rebuild-${label}-${{ matrix.version }}
               echonotice "System package upgrades for ${label} image available"
             else
               echodebug "Image ${label} is up-to-date"
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.version }}
-          path: ${{ matrix.version }}
+          path: rebuild-*
           if-no-files-found: ignore
 
   convert-rebuilds-to-matrix:
@@ -88,35 +88,19 @@ jobs:
     name: Prepare matrix of rebuilds to execute
     needs: calculate-rebuilds
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      rebuild-ee-matrix: ${{ steps.set-matrix.outputs.rebuild_ee_matrix }}
     steps:
       - uses: actions/download-artifact@v4
       - id: set-matrix
         run: |
           # Invert matrix
-          # From version-specific files (e.g. 5.4.1) that list the types that need rebuilding (OSS_NEEDS_REBUILD, EE_NEEDS_REBUILD)
-          # To array of types of builds and their versions (e.g. {"EE_NEEDS_REBUILD":["5.5.7","5.4.2"]})
-          # Even if there are no entries, we still need to ensure it's properly formatted for the matrix to process
-          matrix=$(find . -type f \
-            | while read -r file; do
-                  version=$(basename "${file}")
-                  while IFS= read -r flag; do
-                    echo "{\"flag\":\"${flag}\",\"version\":\"${version}\"}"
-                  done < "${file}"
-              done \
-            | jq --compact-output --slurp '
-                group_by(.flag)
-                | map({ (.[0].flag): [.[].version] })
-                | add
-                | .EE_NEEDS_REBUILD //= []
-              ')
-
-          echo "matrix=${matrix}" >> ${GITHUB_OUTPUT}
+          rebuild_ee_matrix=$((cat **/rebuild-EE-* 2>/dev/null || true) | jq --raw-input --slurp --compact-output 'split("\n")[:-1]')
+          echo "rebuild_ee_matrix=${rebuild_ee_matrix}" >> ${GITHUB_OUTPUT}
 
   rebuild-ee:
     name: Rebuild EE images
     needs: convert-rebuilds-to-matrix
-    if: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD[0] != null }}
+    if: ${{ needs.convert-rebuilds-to-matrix.outputs.rebuild-ee-matrix != null }}
     strategy:
       matrix:
         version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD }}
@@ -128,12 +112,12 @@ jobs:
   rebuild-rhel:
     name: Rebuild EE RHEL images
     needs: convert-rebuilds-to-matrix
-    if: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD[0] != null }}
+    if: ${{ needs.convert-rebuilds-to-matrix.outputs.rebuild-ee-matrix != null }}
     strategy:
       # RedHat does not support concurrent publishing, run sequentially
       max-parallel: 1
       matrix:
-        version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD }}
+        version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.rebuild-ee-matrix) }}
     uses: ./.github/workflows/tag_image_push_rhel.yml
     with:
       SOURCE_REF: v${{ matrix.version }}
@@ -142,10 +126,10 @@ jobs:
   rebuild-nlc:
     name: Rebuild EE NLC images
     needs: convert-rebuilds-to-matrix
-    if: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD[0] != null }}
+    if: ${{ needs.convert-rebuilds-to-matrix.outputs.rebuild-ee-matrix != null }}
     strategy:
       matrix:
-        version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD }}
+        version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.rebuild-ee-matrix) }}
     uses: ./.github/workflows/ee-nlc-tag-push.yml
     with:
       SOURCE_REF: v${{ matrix.version }}

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -32,7 +32,7 @@ jobs:
           . .github/scripts/version.functions.sh
           MIN_VERSION=${MINIMAL_SUPPORTED_VERSION:-$DEFAULT_MINIMAL_SUPPORTED_VERSION}
           echo "Getting latest patch versions starting from $MIN_VERSION"
-          versions=$(printf '%s\n' $(get_latest_patch_versions "${MIN_VERSION}") | jq -R . | jq -c -s .)
+          versions=$(printf '%s\n' $(get_latest_patch_versions "${MIN_VERSION}") | jq --raw-input . | jq --compact-output --slurp .)
           echo "Found latest patch versions: $versions"
           echo "matrix={\"version\":$versions}" >> $GITHUB_OUTPUT
       - name: Slack notification
@@ -41,12 +41,10 @@ jobs:
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}
 
-  trigger-rebuilds:
+  calculate-rebuilds:
     runs-on: ubuntu-latest
-    name: Rebuild ${{ matrix.version }} if base image changed
+    name: Calculate if ${{ matrix.version }} needs a rebuild
     needs: get-latest-patch-versions
-    env:
-      NLC_IMAGE_NAME: ${{ secrets.NLC_IMAGE_NAME }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.get-latest-patch-versions.outputs.matrix) }}
@@ -58,12 +56,6 @@ jobs:
         with:
           ref: v${{ matrix.version }}
           path: v${{ matrix.version }}
-      - name: Login to NLC Docker Repository
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.NLC_REPOSITORY }}
-          username: ${{ secrets.NLC_REPO_USERNAME }}
-          password: ${{ secrets.NLC_REPO_TOKEN }}
       - name: Check if ${{ matrix.version }} base images updated
         run: |
           . .github/scripts/base-image-updated.functions.sh
@@ -76,11 +68,11 @@ jobs:
             local dockerfile=$3
 
             echo "Checking ${label} image"
-            if base_image_outdated_from_dockerfile "${image}" "${dockerfile}"; then 
-              echo "${label}_NEEDS_REBUILD=yes" >> $GITHUB_ENV
+            if base_image_outdated_from_dockerfile "${image}" "${dockerfile}"; then
+              echo "${label}_NEEDS_REBUILD" >> ${{ matrix.version }}
               echonotice "Image ${label} needs rebuild"
             elif packages_updatable_ee "${image}"; then
-              echo "${label}_NEEDS_REBUILD=yes" >> $GITHUB_ENV
+              echo "${label}_NEEDS_REBUILD" >> ${{ matrix.version }}
               echonotice "System package upgrades for ${label} image available"
             else
               echodebug "Image ${label} is up-to-date"
@@ -88,24 +80,90 @@ jobs:
           }
 
           check_image "EE" "hazelcast/hazelcast-enterprise:${{ matrix.version }}-slim" "v${{ matrix.version }}/hazelcast-enterprise/Dockerfile"
-          check_image "EE_NLC" "${{ secrets.NLC_IMAGE_NAME }}:${{ matrix.version }}" "v${{ matrix.version }}/hazelcast-enterprise/Dockerfile"
-      - name: Rebuild ${{ matrix.version }} EE image
-        if: env.EE_NEEDS_REBUILD == 'yes'
-        uses: ./.github/workflows/tag_image_push.yml
+        # GitHub doesn't support outputs of matrix jobs - https://github.com/orgs/community/discussions/26639
+        # Instead, write the content to artifact(s) and upload those to consume downstream
+      - uses: actions/upload-artifact@v4
         with:
-          SOURCE_REF: v${{ matrix.version }}
-      - name: Rebuild ${{ matrix.version }} EE RHEL image
-        if: env.EE_NEEDS_REBUILD == 'yes'
-        uses: ./.github/workflows/tag_image_push_rhel.yml
-        with:
-          SOURCE_REF: v${{ matrix.version }}
-      - name: Rebuild ${{ matrix.version }} EE NLC image
-        if: env.EE_NLC_NEEDS_REBUILD == 'yes'
-        uses: ./.github/workflows/ee-nlc-tag-push.yml
-        with:
-          SOURCE_REF: v${{ matrix.version }}
+          name: ${{ matrix.version }}
+          path: ${{ matrix.version }}
+          if-no-files-found: ignore
+
+  convert-rebuilds-to-matrix:
+    runs-on: ubuntu-latest
+    name: Prepare matrix of rebuilds to execute
+    needs: calculate-rebuilds
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/download-artifact@v4
+      - id: set-matrix
+        run: |
+          # Invert matrix
+          # From version-specific files (e.g. 5.4.1) that list the types that need rebuilding (OSS_NEEDS_REBUILD, EE_NEEDS_REBUILD)
+          # To array of types of builds and their versions (e.g. {"EE_NEEDS_REBUILD":["5.5.7","5.4.2"]})
+          # Even if there are no entries, we still need to ensure it's properly formatted for the matrix to process
+          matrix=$(find . -type f \
+            | while read -r file; do
+                  version=$(basename "${file}")
+                  while IFS= read -r flag; do
+                    echo "{\"flag\":\"${flag}\",\"version\":\"${version}\"}"
+                  done < "${file}"
+              done \
+            | jq --compact-output --slurp '
+                group_by(.flag)
+                | map({ (.[0].flag): [.[].version] })
+                | add
+                | .EE_NEEDS_REBUILD //= []
+              ')
+
+          echo "matrix=${matrix}" >> ${GITHUB_OUTPUT}
+
+  rebuild-ee:
+    name: Rebuild EE images
+    needs: convert-rebuilds-to-matrix
+    if: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD[0] != null }}
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD }}
+    uses: ./.github/workflows/tag_image_push.yml
+    with:
+      SOURCE_REF: ${{ matrix.version }}
+    secrets: inherit
+
+  rebuild-rhel:
+    name: Rebuild EE RHEL images
+    needs: convert-rebuilds-to-matrix
+    if: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD[0] != null }}
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD }}
+    uses: ./.github/workflows/tag_image_push_rhel.yml
+    with:
+      SOURCE_REF: ${{ matrix.version }}
+    secrets: inherit
+
+  rebuild-nlc:
+    name: Rebuild EE NLC images
+    needs: convert-rebuilds-to-matrix
+    if: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD[0] != null }}
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD }}
+    uses: ./.github/workflows/ee-nlc-tag-push.yml
+    with:
+      SOURCE_REF: ${{ matrix.version }}
+    secrets: inherit
+
+  failure-notifications:
+    runs-on: ubuntu-latest
+    name: Failure notification
+    if: failure() && github.event_name != 'workflow_dispatch'
+    needs:
+      - rebuild-ee
+      - rebuild-rhel
+      - rebuild-nlc
+    steps:
       - name: Slack notification
         uses: hazelcast/docker-actions/slack-notification@master
-        if: failure() && github.event_name != 'workflow_dispatch'
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -47,8 +47,6 @@ jobs:
     needs: get-latest-patch-versions
     strategy:
       fail-fast: false
-      # RedHat does not support concurrent publishing, run sequentially
-      max-parallel: 1
       matrix: ${{ fromJSON(needs.get-latest-patch-versions.outputs.matrix) }}
     steps:
       - name: Checkout Code
@@ -137,6 +135,8 @@ jobs:
     needs: convert-rebuilds-to-matrix
     if: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD[0] != null }}
     strategy:
+      # RedHat does not support concurrent publishing, run sequentially
+      max-parallel: 1
       matrix:
         version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.matrix).EE_NEEDS_REBUILD }}
     uses: ./.github/workflows/tag_image_push_rhel.yml

--- a/.github/workflows/check-redhat-service-status.yml
+++ b/.github/workflows/check-redhat-service-status.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  push:
+  service-status:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ee-nlc-snapshot-push.yml
+++ b/.github/workflows/ee-nlc-snapshot-push.yml
@@ -103,7 +103,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs-${{ github.job }}-jdk${{ matrix.jdk }}
+          name: docker-logs-ee-nlc-snapshot-push-${{inputs.SOURCE_REF}}-jdk${{ matrix.jdk }}
           path: |
             ${{ env.DOCKER_LOG_FILE_EE }}
 

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -6,6 +6,12 @@ on:
       SOURCE_REF:
         description: 'The hazelcast-docker branch to build the image from'
         required: true
+  workflow_call:
+    inputs:
+      SOURCE_REF:
+        description: 'The hazelcast-docker branch to build the image from'
+        required: true
+        type: string
 
 env:
   test_container_name_ee: hazelcast-ee-test
@@ -105,7 +111,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs-${{ github.job }}-jdk${{ matrix.jdk }}
+          name: docker-logs-nlc-tag-push-${{inputs.SOURCE_REF}}-jdk${{ matrix.jdk }}
           path: |
             ${{ env.DOCKER_LOG_FILE_EE }}
 

--- a/.github/workflows/ee_latest_snapshot_push.yml
+++ b/.github/workflows/ee_latest_snapshot_push.yml
@@ -98,7 +98,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs${{ matrix.variant.suffix }}-${{ github.job }}-jdk${{ matrix.jdk }}
+          name: docker-logs-ee-snapshot-push-${{inputs.SOURCE_REF}}${{ matrix.variant.suffix }}-jdk${{ matrix.jdk }}
           path: |
             ${{ env.DOCKER_LOG_FILE_EE }}
 

--- a/.github/workflows/oss_latest_snapshot_push.yml
+++ b/.github/workflows/oss_latest_snapshot_push.yml
@@ -101,7 +101,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs${{ matrix.variant.suffix }}-${{ github.job }}-jdk${{ matrix.jdk }}
+          name: docker-logs-oss-snapshot-push-${{inputs.SOURCE_REF}}${{ matrix.variant.suffix }}-jdk${{ matrix.jdk }}
           path: |
             ${{ env.DOCKER_LOG_FILE_OSS }}
 

--- a/.github/workflows/rhel-smoke-test.yml
+++ b/.github/workflows/rhel-smoke-test.yml
@@ -128,7 +128,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: openshift-logs-${{ github.job }}
+          name: openshift-logs
           path: '*.log'
 
       - name: Clean up After Test

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -201,7 +201,7 @@ jobs:
         if: ${{ always() && ( needs.prepare.outputs.should_build_ee == 'yes' || needs.prepare.outputs.should_build_oss == 'yes') }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs${{ matrix.variant.suffix }}-${{ github.job }}-jdk${{ matrix.jdk }}
+          name: docker-logs-tag-image-push-${{inputs.SOURCE_REF}}${{ matrix.variant.suffix }}-jdk${{ matrix.jdk }}
           path: docker-*.log
 
       - name: Build and Push OSS image


### PR DESCRIPTION
Since https://github.com/hazelcast/hazelcast-docker/pull/1039, the [build is failing](https://github.com/hazelcast/hazelcast-docker/actions/runs/17090016143).

This is because we are triggering the `push` actions like they are `composite` actions but they are actually reusable workflows.

Changes:
- refactored the action to calculate the required rebuilds and then trigger these as reusable workflows - i.e. in a separate `job`, not a nested `step`
   - non-trivial
   - but does at least give us the benefit that each of the rebuilds are done in parallel
- ensure that `push` `docker-logs` have unique names
   - previously were executing in different jobs, but now are in the same one
   - overlapping names are not permitted
- removed checking the NLC/EE images separately
   - they are the same image, if one needs rebuilding - they both do
- `ee-nlc-tag-push` wasn't even a reusable workflow


[Example execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/17161450988).