### PR TITLE
Fix `check-base-images`

### DIFF
--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Check if ${{ matrix.version }} base images updated
         if: steps.check-base-images.outputs.outdated
         run: |
-          echo "${{ matrix.version }}" >> rebuild-ee-${{ matrix.version }}
+          echo "${{ matrix.version }}" >> rebuild-EE-${{ matrix.version }}
         # GitHub doesn't support outputs of matrix jobs - https://github.com/orgs/community/discussions/26639
         # Instead, write the content to artifact(s) and upload those to consume downstream
 


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-docker/pull/1070, the `label` parameter was removed and replaced with a hardcoded value - but the casing was changed such that the matrix was not being properly populated.