### PR TITLE
Merge EE & OS build jobs

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -4,12 +4,9 @@ on:
   pull_request:
 
 env:
-  test_container_name_oss: hazelcast-oss-test
-  test_container_name_ee: hazelcast-ee-test
-  docker_log_file_oss: docker-hazelcast-oss-test.log
-  docker_log_file_ee: docker-hazelcast-ee-test.log
-  DOCKER_DIR_OS: hazelcast-oss
-  DOCKER_DIR_EE: hazelcast-enterprise
+  test_container_name: hazelcast-test
+  test_image_name: hazelcast:test
+  docker_log_file: docker-hazelcast-test.log
 
 jobs:
   prepare:
@@ -20,7 +17,7 @@ jobs:
       HZ_VERSION_EE: ${{ steps.get_hz_versions.outputs.HZ_VERSION_EE }}
       LAST_RELEASED_HZ_VERSION_OSS: ${{ steps.get_hz_versions.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
       HAZELCAST_EE_ZIP_URL: ${{ steps.get_ee_vars.outputs.HAZELCAST_EE_ZIP_URL }}
-      jdks: ${{ steps.jdks.outputs.jdks }}
+      jdks: ${{ steps.jdks-with-default.outputs.jdks-with-default }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
@@ -46,7 +43,7 @@ jobs:
         id: get_ee_vars
         run: |
           . .github/scripts/ee-build.functions.sh
-          echo "HAZELCAST_EE_ZIP_URL=$(get_hz_dist_zip "" "${{ steps.get_hz_versions.outputs.HZ_VERSION_EE }}")" >> $GITHUB_OUTPUT
+          echo "HAZELCAST_EE_ZIP_URL=$(get_hz_dist_zip "" "${{ steps.get_hz_versions.outputs.HZ_VERSION_EE }}")" >> ${GITHUB_OUTPUT}
 
       - name: Get supported JDKs
         id: jdks
@@ -54,80 +51,24 @@ jobs:
         with:
           HZ_VERSION: '${{ steps.get_hz_versions.outputs.HZ_VERSION_EE }}'
 
+      - name: Append "default" JDK
+        id: jdks-with-default
+        run: |
+          echo "jdks-with-default=$(jq --compact-output '. + ["default"]' <<< '${{ steps.jdks.outputs.jdks }}')" >> "${GITHUB_OUTPUT}"
+
   build-pr:
     runs-on: ubuntu-latest
-    name: Build with default JDK
-    needs: [ prepare ]
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v5
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
-          fetch-depth: 0
-
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build OSS image
-        run: |
-          HZ_VERSION="${{ needs.prepare.outputs.HZ_VERSION_OSS }}"
-          
-          # duplicated block as GH doesn't support passing sensitive data between jobs
-          . .github/scripts/oss-build.functions.sh
-          export HZ_SNAPSHOT_INTERNAL_PASSWORD=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
-          export HZ_SNAPSHOT_INTERNAL_USERNAME=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
-          HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "" "${HZ_VERSION}")
-          
-          curl --fail --silent --show-error --location "$HAZELCAST_OSS_ZIP_URL" --output ${DOCKER_DIR_OS}/hazelcast-distribution.zip; 
-          
-          docker buildx build --load \
-          --tag hazelcast-oss:test \
-          "${DOCKER_DIR_OS}"
-
-      - name: Run smoke test against OSS image
-        timeout-minutes: 2
-        run: |          
-          . .github/scripts/docker.functions.sh
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test "${{ env.test_container_name_oss }}" oss "${{ needs.prepare.outputs.HZ_VERSION_OSS }}" "$(get_default_jdk ${DOCKER_DIR_OS})"
-
-      - name: Build Test EE image
-        run: |
-          curl --fail --silent --show-error --location "${{ needs.prepare.outputs.HAZELCAST_EE_ZIP_URL }}" --output ${DOCKER_DIR_EE}/hazelcast-enterprise-distribution.zip;
-          
-          docker buildx build --load \
-          --tag hazelcast-ee:test \
-          "${DOCKER_DIR_EE}"
-
-      - name: Run smoke test against EE image
-        timeout-minutes: 2
-        run: |
-          . .github/scripts/docker.functions.sh
-          export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test "${{ env.test_container_name_ee }}" ee "${{ needs.prepare.outputs.HZ_VERSION_EE }}" "$(get_default_jdk ${DOCKER_DIR_EE})"
-
-      - name: Get docker logs
-        if: ${{ always() }}
-        run: |
-          docker logs "${{ env.test_container_name_oss }}" > "${{ env.docker_log_file_oss }}"
-          docker logs "${{ env.test_container_name_ee }}" > "${{ env.docker_log_file_ee }}"
-
-      - name: Store docker logs as artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-logs-${{ github.job }}
-          path: |
-            ${{ env.docker_log_file_oss }}
-            ${{ env.docker_log_file_ee }}
-
-  build-pr-custom-jdk:
-    runs-on: ubuntu-latest
-    needs: [ prepare ]
-    name: Build with jdk-${{ matrix.jdk }}
+    needs: prepare
+    name: Build ${{ matrix.distribution-type.label }} with jdk-${{ matrix.jdk }}
     strategy:
       fail-fast: false
       matrix:
         jdk: ${{ fromJSON(needs.prepare.outputs.jdks) }}
+        distribution-type:
+          - label: oss
+            docker-dir: hazelcast-oss
+          - label: ee
+            docker-dir: hazelcast-enterprise
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
@@ -138,61 +79,67 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3
 
-      - name: Build OSS image
+      - name: Build image
         run: |
-          HZ_VERSION="${{ needs.prepare.outputs.HZ_VERSION_OSS }}"
-          
-          # duplicated block as GH doesn't support passing sensitive data between jobs
-          . .github/scripts/oss-build.functions.sh
-          export HZ_SNAPSHOT_INTERNAL_PASSWORD=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
-          export HZ_SNAPSHOT_INTERNAL_USERNAME=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
-          HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "" "${HZ_VERSION}")
-          
-          curl --fail --silent --show-error --location "$HAZELCAST_OSS_ZIP_URL" --output ${DOCKER_DIR_OS}/hazelcast-distribution.zip;
+          if [ "${{ matrix.distribution-type.label }}" = "oss" ]; then
+            # duplicated block as GH doesn't support passing sensitive data between jobs
+            . .github/scripts/oss-build.functions.sh
+            export HZ_SNAPSHOT_INTERNAL_PASSWORD=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
+            export HZ_SNAPSHOT_INTERNAL_USERNAME=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
+            HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "" "${{ needs.prepare.outputs.HZ_VERSION_OSS }}")
+            
+            curl --fail --silent --show-error --location "$HAZELCAST_OSS_ZIP_URL" --output ${{ matrix.distribution-type.docker-dir }}/hazelcast-distribution.zip;
+          elif [ "${{ matrix.distribution-type.label }}" = "ee" ]; then
+            curl --fail --silent --show-error --location "${{ needs.prepare.outputs.HAZELCAST_EE_ZIP_URL }}" --output ${{ matrix.distribution-type.docker-dir }}/hazelcast-enterprise-distribution.zip;
+          fi
+
+          if [ "${{ matrix.jdk }}" = "default" ]; then
+            . .github/scripts/docker.functions.sh
+            build_arg=""
+          else
+            build_arg="--build-arg JDK_VERSION=${{ matrix.jdk }}"
+          fi
 
           docker buildx build --load \
-          --build-arg JDK_VERSION=${{ matrix.jdk }} \
-          --tag hazelcast-oss:test \
-          "${DOCKER_DIR_OS}"
+          ${build_arg} \
+          --tag ${test_image_name} \
+          "${{ matrix.distribution-type.docker-dir }}"
 
-      - name: Run smoke test against OSS image
+      - name: Run smoke test against image
         timeout-minutes: 2
         run: |
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test "${{ env.test_container_name_oss }}" oss "${{ needs.prepare.outputs.HZ_VERSION_OSS }}" "${{ matrix.jdk }}"
+          if [ "${{ matrix.distribution-type.label }}" = "oss" ]; then
+            version=${{ needs.prepare.outputs.HZ_VERSION_OSS }}
+          elif [ "${{ matrix.distribution-type.label }}" = "ee" ]; then
+            version=${{ needs.prepare.outputs.HZ_VERSION_EE }}
+          fi
 
-      - name: Build Test EE image
-        run: |
-          curl --fail --silent --show-error --location "${{ needs.prepare.outputs.HAZELCAST_EE_ZIP_URL }}" --output ${DOCKER_DIR_EE}/hazelcast-enterprise-distribution.zip;
+          if [ "${{ matrix.jdk }}" = "default" ]; then
+            . .github/scripts/docker.functions.sh
+            jdk=$(get_default_jdk ${{ matrix.distribution-type.docker-dir }})
+          else
+            jdk=${{ matrix.jdk }}
+          fi
 
-          docker buildx build --load \
-          --build-arg JDK_VERSION=${{ matrix.jdk }} \
-          --tag hazelcast-ee:test \
-          "${DOCKER_DIR_EE}"
-
-      - name: Run smoke test against EE image
-        timeout-minutes: 2
-        run: |
-          export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test "${{ env.test_container_name_ee }}" ee "${{ needs.prepare.outputs.HZ_VERSION_EE }}" "${{ matrix.jdk }}"
-
+          .github/scripts/simple-smoke-test.sh ${test_image_name} "${{ env.test_container_name }}" ${{ matrix.distribution-type.label }} "${version}" "${jdk}"
+        env:
+          HZ_LICENSEKEY: ${{ matrix.distribution-type.label == 'ee' && secrets.HZ_ENTERPRISE_LICENSE || '' }}
+ 
       - name: Get docker logs
         if: ${{ always() }}
         run: |
-          docker logs "${{ env.test_container_name_oss }}" > "${{ env.docker_log_file_oss }}"
-          docker logs "${{ env.test_container_name_ee }}" > "${{ env.docker_log_file_ee }}"
+          docker logs "${{ env.test_container_name }}" > "${{ env.docker_log_file }}"
 
       - name: Store docker logs as artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs-${{ github.job }}-jdk${{ matrix.jdk }}
-          path: |
-            ${{ env.docker_log_file_oss }}
-            ${{ env.docker_log_file_ee }}
+          name: docker-logs-${{ matrix.distribution-type.label }}-${{ github.job }}-jdk-${{ matrix.jdk }}
+          path: ${{ env.docker_log_file }}
 
   test-push:
     name: Test pushing image (dry run)
-    needs: [ prepare ]
+    needs: prepare
     uses: ./.github/workflows/tag_image_push.yml
     with:
       SOURCE_REF: v${{ needs.prepare.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
@@ -202,7 +149,7 @@ jobs:
 
   test-push-rhel:
     name: Test pushing RHEL image (dry run)
-    needs: [ prepare ]
+    needs: prepare
     uses: ./.github/workflows/tag_image_push_rhel.yml
     with:
       SOURCE_REF: v${{ needs.prepare.outputs.LAST_RELEASED_HZ_VERSION_OSS }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -33,7 +33,7 @@ jobs:
 
   test-push:
     name: Test pushing image (dry run)
-    needs: prepare
+    needs: [ prepare ]
     uses: ./.github/workflows/tag_image_push.yml
     with:
       SOURCE_REF: v${{ needs.prepare.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
@@ -43,7 +43,7 @@ jobs:
 
   test-push-rhel:
     name: Test pushing RHEL image (dry run)
-    needs: prepare
+    needs: [ prepare ]
     uses: ./.github/workflows/tag_image_push_rhel.yml
     with:
       SOURCE_REF: v${{ needs.prepare.outputs.LAST_RELEASED_HZ_VERSION_OSS }}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -197,12 +197,18 @@ jobs:
           IMAGE_NAME=${DOCKER_ORG}/${{ matrix.distribution-type.image-name }}
           DEFAULT_JDK="$(get_default_jdk ${{ matrix.distribution-type.docker-dir }})"
 
-          if [ "${{ matrix.distribution-type.label }}" = "oss" ]; then
-            # OSS has no LTS releases
-            IS_LATEST_LTS=false
-          elif [ "${{ matrix.distribution-type.label }}" = "ee" ]; then
-            IS_LATEST_LTS="${{ steps.is_latest_lts.outputs.is_latest_lts }}"
-          fi
+          case "${{ matrix.distribution-type.label }}" in
+              "oss")
+              # OSS has no LTS releases
+              IS_LATEST_LTS=false
+              ;;
+              "ee")
+              IS_LATEST_LTS="${{ steps.is_latest_lts.outputs.is_latest_lts }}"
+              ;;
+              *)
+              echoerr "Unsupported LTS behaviour for ${{ matrix.distribution-type.label }}" ; return 1
+              ;;
+          esac
 
           TAGS_TO_PUSH=$(get_tags_to_push "${HZ_VERSION}" "${{ matrix.variant.suffix }}" "${{ matrix.jdk }}" "${DEFAULT_JDK}" "${IS_LATEST_LTS}")
           echodebug "TAGS_TO_PUSH=${TAGS_TO_PUSH}"
@@ -214,11 +220,17 @@ jobs:
 
           output=
 
-          if [ "${{ matrix.distribution-type.label }}" = "oss" ]; then
-            PLATFORMS="$(get_alpine_supported_platforms "${{ matrix.jdk }}")"
-          elif [ "${{ matrix.distribution-type.label }}" = "ee" ]; then
-            PLATFORMS="$(get_ubi_supported_platforms "${{ matrix.jdk }}")"
-          fi
+          case "${{ matrix.distribution-type.label }}" in
+              "oss")
+              PLATFORMS="$(get_alpine_supported_platforms "${{ matrix.jdk }}")"
+              ;;
+              "ee")
+              PLATFORMS="$(get_ubi_supported_platforms "${{ matrix.jdk }}")"
+              ;;
+              *)
+              echoerr "Unsupported platform behaviour for ${{ matrix.distribution-type.label }}" ; return 1
+              ;;
+          esac
 
           if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
             echodebug "DRY RUN: Skipping push for platforms ${PLATFORMS} and tags: ${TAGS_TO_PUSH}"

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -94,6 +94,7 @@ jobs:
       - name: Compute distribution type matrix
         id: distribution-type-matrix
         run: |
+          # We expect at least _one_ output distribution type, otherwise will produce an empty array that will break GitHub matrixes
           entries=()
 
           if [ "${{ steps.resolve-editions.outputs.should_build_oss }}" = "yes" ]; then

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -139,7 +139,7 @@ jobs:
         uses: ./.github/actions/setup-docker
 
       - name: Login to Docker Hub
-        if: ${{ inputs.DRY_RUN != 'true' && matrix.distribution-type.label == 'oss' }}
+        if: inputs.DRY_RUN != 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -54,18 +54,13 @@ on:
         default: 'false'
         type: string
 
-env:
-  test_container_name_oss: hazelcast-oss-test
-  test_container_name_ee: hazelcast-ee-test
-
 jobs:
   prepare:
     runs-on: ubuntu-latest
     env:
       RELEASE_TYPE: ${{ inputs.RELEASE_TYPE }}
     outputs:
-      should_build_oss: ${{ steps.resolve-editions.outputs.should_build_oss }}
-      should_build_ee: ${{ steps.resolve-editions.outputs.should_build_ee }}
+      distribution-types: ${{ steps.distribution-type-matrix.outputs.matrix }}
       HZ_VERSION: ${{ steps.get_hz_versions.outputs.HZ_VERSION_EE }}
       jdks: ${{ steps.jdks.outputs.jdks }}
     steps:
@@ -96,6 +91,21 @@ jobs:
         with:
           HZ_VERSION: '${{ steps.get_hz_versions.outputs.HZ_VERSION_EE }}'
 
+      - name: Compute distribution type matrix
+        id: distribution-type-matrix
+        run: |
+          entries=()
+
+          if [ "${{ steps.resolve-editions.outputs.should_build_oss }}" = "yes" ]; then
+            entries+=('{"label":"oss","docker-dir":"source_path/hazelcast-oss","image-name":"hazelcast","build-functions-script-path":".github/scripts/oss-build.functions.sh"}')
+          fi
+          if [ "${{ steps.resolve-editions.outputs.should_build_ee }}" = "yes" ]; then
+            entries+=('{"label":"ee","docker-dir":"source_path/hazelcast-enterprise","image-name":"hazelcast-enterprise","build-functions-script-path":".github/scripts/ee-build.functions.sh"}')
+          fi
+
+          json="[$(IFS=,; echo "${entries[*]}")]"
+          echo "matrix=$json" >> "${GITHUB_OUTPUT}"
+
   distribution-variants:
     uses: hazelcast/hazelcast-docker/.github/workflows/get-distribution-variants.yaml@master
 
@@ -108,18 +118,13 @@ jobs:
       matrix:
         jdk: ${{ fromJSON(needs.prepare.outputs.jdks) }}
         variant: ${{ fromJSON(needs.distribution-variants.outputs.variants) }}
+        distribution-type: ${{ fromJSON(needs.prepare.outputs.distribution-types) }}
     env:
       DOCKER_ORG: hazelcast
       HZ_VERSION: ${{ needs.prepare.outputs.HZ_VERSION }}
-      DOCKER_DIR_OS: source_path/hazelcast-oss
-      DOCKER_DIR_EE: source_path/hazelcast-enterprise
+      TEST_CONTAINER_NAME: hazelcast-test
+      TEST_IMAGE_NAME: hazelcast:test
     steps:
-
-      - name: Set environment variables
-        run: |
-          echo "DOCKER_LOG_FILE_OSS=docker-${{ env.test_container_name_oss }}${{ matrix.variant.suffix }}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
-          echo "DOCKER_LOG_FILE_EE=docker-${{ env.test_container_name_ee }}${{ matrix.variant.suffix }}-jdk${{ matrix.jdk }}.log" >> $GITHUB_ENV
-
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
@@ -132,132 +137,82 @@ jobs:
       - name: Setup Docker
         uses: ./.github/actions/setup-docker
 
+      - name: Login to Docker Hub
+        if: ${{ inputs.DRY_RUN != 'true' && matrix.distribution-type.label == 'oss' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Configure AWS credentials
+        if: matrix.distribution-type.label == 'ee'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: 'us-east-1'
 
-      - name: Login to Docker Hub
-        if: inputs.DRY_RUN != 'true'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Get OSS dist ZIP URL
-        if: needs.prepare.outputs.should_build_oss == 'yes'
+      - name: Get dist ZIP URL
         run: |
-          . .github/scripts/oss-build.functions.sh
-          echo "HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant.classifier }}" "${{ env.HZ_VERSION }}")" >> $GITHUB_ENV
+          . ${{ matrix.distribution-type.build-functions-script-path }}
+          echo "HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant.classifier }}" "${{ env.HZ_VERSION }}")" >> ${GITHUB_ENV}
 
-      - name: Build Test OSS image
-        if: needs.prepare.outputs.should_build_oss == 'yes'
+      - name: Build Test image
         run: |
+          . ${{ matrix.distribution-type.build-functions-script-path }}
+
           docker buildx build --load \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_OSS_ZIP_URL \
-            --tag hazelcast-oss:test \
-            ${DOCKER_DIR_OS}
+            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_ZIP_URL \
+            --tag ${TEST_IMAGE_NAME} \
+            ${{ matrix.distribution-type.docker-dir }}
 
-      - name: Run smoke test against OSS image
-        if: needs.prepare.outputs.should_build_oss == 'yes'
+      - name: Run smoke test against image
         timeout-minutes: 2
         run: |
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test "${{ env.test_container_name_oss }}" oss "${{ env.HZ_VERSION }}" "${{ matrix.jdk }}"
-
-      - name: Get EE dist ZIP URL
-        if: needs.prepare.outputs.should_build_ee == 'yes'
-        run: |
-          . .github/scripts/ee-build.functions.sh
-          echo "HAZELCAST_EE_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant.classifier }}" "${{ env.HZ_VERSION }}")" >> $GITHUB_ENV
-
-      - name: Build Test EE image
-        if: needs.prepare.outputs.should_build_ee == 'yes'
-        run: |
-          . .github/scripts/ee-build.functions.sh
-          docker buildx build --load \
-            --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_EE_ZIP_URL \
-            --tag hazelcast-ee:test \
-            ${DOCKER_DIR_EE}
-
-      - name: Run smoke test against EE image
-        if: needs.prepare.outputs.should_build_ee == 'yes'
-        timeout-minutes: 2
-        run: |
-          export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test "${{ env.test_container_name_ee }}" ee "${{ env.HZ_VERSION }}" "${{ matrix.jdk }}"
+          .github/scripts/simple-smoke-test.sh ${TEST_IMAGE_NAME} "${{ env.TEST_CONTAINER_NAME }}" ${{ matrix.distribution-type.label }} "${{ env.HZ_VERSION }}" "${{ matrix.jdk }}"
+        env:
+          HZ_LICENSEKEY: ${{ matrix.distribution-type.label == 'ee' && secrets.HZ_ENTERPRISE_LICENSE || '' }}
 
       - name: Get docker logs
         if: ${{ always() }}
         run: |
-          docker logs "${{ env.test_container_name_oss }}" > "${{ env.DOCKER_LOG_FILE_OSS }}" || true
-          docker logs "${{ env.test_container_name_ee }}" > "${{ env.DOCKER_LOG_FILE_EE }}" || true
+          docker logs "${{ env.TEST_CONTAINER_NAME }}" > "docker-${{ env.TEST_CONTAINER_NAME }}${{ matrix.variant.suffix }}-jdk${{ matrix.jdk }}.log" || true
 
       - name: Store docker logs as artifact
-        if: ${{ always() && ( needs.prepare.outputs.should_build_ee == 'yes' || needs.prepare.outputs.should_build_oss == 'yes') }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs${{ matrix.variant.suffix }}-${{ github.job }}-jdk${{ matrix.jdk }}
+          name: docker-logs-${{ matrix.distribution-type.label }}${{ matrix.variant.suffix }}-${{ github.job }}-jdk${{ matrix.jdk }}
           path: docker-*.log
 
-      - name: Build and Push OSS image
-        if: needs.prepare.outputs.should_build_oss == 'yes'
-        run: |
-          . .github/scripts/get-tags-to-push.sh 
-          . .github/scripts/docker.functions.sh
-          
-          IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast
-          DEFAULT_JDK="$(get_default_jdk ${DOCKER_DIR_OS})"
-          
-          # OSS has no LTS releases
-          IS_LATEST_LTS=false
-          TAGS_TO_PUSH=$(get_tags_to_push "${{ env.HZ_VERSION }}" "${{ matrix.variant.suffix }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
-          echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
-          TAGS_ARG=""
-          for tag in ${TAGS_TO_PUSH[@]}
-          do
-            TAGS_ARG="${TAGS_ARG} --tag ${IMAGE_NAME}:${tag}"
-          done
-          
-          output=
-
-          PLATFORMS="$(get_alpine_supported_platforms "${{ matrix.jdk }}")"
-
-          if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
-            echo "DRY RUN: Skipping push for platforms ${PLATFORMS} and tags: ${TAGS_TO_PUSH}"
-          else
-            output=--push
-          fi
-
-          docker buildx build ${output} \
-            --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=${HAZELCAST_OSS_ZIP_URL} \
-            ${TAGS_ARG} \
-            --platform=${PLATFORMS} "${DOCKER_DIR_OS}"
-
       - name: Check if latest EE LTS release
+        if: matrix.distribution-type.label == 'ee'
         id: is_latest_lts
         uses: ./.github/actions/check-if-latest-lts-release
         with:
           hz_version: ${{ env.HZ_VERSION }}
           is_lts_override: ${{ inputs.IS_LTS_OVERRIDE }}
 
-      - name: Build/Push EE image
-        if: needs.prepare.outputs.should_build_ee == 'yes'
+      - name: Build and Push image
         run: |
-          . .github/scripts/get-tags-to-push.sh 
+          . .github/scripts/logging.functions.sh
+          . .github/scripts/get-tags-to-push.sh
           . .github/scripts/docker.functions.sh
-          . .github/scripts/ee-build.functions.sh
-          
-          IMAGE_NAME=${{ env.DOCKER_ORG }}/hazelcast-enterprise
-          DEFAULT_JDK="$(get_default_jdk ${DOCKER_DIR_EE})"
-          
-          IS_LATEST_LTS="${{ steps.is_latest_lts.outputs.is_latest_lts }}"
-          TAGS_TO_PUSH=$(get_tags_to_push "${{ env.HZ_VERSION }}" "${{ matrix.variant.suffix }}" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
-          echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
+          . ${{ matrix.distribution-type.build-functions-script-path }}
+
+          IMAGE_NAME=${{ env.DOCKER_ORG }}/${{ matrix.distribution-type.image-name }}
+          DEFAULT_JDK="$(get_default_jdk ${{ matrix.distribution-type.docker-dir }})"
+
+          if [ "${{ matrix.distribution-type.label }}" = "oss" ]; then
+            # OSS has no LTS releases
+            IS_LATEST_LTS=false
+          elif [ "${{ matrix.distribution-type.label }}" = "ee" ]; then
+            IS_LATEST_LTS="${{ steps.is_latest_lts.outputs.is_latest_lts }}"
+          fi
+
+          TAGS_TO_PUSH=$(get_tags_to_push "${{ env.HZ_VERSION }}" "${{ matrix.variant.suffix }}" "${{ matrix.jdk }}" "${DEFAULT_JDK}" "${IS_LATEST_LTS}")
+          echodebug "TAGS_TO_PUSH=${TAGS_TO_PUSH}"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}
           do
@@ -266,20 +221,30 @@ jobs:
 
           output=
 
-          PLATFORMS="$(get_ubi_supported_platforms "${{ matrix.jdk }}")"
+          if [ "${{ matrix.distribution-type.label }}" = "oss" ]; then
+            PLATFORMS="$(get_alpine_supported_platforms "${{ matrix.jdk }}")"
+          elif [ "${{ matrix.distribution-type.label }}" = "ee" ]; then
+            PLATFORMS="$(get_ubi_supported_platforms "${{ matrix.jdk }}")"
+          fi
+          
 
           if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
-            echo "DRY RUN: Skipping push for platforms ${PLATFORMS} and tags: ${TAGS_TO_PUSH}"
+            echodebug "DRY RUN: Skipping push for platforms ${PLATFORMS} and tags: ${TAGS_TO_PUSH}"
           else
             output=--push
           fi
 
           docker buildx build ${output} \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=${HAZELCAST_EE_ZIP_URL} \
+            --build-arg HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL} \
             ${TAGS_ARG} \
-            --platform=${PLATFORMS} "${DOCKER_DIR_EE}"
+            --platform=${PLATFORMS} "${{ matrix.distribution-type.docker-dir }}"
 
+  create-release:
+    needs: push
+    if: inputs.DRY_RUN != 'true' && (needs.prepare.outputs.should_build_ee == 'yes' || needs.prepare.outputs.should_build_oss == 'yes')
+    runs-on: ubuntu-latest
+    steps:
       - name: Create release
         if: inputs.DRY_RUN != 'true'
         uses: ncipollo/release-action@v1
@@ -288,14 +253,21 @@ jobs:
           allowUpdates: true
           tag: ${{ inputs.SOURCE_REF }}
 
-      - name: Slack notification
-        uses: hazelcast/docker-actions/slack-notification@master
-        if: failure() && github.triggering_actor == 'devOpsHazelcast'
-        with:
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}
-
   readme:
-    needs: [ prepare, push ]
+    needs:
+      - prepare
+      - push
     if: inputs.DRY_RUN != 'true' && (needs.prepare.outputs.should_build_ee == 'yes' || needs.prepare.outputs.should_build_oss == 'yes')
     uses: ./.github/workflows/update_readme.yml
     secrets: inherit
+
+  failure-notifications:
+    runs-on: ubuntu-latest
+    name: Failure notification
+    if: failure() && github.triggering_actor == 'devOpsHazelcast'
+    needs: readme
+    steps:
+      - name: Slack notification
+        uses: hazelcast/docker-actions/slack-notification@master
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -247,10 +247,8 @@ jobs:
           tag: ${{ inputs.SOURCE_REF }}
 
   readme:
-    needs:
-      - prepare
-      - push
-    if: inputs.DRY_RUN != 'true' && (needs.prepare.outputs.should_build_ee == 'yes' || needs.prepare.outputs.should_build_oss == 'yes')
+    needs: push
+    if: inputs.DRY_RUN != 'true'
     uses: ./.github/workflows/update_readme.yml
     secrets: inherit
 

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -234,7 +234,7 @@ jobs:
 
   create-release:
     needs: push
-    if: inputs.DRY_RUN != 'true' && (needs.prepare.outputs.should_build_ee == 'yes' || needs.prepare.outputs.should_build_oss == 'yes')
+    if: inputs.DRY_RUN != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Create release

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -156,7 +156,7 @@ jobs:
 
           docker buildx build --load \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$HAZELCAST_ZIP_URL \
+            --build-arg HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL} \
             --tag ${TEST_IMAGE_NAME} \
             ${{ matrix.distribution-type.docker-dir }}
 

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -233,7 +233,7 @@ jobs:
           esac
 
           if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
-            echodebug "DRY RUN: Skipping push for platforms ${PLATFORMS} and tags: ${TAGS_TO_PUSH}"
+            echonotice "DRY RUN: Skipping push for platforms ${PLATFORMS} and tags: ${TAGS_TO_PUSH}"
           else
             output=--push
           fi

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -219,7 +219,6 @@ jobs:
           elif [ "${{ matrix.distribution-type.label }}" = "ee" ]; then
             PLATFORMS="$(get_ubi_supported_platforms "${{ matrix.jdk }}")"
           fi
-          
 
           if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
             echodebug "DRY RUN: Skipping push for platforms ${PLATFORMS} and tags: ${TAGS_TO_PUSH}"

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -145,14 +145,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Configure AWS credentials
-        if: matrix.distribution-type.label == 'ee'
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: 'us-east-1'
-
       - name: Get dist ZIP URL
         run: |
           . ${{ matrix.distribution-type.build-functions-script-path }}

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Get dist ZIP URL
         run: |
           . ${{ matrix.distribution-type.build-functions-script-path }}
-          echo "HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant.classifier }}" "${{ env.HZ_VERSION }}")" >> ${GITHUB_ENV}
+          echo "HAZELCAST_ZIP_URL=$(get_hz_dist_zip "${{ matrix.variant.classifier }}" "${HZ_VERSION}")" >> ${GITHUB_ENV}
 
       - name: Build Test image
         run: |
@@ -163,14 +163,14 @@ jobs:
       - name: Run smoke test against image
         timeout-minutes: 2
         run: |
-          .github/scripts/simple-smoke-test.sh ${TEST_IMAGE_NAME} "${{ env.TEST_CONTAINER_NAME }}" ${{ matrix.distribution-type.label }} "${{ env.HZ_VERSION }}" "${{ matrix.jdk }}"
+          .github/scripts/simple-smoke-test.sh ${TEST_IMAGE_NAME} "${TEST_CONTAINER_NAME}" ${{ matrix.distribution-type.label }} "${HZ_VERSION}" "${{ matrix.jdk }}"
         env:
           HZ_LICENSEKEY: ${{ matrix.distribution-type.label == 'ee' && secrets.HZ_ENTERPRISE_LICENSE || '' }}
 
       - name: Get docker logs
         if: ${{ always() }}
         run: |
-          docker logs "${{ env.TEST_CONTAINER_NAME }}" > "docker-${{ env.TEST_CONTAINER_NAME }}${{ matrix.variant.suffix }}-jdk${{ matrix.jdk }}.log" || true
+          docker logs "${TEST_CONTAINER_NAME}" > "docker-${TEST_CONTAINER_NAME}${{ matrix.variant.suffix }}-jdk${{ matrix.jdk }}.log" || true
 
       - name: Store docker logs as artifact
         if: ${{ always() }}
@@ -194,7 +194,7 @@ jobs:
           . .github/scripts/docker.functions.sh
           . ${{ matrix.distribution-type.build-functions-script-path }}
 
-          IMAGE_NAME=${{ env.DOCKER_ORG }}/${{ matrix.distribution-type.image-name }}
+          IMAGE_NAME=${DOCKER_ORG}/${{ matrix.distribution-type.image-name }}
           DEFAULT_JDK="$(get_default_jdk ${{ matrix.distribution-type.docker-dir }})"
 
           if [ "${{ matrix.distribution-type.label }}" = "oss" ]; then
@@ -204,7 +204,7 @@ jobs:
             IS_LATEST_LTS="${{ steps.is_latest_lts.outputs.is_latest_lts }}"
           fi
 
-          TAGS_TO_PUSH=$(get_tags_to_push "${{ env.HZ_VERSION }}" "${{ matrix.variant.suffix }}" "${{ matrix.jdk }}" "${DEFAULT_JDK}" "${IS_LATEST_LTS}")
+          TAGS_TO_PUSH=$(get_tags_to_push "${HZ_VERSION}" "${{ matrix.variant.suffix }}" "${{ matrix.jdk }}" "${DEFAULT_JDK}" "${IS_LATEST_LTS}")
           echodebug "TAGS_TO_PUSH=${TAGS_TO_PUSH}"
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}


### PR DESCRIPTION
`tag_image_push` builds EE and OS images - but the structure is _something like_:
- build OS test image
- test OS test image
- build real OS image
- build EE test image
- test EE test image
- build EE real image

The commands to build and test _should_ be basically identical, and reducing duplication avoids them become out-of-sync.

Refactored to run (basically) the same commands to perform the build-test/test/build-real operations with the EE-or-OS flag coming from a matrix. 

The net result of this is -30LOC and the PR builder drops from [7m43s](https://github.com/hazelcast/hazelcast-docker/actions/runs/17179499550) -> [5m47s](https://github.com/hazelcast/hazelcast-docker/actions/runs/17236039849) (1⁄3 faster) because the OS/EE builds can be done in parallel.

Pre-merge actions:
- [ ] trigger an _actual_ push