### PR TITLE
Remove duplicated Docker secrets

### DIFF
--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -266,8 +266,8 @@ jobs:
         if: inputs.DRY_RUN != 'true'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to JFrog
         if: inputs.DRY_RUN != 'true'

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -110,8 +110,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to NLC Repository
         if: matrix.distribution-type == 'ee'

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Update Docker Hub Description
         uses: peter-evans/dockerhub-description@432a30c9e07499fd01da9f8a49f0faf9e0ca5b77 # v4.0.2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
           repository: ${{ matrix.repository }}
           short-description: ${{ matrix.short-description }}
           readme-filepath: ./README-docker.md


### PR DESCRIPTION
The secrets are defined in the repo and the org, use the organisation credentials instead.

Post-merge actions:
- [x] remove `DOCKER_PASSWORD` from repo
- [x] remove `DOCKER_USERNAME` from repo