### PR TITLE
Support multi-line Strings in `logging.functions.sh`

### DIFF
--- a/.github/scripts/logging.functions.sh
+++ b/.github/scripts/logging.functions.sh
@@ -10,19 +10,22 @@ function echoerr() {
 # Prints the given message as a warning
 function echowarning() {
   # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-warning-message
-  echo "::warning::$*" 1>&2;
+  # Support multi-line strings by replacing line separator with GitHub Actions compatible one
+  echo "::warning::${*//$'\n'/%0A}" 1>&2;
 }
 
 # Prints the given message as a notice
 function echonotice() {
   # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-notice-message
-  echo "::notice::$*" 1>&2;
+  # Support multi-line strings by replacing line separator with GitHub Actions compatible one
+  echo "::notice::${*//$'\n'/%0A}" 1>&2;
 }
 
 # Prints the given message to debug logs, _if enabled_
 function echodebug() {
   # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-debug-message
-  echo "::debug::$*" 1>&2;
+  # Support multi-line strings by replacing line separator with GitHub Actions compatible one
+  echo "::debug::${*//$'\n'/%0A}" 1>&2;
 }
 
 # Create group


### PR DESCRIPTION
Support was added for multi-line error messages in https://github.com/hazelcast/hazelcast-docker/pull/970, but not for the rest of the functions - without this change, only the first line is logged.