### PR TITLE
Optimise `base-image-updated` script

### DIFF
--- a/.github/scripts/base-image-updated.functions.sh
+++ b/.github/scripts/base-image-updated.functions.sh
@@ -31,6 +31,5 @@ function base_image_outdated() {
 
 function get_base_image_sha() {
   local image=$1
-  docker pull "${image}" --quiet
-  docker image inspect --format '{{index .RootFS.Layers 0}}' "${image}"
+  skopeo inspect --format "{{ .Digest }}" "docker://${image}"
 }


### PR DESCRIPTION
[It was mentioned](https://github.com/hazelcast/hazelcast-docker/pull/1057#issuecomment-3215269850) that we could improve runtime of the script by avoiding an explicit `pull`.

This change drops runtime of the `base-image-updated` test from 18 -> 9 seconds (>2x faster).

Note - in isolation this makes the PR builder slower as the the `packages-updated` tests _also_ pull the image so there was some caching, but now one caches and the other queries remotely.