### PR TITLE
Use same image for Docker & RedHat [DI-457]

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -40,12 +40,3 @@ jobs:
       RELEASE_TYPE: ALL
       DRY_RUN: true
     secrets: inherit
-
-  test-push-rhel:
-    name: Test pushing RHEL image (dry run)
-    needs: [ prepare ]
-    uses: ./.github/workflows/tag_image_push_rhel.yml
-    with:
-      SOURCE_REF: v${{ needs.prepare.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
-      DRY_RUN: true
-    secrets: inherit

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -85,23 +85,11 @@ jobs:
     needs: convert-rebuilds-to-matrix
     if: ${{ needs.convert-rebuilds-to-matrix.outputs.rebuild-ee-matrix != null }}
     strategy:
-      matrix:
-        version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.rebuild-ee-matrix) }}
-    uses: ./.github/workflows/tag_image_push.yml
-    with:
-      SOURCE_REF: v${{ matrix.version }}
-    secrets: inherit
-
-  rebuild-rhel:
-    name: Rebuild EE RHEL images
-    needs: convert-rebuilds-to-matrix
-    if: ${{ needs.convert-rebuilds-to-matrix.outputs.rebuild-ee-matrix != null }}
-    strategy:
       # RedHat does not support concurrent publishing, run sequentially
       max-parallel: 1
       matrix:
         version: ${{ fromJSON(needs.convert-rebuilds-to-matrix.outputs.rebuild-ee-matrix) }}
-    uses: ./.github/workflows/tag_image_push_rhel.yml
+    uses: ./.github/workflows/tag_image_push.yml
     with:
       SOURCE_REF: v${{ matrix.version }}
     secrets: inherit
@@ -124,7 +112,6 @@ jobs:
     if: failure() && github.event_name != 'workflow_dispatch'
     needs:
       - rebuild-ee
-      - rebuild-rhel
       - rebuild-nlc
     steps:
       - name: Slack notification

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -230,7 +230,7 @@ jobs:
           else
             LABEL_ARG=""
           fi
- 
+
           docker buildx build --push \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
             --build-arg HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL} \

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -230,8 +230,7 @@ jobs:
           else
             LABEL_ARG=""
           fi
-
-          # provenance disabled as causes RedHat publish failure 
+ 
           docker buildx build --push \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
             --build-arg HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL} \

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -70,6 +70,7 @@ jobs:
       distribution-types: ${{ steps.distribution-type-matrix.outputs.matrix }}
       HZ_VERSION: ${{ steps.get_hz_versions.outputs.HZ_VERSION }}
       jdks: ${{ steps.jdks.outputs.jdks }}
+      should-build-ee: ${{ steps.resolve-editions.outputs.should_build_ee }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
@@ -207,11 +208,10 @@ jobs:
           TAGS_ARG=""
           for tag in ${TAGS_TO_PUSH[@]}
           do
+            # Keep a reference to _a_ tag to get the image later on
             echo "TAG=${tag}" >> ${GITHUB_ENV}
             TAGS_ARG="${TAGS_ARG} --tag ${LOCAL_IMAGE_NAME}:${tag}"
           done
-
-          output=
 
           case "${{ matrix.distribution-type.label }}" in
               "oss")
@@ -231,6 +231,7 @@ jobs:
             LABEL_ARG=""
           fi
 
+          # provenance disabled as causes RedHat publish failure 
           docker buildx build --push \
             --build-arg JDK_VERSION=${{ matrix.jdk }} \
             --build-arg HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL} \
@@ -313,11 +314,27 @@ jobs:
     uses: ./.github/workflows/update_readme.yml
     secrets: inherit
 
+  push-rhel:
+    name: Push RHEL image
+    needs:
+      - prepare
+      - push
+    if: inputs.DRY_RUN != 'true' && needs.prepare.outputs.should-build-ee && !contains(needs.prepare.outputs.HZ_VERSION, 'SNAPSHOT')
+    uses: ./.github/workflows/tag_image_push_rhel.yml
+    with:
+      SOURCE_REF: ${{ inputs.SOURCE_REF }}
+      IS_LTS_OVERRIDE: ${{ inputs.IS_LTS_OVERRIDE }}
+    secrets: inherit
+
   failure-notifications:
     runs-on: ubuntu-latest
     name: Failure notification
     if: failure() && github.triggering_actor == 'devOpsHazelcast'
-    needs: readme
+    needs:
+      - push
+      - push-rhel
+      - readme
+      - create-release
     steps:
       - name: Slack notification
         uses: hazelcast/docker-actions/slack-notification@master

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -78,21 +78,6 @@ jobs:
         with:
           version: ${{ env.HZ_VERSION }}
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: 'us-east-1'
-
-      - name: Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          secret-ids: |
-            OCP_LOGIN_USERNAME,CN/OCP_USERNAME
-            OCP_LOGIN_PASSWORD,CN/OCP_PASSWORD
-            OCP_CLUSTER_URL,CN/OCP_CLUSTER_URL
-
       - name: Set scan registry secrets
         run: |
           echo "SCAN_REGISTRY_USER=${{ secrets[format('SCAN_REGISTRY_USER_V{0}', steps.version.outputs.major)] }}" >> $GITHUB_ENV

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -1,10 +1,10 @@
-name: Build EE RHEL image
+name: Push EE RHEL image
 
 on:
   workflow_dispatch:
     inputs:
       SOURCE_REF:
-        description: 'The hazelcast-docker branch to build the image from'
+        description: 'The hazelcast-docker branch to use as a reference to obtain the image from'
         required: true
       IS_LTS_OVERRIDE:
         description: 'Override is LTS release'
@@ -15,29 +15,16 @@ on:
           - ''
           - 'false'
           - 'true'
-      DRY_RUN:
-        description: 'Skip pushing the images to remote registry'
-        required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'false'
-          - 'true'
   workflow_call:
     inputs:
       SOURCE_REF:
-        description: 'The hazelcast-docker branch to build the image from'
+        description: 'The hazelcast-docker branch to use as a reference to obtain the image from'
         required: true
         type: string
       IS_LTS_OVERRIDE:
         description: 'Override is LTS release'
         required: false
         default: ''
-        type: string
-      DRY_RUN:
-        description: 'Skip pushing the images to remote registry'
-        required: false
-        default: 'false'
         type: string
 jobs:
   prepare:
@@ -86,9 +73,6 @@ jobs:
           ref: ${{ inputs.SOURCE_REF }}
           path: source_path
 
-      - name: Setup Docker
-        uses: ./.github/actions/setup-docker
-
       - uses: madhead/semver-utils@latest
         id: version
         with:
@@ -115,11 +99,9 @@ jobs:
           echo "SCAN_REGISTRY_PASSWORD=${{ secrets[format('SCAN_REGISTRY_PASSWORD_V{0}', steps.version.outputs.major)] }}" >> $GITHUB_ENV
           echo "RHEL_PROJECT_ID=${{ secrets[format('RHEL_PROJECT_ID_V{0}', steps.version.outputs.major)] }}" >> $GITHUB_ENV
 
-      - name: Set RHEL image as environment variable
+      - name: Set scan repository as environment variable
         run: |
-          SCAN_REPOSITORY=${SCAN_REGISTRY}/redhat-isv-containers/${RHEL_PROJECT_ID}
-          echo "SCAN_REPOSITORY=${SCAN_REPOSITORY}" >> $GITHUB_ENV
-          echo "RHEL_IMAGE=${SCAN_REPOSITORY}:${HZ_VERSION}-jdk${{ matrix.jdk }}" >> $GITHUB_ENV
+          echo "SCAN_REPOSITORY=${SCAN_REGISTRY}/redhat-isv-containers/${RHEL_PROJECT_ID}" >> $GITHUB_ENV
 
       - name: Log in to Red Hat Scan Registry
         uses: docker/login-action@v3
@@ -135,41 +117,29 @@ jobs:
           hz_version: ${{ env.HZ_VERSION }}
           is_lts_override: ${{ inputs.IS_LTS_OVERRIDE }}
 
-      - name: Build the Hazelcast Enterprise image
+      - name: Copy image to Quay
         run: |
           . .github/scripts/get-tags-to-push.sh 
           . .github/scripts/docker.functions.sh
-          . .github/scripts/ee-build.functions.sh
 
-          IMAGE_NAME=${SCAN_REPOSITORY}
           DEFAULT_JDK="$(get_default_jdk ${DOCKER_DIR})"
 
           IS_LATEST_LTS="${{ steps.is_latest_lts.outputs.is_latest_lts }}"
           TAGS_TO_PUSH=$(get_tags_to_push "${{ env.HZ_VERSION }}" "" "${{ matrix.jdk }}" "$DEFAULT_JDK" "$IS_LATEST_LTS")
           echo "TAGS_TO_PUSH=$TAGS_TO_PUSH"
-          TAGS_ARG=""
+
           for tag in ${TAGS_TO_PUSH[@]}
           do
-            TAGS_ARG="${TAGS_ARG} --tag ${IMAGE_NAME}:${tag}"
+            # Keep a reference to _a_ tag to get the image later on
+            echo "TAG=${tag}" >> ${GITHUB_ENV}
+
+            # Deliberately only copy a single architecture - https://github.com/hazelcast/hazelcast-docker/pull/1042#issuecomment-3141395993
+            skopeo copy \
+              --override-os linux \
+              --override-arch amd64 \
+              docker://hazelcast/hazelcast-enterprise:${tag} \
+              docker://${SCAN_REPOSITORY}:${tag}
           done
-
-          output=
-
-          PLATFORMS="linux/amd64"
-
-          if [ "${{ inputs.DRY_RUN }}" == "true" ] ; then
-            echo "DRY RUN: Skipping push for platforms ${PLATFORMS} and tags: ${TAGS_TO_PUSH}"
-          else
-            output=--push
-          fi
-
-          # provenance disabled as causes RedHat publish failure 
-          docker buildx build ${output} \
-            --provenance=false \
-            --build-arg JDK_VERSION=${{ matrix.jdk }} \
-            --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "" "${{ env.HZ_VERSION }}") \
-            ${TAGS_ARG} \
-            --platform=${PLATFORMS} "${DOCKER_DIR}"
 
       - name: Install `preflight` OpenShift tool from GitHub
         uses: redhat-actions/openshift-tools-installer@v1
@@ -179,11 +149,10 @@ jobs:
           skip_cache: true
 
       - name: Run preflight scan
-        if: inputs.DRY_RUN != 'true'
         run: |
           source .github/scripts/logging.functions.sh
 
-          PREFLIGHT_OUTPUT=$(preflight check container "${RHEL_IMAGE}" \
+          PREFLIGHT_OUTPUT=$(preflight check container "${SCAN_REPOSITORY}:${TAG}" \
             --submit --pyxis-api-token=${RHEL_API_KEY} \
             --certification-component-id=${RHEL_PROJECT_ID} \
             --docker-config ~/.docker/config.json \
@@ -202,7 +171,6 @@ jobs:
           fi
 
       - name: Publish the Hazelcast Enterprise image
-        if: inputs.DRY_RUN != 'true'
         run: |
           .github/scripts/publish-rhel.sh "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}" "${TIMEOUT_IN_MINS}"
 

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -102,7 +102,7 @@ jobs:
           hz_version: ${{ env.HZ_VERSION }}
           is_lts_override: ${{ inputs.IS_LTS_OVERRIDE }}
 
-      - name: Copy image to Quay
+      - name: Copy image to RedHat Container Registry
         run: |
           . .github/scripts/get-tags-to-push.sh 
           . .github/scripts/docker.functions.sh


### PR DESCRIPTION
The image we push to Docker and RedHat are built using the same parameters, but built in different jobs - instead of building separately, we should build once and deploy the _same_ image.

Changes:
- `tag_image_push_rhel.yml`
   - _copy_ the image from DockerHub to Quay rather than building afresh
   - removed unused
   - remove `DRY_RUN` parameter - this was only used to test the _build_ portion which is now redundant
- `tag_image_push.yml`
   - add execution of `tag_image_push_rhel.yml` automatically after an (EE non-`SNAPSHOT`) image is `push`ed
- `build-pr.yml`
   - `tag_image_push_rhel.yml` execution removed as has no `DRY_RUN` mode
- `check-base-images.yml`
   - `tag_image_push_rhel.yml` execution removed as triggered automatically after `tag_image_push.yml`

[Example execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/17408004324)

Fixes: [DI-457](https://hazelcast.atlassian.net/browse/DI-457)

Pre-merge checklist:
- [x] [Run the RHEL test](https://github.com/hazelcast/hazelcast-docker/actions/runs/17408308303)

Post-merge checklist:
- [x] [Remove any RHEL build jobs from release pipeline](https://github.com/hazelcast/hazelcast-pipeline-library/pull/290)

[DI-457]: https://hazelcast.atlassian.net/browse/DI-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ