### PR TITLE
Migrate RedHat repository configuration to GitHub environments [DI-589]

### DIFF
--- a/.github/workflows/rhel-smoke-test.yml
+++ b/.github/workflows/rhel-smoke-test.yml
@@ -13,7 +13,7 @@ jobs:
       SCAN_REGISTRY: "quay.io"
       HZ_VERSION: ${{ inputs.HZ_VERSION }}
       PROJECT_NAME: test-${{ github.run_id }}-${{ github.run_attempt }}
-
+    environment: live
     runs-on: ubuntu-latest
     steps:
       - name: Set HZ version as environment variable
@@ -48,16 +48,17 @@ jobs:
             OCP_CLUSTER_URL,CN/OCP_CLUSTER_URL
 
       - name: Set scan registry secrets
+        id: scan_registry_secrets
         run: |
-          echo "SCAN_REGISTRY_USER=${{ secrets[format('SCAN_REGISTRY_USER_V{0}', steps.version.outputs.major)] }}" >> $GITHUB_ENV
-          echo "SCAN_REGISTRY_PASSWORD=${{ secrets[format('SCAN_REGISTRY_PASSWORD_V{0}', steps.version.outputs.major)] }}" >> $GITHUB_ENV
+          echo "SCAN_REGISTRY_USER=redhat-isv-containers+${{ secrets[format('RHEL_PROJECT_ID_V{0}', steps.version.outputs.major)] }}-robot" >> ${GITHUB_OUTPUT}
+          echo "SCAN_REGISTRY_PASSWORD=${{ secrets[format('SCAN_REGISTRY_PASSWORD_V{0}', steps.version.outputs.major)] }}" >> ${GITHUB_OUTPUT}
 
       - name: Log in to Red Hat Scan Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.SCAN_REGISTRY }}
-          username: ${{ env.SCAN_REGISTRY_USER }}
-          password: ${{ env.SCAN_REGISTRY_PASSWORD }}
+          username: ${{ steps.scan_registry_secrets.outputs.USERNAME }}
+          password: ${{ steps.scan_registry_secrets.outputs.PASSWORD }}
 
       - name: Install `oc` OpenShift tool from mirror
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/rhel-smoke-test.yml
+++ b/.github/workflows/rhel-smoke-test.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Set scan registry secrets
         id: scan_registry_secrets
         run: |
-          echo "SCAN_REGISTRY_USER=redhat-isv-containers+${{ secrets[format('RHEL_PROJECT_ID_V{0}', steps.version.outputs.major)] }}-robot" >> ${GITHUB_OUTPUT}
-          echo "SCAN_REGISTRY_PASSWORD=${{ secrets[format('SCAN_REGISTRY_PASSWORD_V{0}', steps.version.outputs.major)] }}" >> ${GITHUB_OUTPUT}
+          echo "USERNAMD=redhat-isv-containers+${{ secrets[format('RHEL_PROJECT_ID_V{0}', steps.version.outputs.major)] }}-robot" >> ${GITHUB_OUTPUT}
+          echo "PASSWORD=${{ secrets[format('SCAN_REGISTRY_PASSWORD_V{0}', steps.version.outputs.major)] }}" >> ${GITHUB_OUTPUT}
 
       - name: Log in to Red Hat Scan Registry
         uses: docker/login-action@v3

--- a/.github/workflows/rhel-smoke-test.yml
+++ b/.github/workflows/rhel-smoke-test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set scan registry secrets
         id: scan_registry_secrets
         run: |
-          echo "USERNAMD=redhat-isv-containers+${{ secrets[format('RHEL_PROJECT_ID_V{0}', steps.version.outputs.major)] }}-robot" >> ${GITHUB_OUTPUT}
+          echo "USERNAME=redhat-isv-containers+${{ secrets[format('RHEL_PROJECT_ID_V{0}', steps.version.outputs.major)] }}-robot" >> ${GITHUB_OUTPUT}
           echo "PASSWORD=${{ secrets[format('SCAN_REGISTRY_PASSWORD_V{0}', steps.version.outputs.major)] }}" >> ${GITHUB_OUTPUT}
 
       - name: Log in to Red Hat Scan Registry

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -330,6 +330,7 @@ jobs:
       JDKS: ${{ needs.prepare.outputs.jdks }} 
       IS_LATEST_LTS: ${{ needs.push.outputs.is_latest_lts }}
       DEFAULT_JDK: ${{ needs.push.outputs.default_jdk }}
+      ENVIRONMENT: live
     secrets: inherit
 
   failure-notifications:

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -12,6 +12,8 @@ on:
         required: true
       DEFAULT_JDK:
         required: true
+      ENVIRONMENT:
+        required: true
   workflow_call:
     inputs:
       HZ_VERSION:
@@ -26,12 +28,17 @@ on:
       DEFAULT_JDK:
         required: true
         type: string
+      ENVIRONMENT:
+        description: 'Environment to use'
+        required: true
+        type: string
 jobs:
   build:
     env:
       SCAN_REGISTRY: "quay.io"
       TIMEOUT_IN_MINS: 240
       RHEL_API_KEY: ${{ secrets.RHEL_API_KEY }}
+    environment: ${{ inputs.ENVIRONMENT }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -48,21 +55,33 @@ jobs:
           version: ${{ inputs.HZ_VERSION }}
 
       - name: Set scan registry secrets
+        id: scan_registry_secrets
         run: |
-          echo "SCAN_REGISTRY_USER=${{ secrets[format('SCAN_REGISTRY_USER_V{0}', steps.version.outputs.major)] }}" >> $GITHUB_ENV
-          echo "SCAN_REGISTRY_PASSWORD=${{ secrets[format('SCAN_REGISTRY_PASSWORD_V{0}', steps.version.outputs.major)] }}" >> $GITHUB_ENV
-          echo "RHEL_PROJECT_ID=${{ secrets[format('RHEL_PROJECT_ID_V{0}', steps.version.outputs.major)] }}" >> $GITHUB_ENV
+          # Some repositories have a separate projects for each (major) version
+          # First see if a version-specific secret exists, falling back to default
 
-      - name: Set scan repository as environment variable
-        run: |
-          echo "SCAN_REPOSITORY=${SCAN_REGISTRY}/redhat-isv-containers/${RHEL_PROJECT_ID}" >> $GITHUB_ENV
+          PROJECT_ID=${{ secrets[format('RHEL_PROJECT_ID_V{0}', steps.version.outputs.major)] }}
+          if [[ -z "${PROJECT_ID}" ]]; then
+            PROJECT_ID=${{ secrets.RHEL_PROJECT_ID }}
+          fi
+          echo "PROJECT_ID=${PROJECT_ID}" >> ${GITHUB_OUTPUT}
+
+          echo "USERNAME=redhat-isv-containers+${PROJECT_ID}-robot" >> ${GITHUB_OUTPUT}
+
+          PASSWORD=${{ secrets[format('SCAN_REGISTRY_PASSWORD_V{0}', steps.version.outputs.major)] }}
+          if [[ -z "${PASSWORD}" ]]; then
+            PASSWORD=${{ secrets.SCAN_REGISTRY_PASSWORD }}
+          fi
+          echo "PASSWORD=${PASSWORD}" >> ${GITHUB_OUTPUT}
+
+          echo "SCAN_REPOSITORY=${SCAN_REGISTRY}/redhat-isv-containers/${PROJECT_ID}" >> ${GITHUB_OUTPUT}
 
       - name: Log in to Red Hat Scan Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.SCAN_REGISTRY }}
-          username: ${{ env.SCAN_REGISTRY_USER }}
-          password: ${{ env.SCAN_REGISTRY_PASSWORD }}
+          username: ${{ steps.scan_registry_secrets.outputs.USERNAME }}
+          password: ${{ steps.scan_registry_secrets.outputs.PASSWORD }}
 
       - name: Copy image to RedHat Container Registry
         run: |
@@ -78,7 +97,7 @@ jobs:
               --override-os linux \
               --override-arch amd64 \
               docker://hazelcast/hazelcast-enterprise:${source_tag} \
-              docker://${SCAN_REPOSITORY}:${destination_tag}
+              docker://${{ steps.scan_registry_secrets.outputs.SCAN_REPOSITORY }}:${destination_tag}
           }
 
           TAGS_TO_PUSH=$(get_tags_to_push "${{ inputs.HZ_VERSION }}" "" "${{ matrix.jdk }}" "${{ inputs.DEFAULT_JDK }}" "${{ inputs.IS_LATEST_LTS }}")
@@ -109,9 +128,9 @@ jobs:
         run: |
           source .github/scripts/logging.functions.sh
 
-          PREFLIGHT_OUTPUT=$(preflight check container "${SCAN_REPOSITORY}:${PRIMARY_TAG}" \
+          PREFLIGHT_OUTPUT=$(preflight check container "${{ steps.scan_registry_secrets.outputs.SCAN_REPOSITORY }}:${PRIMARY_TAG}" \
             --submit --pyxis-api-token=${RHEL_API_KEY} \
-            --certification-component-id=${RHEL_PROJECT_ID} \
+            --certification-component-id=${{ steps.scan_registry_secrets.outputs.PROJECT_ID }} \
             --docker-config ~/.docker/config.json \
             2>&1)
 
@@ -129,7 +148,7 @@ jobs:
 
       - name: Publish the Hazelcast Enterprise image
         run: |
-          .github/scripts/publish-rhel.sh "${RHEL_PROJECT_ID}" "${IMAGE_ID}" "${RHEL_API_KEY}" "${TIMEOUT_IN_MINS}"
+          .github/scripts/publish-rhel.sh "${{ steps.scan_registry_secrets.outputs.PROJECT_ID }}" "${IMAGE_ID}" "${RHEL_API_KEY}" "${TIMEOUT_IN_MINS}"
 
       - name: Check RedHat service status
         if: failure()


### PR DESCRIPTION
To support different repository configurations, reconfigure RedHat publish to lookup secrets from an [environment](https://github.com/hazelcast/hazelcast-docker/settings/environments).

Changes:
- Introduce `live` and `sandbox` environments
- Migrate `SCAN_REGISTRY_USER` from being a secret, to simply being a constant as it's always `redhat-isv-containers+${PROJECT-ID}-robot`
- Avoid pushing secrets to `GITHUB_ENV` (which is implicitly accessible to any subsequent step) and instead `GITHUB_OUTPUT` so that references to secrets must be explicit

_In isolation_ this PR makes no behavioural changes - everything still goes to `live` - but lays the groundwork for future changes.

[Example execution](https://github.com/hazelcast/hazelcast-docker/actions/runs/17779933367) pushing to `sandbox` - this [failed to publish](https://hazelcast.atlassian.net/browse/DI-589?focusedCommentId=115014), but the fact that it authorized with a different repository and pushed the image there _instead_ illustrates this change works correctly.

_Partially addresses_: [DI-589](https://hazelcast.atlassian.net/browse/DI-589)

Post-merge actions:
- [ ] remove non-environment secrets:
   - `RHEL_PROJECT_ID_V5`
   - `RHEL_PROJECT_ID_V6`
   - `SCAN_REGISTRY_USER_V5`
   - `SCAN_REGISTRY_USER_V6`
   - `SCAN_REGISTRY_PASSWORD_V5`
   - `SCAN_REGISTRY_PASSWORD_V6`

[DI-589]: https://hazelcast.atlassian.net/browse/DI-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ