### PR TITLE
Remove building image in `build-pr` as duplicated in `tag_image_push`

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -3,23 +3,12 @@ name: Build PR
 on:
   pull_request:
 
-env:
-  test_container_name_oss: hazelcast-oss-test
-  test_container_name_ee: hazelcast-ee-test
-  docker_log_file_oss: docker-hazelcast-oss-test.log
-  docker_log_file_ee: docker-hazelcast-ee-test.log
-  DOCKER_DIR_OS: hazelcast-oss
-  DOCKER_DIR_EE: hazelcast-enterprise
-
 jobs:
   prepare:
     runs-on: ubuntu-latest
     name: Prepare environment
     outputs:
-      HZ_VERSION_OSS: ${{ steps.get_hz_versions.outputs.HZ_VERSION_OSS }}
-      HZ_VERSION_EE: ${{ steps.get_hz_versions.outputs.HZ_VERSION_EE }}
       LAST_RELEASED_HZ_VERSION_OSS: ${{ steps.get_hz_versions.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
-      HAZELCAST_EE_ZIP_URL: ${{ steps.get_ee_vars.outputs.HAZELCAST_EE_ZIP_URL }}
       jdks: ${{ steps.jdks.outputs.jdks }}
     steps:
       - name: Checkout Code
@@ -41,154 +30,6 @@ jobs:
       - name: Get HZ versions
         id: get_hz_versions
         uses: hazelcast/docker-actions/get-hz-versions@master
-
-      - name: Setup EE variables
-        id: get_ee_vars
-        run: |
-          . .github/scripts/ee-build.functions.sh
-          echo "HAZELCAST_EE_ZIP_URL=$(get_hz_dist_zip "" "${{ steps.get_hz_versions.outputs.HZ_VERSION_EE }}")" >> $GITHUB_OUTPUT
-
-      - name: Get supported JDKs
-        id: jdks
-        uses: hazelcast/docker-actions/get-supported-jdks@master
-        with:
-          HZ_VERSION: '${{ steps.get_hz_versions.outputs.HZ_VERSION_EE }}'
-
-  build-pr:
-    runs-on: ubuntu-latest
-    name: Build with default JDK
-    needs: [ prepare ]
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v5
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
-          fetch-depth: 0
-
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build OSS image
-        run: |
-          HZ_VERSION="${{ needs.prepare.outputs.HZ_VERSION_OSS }}"
-          
-          # duplicated block as GH doesn't support passing sensitive data between jobs
-          . .github/scripts/oss-build.functions.sh
-          export HZ_SNAPSHOT_INTERNAL_PASSWORD=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
-          export HZ_SNAPSHOT_INTERNAL_USERNAME=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
-          HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "" "${HZ_VERSION}")
-          
-          curl --fail --silent --show-error --location "$HAZELCAST_OSS_ZIP_URL" --output ${DOCKER_DIR_OS}/hazelcast-distribution.zip; 
-          
-          docker buildx build --load \
-          --tag hazelcast-oss:test \
-          "${DOCKER_DIR_OS}"
-
-      - name: Run smoke test against OSS image
-        timeout-minutes: 2
-        run: |          
-          . .github/scripts/docker.functions.sh
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test "${{ env.test_container_name_oss }}" oss "${{ needs.prepare.outputs.HZ_VERSION_OSS }}" "$(get_default_jdk ${DOCKER_DIR_OS})"
-
-      - name: Build Test EE image
-        run: |
-          curl --fail --silent --show-error --location "${{ needs.prepare.outputs.HAZELCAST_EE_ZIP_URL }}" --output ${DOCKER_DIR_EE}/hazelcast-enterprise-distribution.zip;
-          
-          docker buildx build --load \
-          --tag hazelcast-ee:test \
-          "${DOCKER_DIR_EE}"
-
-      - name: Run smoke test against EE image
-        timeout-minutes: 2
-        run: |
-          . .github/scripts/docker.functions.sh
-          export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test "${{ env.test_container_name_ee }}" ee "${{ needs.prepare.outputs.HZ_VERSION_EE }}" "$(get_default_jdk ${DOCKER_DIR_EE})"
-
-      - name: Get docker logs
-        if: ${{ always() }}
-        run: |
-          docker logs "${{ env.test_container_name_oss }}" > "${{ env.docker_log_file_oss }}"
-          docker logs "${{ env.test_container_name_ee }}" > "${{ env.docker_log_file_ee }}"
-
-      - name: Store docker logs as artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-logs-${{ github.job }}
-          path: |
-            ${{ env.docker_log_file_oss }}
-            ${{ env.docker_log_file_ee }}
-
-  build-pr-custom-jdk:
-    runs-on: ubuntu-latest
-    needs: [ prepare ]
-    name: Build with jdk-${{ matrix.jdk }}
-    strategy:
-      fail-fast: false
-      matrix:
-        jdk: ${{ fromJSON(needs.prepare.outputs.jdks) }}
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v5
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
-          fetch-depth: 0
-
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build OSS image
-        run: |
-          HZ_VERSION="${{ needs.prepare.outputs.HZ_VERSION_OSS }}"
-          
-          # duplicated block as GH doesn't support passing sensitive data between jobs
-          . .github/scripts/oss-build.functions.sh
-          export HZ_SNAPSHOT_INTERNAL_PASSWORD=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
-          export HZ_SNAPSHOT_INTERNAL_USERNAME=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
-          HAZELCAST_OSS_ZIP_URL=$(get_hz_dist_zip "" "${HZ_VERSION}")
-          
-          curl --fail --silent --show-error --location "$HAZELCAST_OSS_ZIP_URL" --output ${DOCKER_DIR_OS}/hazelcast-distribution.zip;
-
-          docker buildx build --load \
-          --build-arg JDK_VERSION=${{ matrix.jdk }} \
-          --tag hazelcast-oss:test \
-          "${DOCKER_DIR_OS}"
-
-      - name: Run smoke test against OSS image
-        timeout-minutes: 2
-        run: |
-          .github/scripts/simple-smoke-test.sh hazelcast-oss:test "${{ env.test_container_name_oss }}" oss "${{ needs.prepare.outputs.HZ_VERSION_OSS }}" "${{ matrix.jdk }}"
-
-      - name: Build Test EE image
-        run: |
-          curl --fail --silent --show-error --location "${{ needs.prepare.outputs.HAZELCAST_EE_ZIP_URL }}" --output ${DOCKER_DIR_EE}/hazelcast-enterprise-distribution.zip;
-
-          docker buildx build --load \
-          --build-arg JDK_VERSION=${{ matrix.jdk }} \
-          --tag hazelcast-ee:test \
-          "${DOCKER_DIR_EE}"
-
-      - name: Run smoke test against EE image
-        timeout-minutes: 2
-        run: |
-          export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
-          .github/scripts/simple-smoke-test.sh hazelcast-ee:test "${{ env.test_container_name_ee }}" ee "${{ needs.prepare.outputs.HZ_VERSION_EE }}" "${{ matrix.jdk }}"
-
-      - name: Get docker logs
-        if: ${{ always() }}
-        run: |
-          docker logs "${{ env.test_container_name_oss }}" > "${{ env.docker_log_file_oss }}"
-          docker logs "${{ env.test_container_name_ee }}" > "${{ env.docker_log_file_ee }}"
-
-      - name: Store docker logs as artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-logs-${{ github.job }}-jdk${{ matrix.jdk }}
-          path: |
-            ${{ env.docker_log_file_oss }}
-            ${{ env.docker_log_file_ee }}
 
   test-push:
     name: Test pushing image (dry run)


### PR DESCRIPTION
In `build-pr` we build test images and then run `simple-smoke-test`.

We subsequently trigger `tag_image_push` (in `DRY_RUN` mode) which _also_ builds a test image and then runs  `simple-smoke-test` on it (among other things).

As such we should remove this duplication, and instead rely on the script _we actually use for release_.

Post-merge actions:
- [ ] [update branch protection rules](https://github.com/hazelcast/hazelcast-docker/settings/branch_protection_rules/24406088)