### PR TITLE
Update Hazelcast License Key

### DIFF
--- a/.github/workflows/rhel-smoke-test.yml
+++ b/.github/workflows/rhel-smoke-test.yml
@@ -79,7 +79,7 @@ jobs:
           oc new-project "${PROJECT_NAME}"
 
           oc create secret generic hz-license-secret \
-            --from-literal=key="${{ secrets.HZ_ENTERPRISE_LICENSE }}"
+            --from-literal=key="${{ secrets.HAZELCAST_ENTERPRISE_KEY }}"
 
           helm repo add hazelcast https://hazelcast-charts.s3.amazonaws.com/
           helm repo update

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -248,7 +248,7 @@ jobs:
         run: |
           .github/scripts/simple-smoke-test.sh ${LOCAL_IMAGE_NAME}:${PRIMARY_TAG} "${TEST_CONTAINER_NAME}" ${{ matrix.distribution-type.label }} "${HZ_VERSION}" "${{ matrix.jdk }}"
         env:
-          HZ_LICENSEKEY: ${{ matrix.distribution-type.label == 'ee' && secrets.HZ_ENTERPRISE_LICENSE || '' }}
+          HZ_LICENSEKEY: ${{ matrix.distribution-type.label == 'ee' && secrets.HAZELCAST_ENTERPRISE_KEY || '' }}
 
       - name: Get docker logs
         if: ${{ always() }}

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -167,7 +167,7 @@ jobs:
           esac
 
           if [[ "${{ matrix.distribution-type }}" == "ee" ]]; then
-            export HZ_LICENSEKEY=${{ secrets.HZ_ENTERPRISE_LICENSE }}
+            export HZ_LICENSEKEY=${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
             export HZ_INSTANCETRACKING_FILENAME=instance-tracking.txt
           fi
 


### PR DESCRIPTION
The repo has it's _own_ license key, instead it should inherit global to make future maintenance simpler.

The key isn't the same, but it's equivalent - as demonstrated by the EE smoke test in the PR builder.

Post-merge actions:
- [ ] remove `HZ_ENTERPRISE_LICENSE` from repo