### PR TITLE
Update Maven central URL

### DIFF
--- a/.github/scripts/ee-build.functions.sh
+++ b/.github/scripts/ee-build.functions.sh
@@ -5,7 +5,7 @@ set -euo pipefail ${RUNNER_DEBUG:+-x}
 # If the version is snapshot, the script downloads the 'maven-metadata.xml' and parses it for the snapshot version. 'maven-metadata.xml' only holds the values for
 # the latest snapshot version. Thus, the [1] in snapshotVersion[1] is arbitrary because all of elements in the list have same value. The list consists of 'jar', 'pom', 'sources' and 'javadoc'.
 #
-# 'maven-metadata.xml' example - https://repo1.maven.org/maven2/com/hazelcast/hazelcast/maven-metadata.xml
+# 'maven-metadata.xml' example - https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast/maven-metadata.xml
 function get_hz_dist_zip() {
   local hz_variant=$1
   local hz_version=$2

--- a/.github/scripts/maven.functions_tests.sh
+++ b/.github/scripts/maven.functions_tests.sh
@@ -41,11 +41,11 @@ function assert_get_latest_url_without_extension {
 }
 
 log_header "Tests for get_latest_version"
-assert_get_latest_version com.google.guava listenablefuture https://repo1.maven.org/maven2 9999.0-empty-to-avoid-conflict-with-guava
+assert_get_latest_version com.google.guava listenablefuture https://repo.maven.apache.org/maven2 9999.0-empty-to-avoid-conflict-with-guava
 assert_get_latest_version com.google.guava listenablefuture https://maven-central.storage.googleapis.com/maven2 9999.0-empty-to-avoid-conflict-with-guava
 
 log_header "Tests for get_latest_url_without_extension"
-assert_get_latest_url_without_extension com.google.guava listenablefuture https://repo1.maven.org/maven2 https://repo1.maven.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava
+assert_get_latest_url_without_extension com.google.guava listenablefuture https://repo.maven.apache.org/maven2 https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava
 assert_get_latest_url_without_extension com.google.guava listenablefuture https://maven-central.storage.googleapis.com/maven2 https://maven-central.storage.googleapis.com/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava
 
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/.github/scripts/oss-build.functions.sh
+++ b/.github/scripts/oss-build.functions.sh
@@ -11,7 +11,7 @@ function get_hz_dist_zip() {
   then
       url="https://${HZ_SNAPSHOT_INTERNAL_USERNAME}:${HZ_SNAPSHOT_INTERNAL_PASSWORD}@repository.hazelcast.com/snapshot-internal/com/hazelcast/hazelcast-distribution/${hz_version}/hazelcast-distribution-${hz_version}${suffix}.zip"
   else
-      url="https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/${hz_version}/hazelcast-distribution-${hz_version}${suffix}.zip"
+      url="https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast-distribution/${hz_version}/hazelcast-distribution-${hz_version}${suffix}.zip"
   fi
 
   echo "$url"

--- a/.github/scripts/oss-build.functions_tests.sh
+++ b/.github/scripts/oss-build.functions_tests.sh
@@ -21,7 +21,7 @@ function assert_get_hz_dist_zip {
 }
 
 log_header "Tests for get_hz_dist_zip"
-assert_get_hz_dist_zip slim 5.4.0 https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0-slim.zip
-assert_get_hz_dist_zip "" 5.4.0 https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0.zip
+assert_get_hz_dist_zip slim 5.4.0 https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0-slim.zip
+assert_get_hz_dist_zip "" 5.4.0 https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0.zip
 
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/hazelcast-enterprise/maven.functions.sh
+++ b/hazelcast-enterprise/maven.functions.sh
@@ -29,7 +29,7 @@ function get_latest_version() {
 #   repository_url  e.g. https://repo1.maven.org
 #
 # Prints a URL to the latest released version of a given artifact in the Maven repository, without a file extension, assuming a "typical" naming format
-# E.G. `https://repo1.maven.org/maven2/com/google/guava/guava/33.2.0-jre/guava-33.2.0-jre`
+# E.G. `https://repo.maven.apache.org/maven2/com/google/guava/guava/33.2.0-jre/guava-33.2.0-jre`
 function get_latest_url_without_extension() {
   local group_id=$1
   local artifact_id=$2

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -35,7 +35,7 @@ RUN echo "Upgrading APK packages" \
     && if [[ ! -f ${HZ_HOME}/hazelcast-distribution.zip ]]; then \
        if [ -z ${HAZELCAST_ZIP_URL} ]; then \
             source ${HZ_HOME}/maven.functions.sh; \
-            HAZELCAST_ZIP_URL="$(get_latest_url_without_extension com.hazelcast hazelcast-distribution https://repo1.maven.org/maven2)".zip; \
+            HAZELCAST_ZIP_URL="$(get_latest_url_without_extension com.hazelcast hazelcast-distribution https://repo.maven.apache.org/maven2)".zip; \
        fi; \
        echo "Downloading Hazelcast distribution zip from ${HAZELCAST_ZIP_URL}..."; \
        mkdir --parents ${HZ_HOME}; \

--- a/hazelcast-oss/maven.functions.sh
+++ b/hazelcast-oss/maven.functions.sh
@@ -29,7 +29,7 @@ function get_latest_version() {
 #   repository_url  e.g. https://repo1.maven.org
 #
 # Prints a URL to the latest released version of a given artifact in the Maven repository, without a file extension, assuming a "typical" naming format
-# E.G. `https://repo1.maven.org/maven2/com/google/guava/guava/33.2.0-jre/guava-33.2.0-jre`
+# E.G. `https://repo.maven.apache.org/maven2/com/google/guava/guava/33.2.0-jre/guava-33.2.0-jre`
 function get_latest_url_without_extension() {
   local group_id=$1
   local artifact_id=$2


### PR DESCRIPTION
In https://issues.apache.org/jira/browse/MNG-5151 Maven updated the default URL from `repo1.maven.org/maven2` -> `repo.maven.apache.org/maven2`.

Updated references to suit.