### PR TITLE
Migrate `version.functions` to use `gh` _where possible_

### DIFF
--- a/.github/actions/check-if-latest-lts-release/action.yml
+++ b/.github/actions/check-if-latest-lts-release/action.yml
@@ -1,6 +1,8 @@
 name: Check if latest EE LTS release
 description: Check if latest EE LTS release
 inputs:
+  GITHUB_TOKEN:
+    required: true
   hz_version:
     description: Version to be released
     required: true
@@ -44,3 +46,5 @@ runs:
         else 
            echo "is_latest_lts=false" >> $GITHUB_OUTPUT
         fi
+      env:
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}

--- a/.github/scripts/version.functions_tests.sh
+++ b/.github/scripts/version.functions_tests.sh
@@ -12,7 +12,7 @@ TESTS_RESULT=0
 function assert_minor_versions_contain {
   local MINIMAL_SUPPORTED_VERSION=$1
   local EXPECTED_VERSION=$2
-  local ACTUAL_MINOR_VERSIONS=$(get_minor_versions "$MINIMAL_SUPPORTED_VERSION")
+  local ACTUAL_MINOR_VERSIONS=$(__get_minor_versions "$MINIMAL_SUPPORTED_VERSION")
   local MSG="Minor versions starting from $MINIMAL_SUPPORTED_VERSION should contain $EXPECTED_VERSION "
   assert_contain "$ACTUAL_MINOR_VERSIONS" "$EXPECTED_VERSION" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
 }
@@ -20,7 +20,7 @@ function assert_minor_versions_contain {
 function assert_minor_versions_not_contain {
   local MINIMAL_SUPPORTED_VERSION=$1
   local EXPECTED_VERSION=$2
-  local ACTUAL_MINOR_VERSIONS=$(get_minor_versions "$MINIMAL_SUPPORTED_VERSION")
+  local ACTUAL_MINOR_VERSIONS=$(__get_minor_versions "$MINIMAL_SUPPORTED_VERSION")
   local MSG="Minor versions starting from $MINIMAL_SUPPORTED_VERSION should NOT contain $EXPECTED_VERSION"
   assert_not_contain "$ACTUAL_MINOR_VERSIONS" "$EXPECTED_VERSION" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
 }
@@ -66,7 +66,7 @@ assert_latest_patch_version "4.1-BETA-1" "4.1.10"
 assert_latest_patch_version "4.1" "4.1.10"
 assert_latest_patch_version "3.9" "3.9.4"
 
-log_header "Tests for get_minor_versions"
+log_header "Tests for __get_minor_versions"
 assert_minor_versions_contain "3.12" "3.12"
 assert_minor_versions_contain "4.2" "4.2"
 assert_minor_versions_contain "4.2" "5.0"
@@ -85,8 +85,7 @@ assert_latest_patch_versions_contain "4.1" "4.1.10"
 assert_latest_patch_versions_not_contain "3.12" "3.12.11"
 assert_latest_patch_versions_not_contain "4.2" "3.9.4"
 assert_latest_patch_versions_not_contain "4.2" "4.1.10"
-LATEST_5_4_DEVEL="$(git tag | sort -V | grep 'v5.4.0-DEVEL-' | tail -n 1 | cut -c2-)"
-assert_latest_patch_versions_not_contain "5.3" "$LATEST_5_4_DEVEL"
+assert_latest_patch_versions_not_contain "5.3" "5.4.0-DEVEL-20"
 
 log_header "Tests for get_last_version_with_file"
 assert_get_last_version_with_file ".github/containerscan/allowedlist.yaml" "5.3.1" # it was removed in 5.3.2

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
 
       - name: Forbid .github/release_type file
         run: |
@@ -26,6 +24,8 @@ jobs:
       - name: Test scripts
         run: |
           .github/scripts/test_scripts.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Get HZ versions
         id: get_hz_versions

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
       - id: get-maintenance-versions
         uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions@master
       - name: Calculate minimal supported version
@@ -36,6 +34,8 @@ jobs:
           versions=$(printf '%s\n' $(get_latest_patch_versions "${MIN_VERSION}") | jq --raw-input . | jq --compact-output --slurp .)
           echodebug "Found latest patch versions: ${versions}"
           echo "matrix={\"version\":$versions}" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   # Only checks enterprise
   calculate-rebuilds:

--- a/.github/workflows/ee-nlc-snapshot-push.yml
+++ b/.github/workflows/ee-nlc-snapshot-push.yml
@@ -129,6 +129,8 @@ jobs:
             --label hazelcast.ee.revision=${{ inputs.HZ_EE_REVISION }} \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} ${DOCKER_DIR}
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Check RedHat service status
         if: failure()
         uses: hazelcast/docker-actions/check-redhat-service-status@master

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -136,6 +136,8 @@ jobs:
             --build-arg HAZELCAST_ZIP_URL=${HAZELCAST_ZIP_URL} \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} ${DOCKER_DIR}
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Check RedHat service status
         if: failure()
         uses: hazelcast/docker-actions/check-redhat-service-status@master

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -138,8 +138,6 @@ jobs:
           - 5000:5000
     steps:
       - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
 
       - uses: actions/checkout@v5
         with:
@@ -167,6 +165,7 @@ jobs:
         with:
           hz_version: ${{ env.HZ_VERSION }}
           is_lts_override: ${{ inputs.IS_LTS_OVERRIDE }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Build and Push image to local registry
         run: |
@@ -237,6 +236,8 @@ jobs:
             ${TAGS_ARG} \
             ${LABEL_ARG} \
             --platform=${PLATFORMS} "${{ matrix.distribution-type.docker-dir }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Run smoke test against image
         timeout-minutes: 2

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -78,8 +78,6 @@ jobs:
         jdk: ${{ fromJSON(needs.prepare.outputs.jdks) }}
     steps:
       - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
 
       - uses: actions/checkout@v5
         with:
@@ -134,6 +132,7 @@ jobs:
         with:
           hz_version: ${{ env.HZ_VERSION }}
           is_lts_override: ${{ inputs.IS_LTS_OVERRIDE }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Build the Hazelcast Enterprise image
         run: |
@@ -170,6 +169,8 @@ jobs:
             --build-arg HAZELCAST_ZIP_URL=$(get_hz_dist_zip "" "${{ env.HZ_VERSION }}") \
             ${TAGS_ARG} \
             --platform=${PLATFORMS} "${DOCKER_DIR}"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Install `preflight` OpenShift tool from GitHub
         uses: redhat-actions/openshift-tools-installer@v1


### PR DESCRIPTION
`version.functions` uses native `git` commands to query tags - which necessitates a full checkout.

Instead, the tags can be queried via the `gh` tool.

Justification - the functions are used heavily in `tags-to-push`, if that action was extracted to `docker-actions`, the _step_ would need to do a full checkout just to determine this information.