### PR TITLE
Normalise OS/EE Dockerfiles

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -7,9 +7,6 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     name: Prepare environment
-    outputs:
-      LAST_RELEASED_HZ_VERSION_OSS: ${{ steps.get_hz_versions.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
-      jdks: ${{ steps.jdks.outputs.jdks }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
@@ -27,16 +24,11 @@ jobs:
         run: |
           .github/scripts/test_scripts.sh
 
-      - name: Get HZ versions
-        id: get_hz_versions
-        uses: hazelcast/docker-actions/get-hz-versions@master
-
   test-push:
     name: Test pushing image (dry run)
-    needs: prepare
     uses: ./.github/workflows/tag_image_push.yml
     with:
-      SOURCE_REF: v${{ needs.prepare.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
+      SOURCE_REF: ${{ github.head_ref }}
       RELEASE_TYPE: ALL
       DRY_RUN: true
     secrets: inherit

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -4,13 +4,15 @@ FROM redhat/ubi9-minimal:9.6
 # Describes the version of the Dockerfile, *not* the version of the bundled Hazelcast binary as this is/can be controlled externally
 # Dockerfile needs some concept of versioning so that the release pipeline can tag/archive with an appropriate label
 ARG HZ_VERSION=5.7.0-SNAPSHOT
-ARG JDK_VERSION="21"
 
 # Build constants
 ARG HZ_HOME="/opt/hazelcast"
 ARG USER_NAME="hazelcast"
+ARG USER_GROUP="hazelcast"
+ARG JDK_VERSION="21"
 # Optional, defaults to latest released version
 ARG HAZELCAST_ZIP_URL=""
+ARG HAZELCAST_ZIP_FILE_NAME="hazelcast-enterprise-distribution.zip"
 
 # Runtime variables
 ENV HZ_HOME="${HZ_HOME}" \
@@ -39,43 +41,42 @@ COPY licenses /licenses
 COPY *.jar hazelcast-*.zip maven.functions.sh ${HZ_HOME}/
 
 # Install
-RUN echo "Installing new packages" \
+RUN echo "Upgrading packages" \
     && microdnf -y update --nodocs \
+    && echo "Installing new packages" \
     && microdnf -y --nodocs --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms \
         --disableplugin=subscription-manager install shadow-utils java-${JDK_VERSION}-openjdk-headless zip tar tzdata-java util-linux \
-    && if [[ ! -f ${HZ_HOME}/hazelcast-enterprise-distribution.zip ]]; then \
+    && if [[ ! -f ${HZ_HOME}/${HAZELCAST_ZIP_FILE_NAME} ]]; then \
         if [ -z ${HAZELCAST_ZIP_URL} ]; then \
             source ${HZ_HOME}/maven.functions.sh; \
             HAZELCAST_ZIP_URL="$(get_latest_url_without_extension com.hazelcast hazelcast-enterprise-distribution https://repository.hazelcast.com/release)".zip; \
         fi; \
         echo "Downloading Hazelcast distribution zip from ${HAZELCAST_ZIP_URL}..."; \
         mkdir --parents ${HZ_HOME}; \
-        curl --fail --silent --show-error --location ${HAZELCAST_ZIP_URL} --output ${HZ_HOME}/hazelcast-enterprise-distribution.zip; \
+        curl --fail --silent --show-error --location ${HAZELCAST_ZIP_URL} --output ${HZ_HOME}/${HAZELCAST_ZIP_FILE_NAME}; \
     else \
-           echo "Using local hazelcast-enterprise-distribution.zip"; \
+           echo "Using local ${HAZELCAST_ZIP_FILE_NAME}"; \
     fi \
-    && unzip -qq ${HZ_HOME}/hazelcast-enterprise-distribution.zip 'hazelcast-*/**' -d ${HZ_HOME}/tmp/ \
+    && unzip -qq ${HZ_HOME}/${HAZELCAST_ZIP_FILE_NAME} 'hazelcast-*/**' -d ${HZ_HOME}/tmp/ \
     && mv ${HZ_HOME}/tmp/*/* ${HZ_HOME}/ \
     && echo "Setting Pardot ID to 'docker'" \
     && echo 'hazelcastDownloadId=docker' > "${HZ_HOME}/lib/hazelcast-download.properties" \
     && echo "Granting read permission to ${HZ_HOME}" \
     && chmod -R +r ${HZ_HOME} \
-    && echo "Removing cached package data and unnecessary tools" \
+    && echo "Removing unnecessary packages and redundant files/folders" \
     && microdnf -y remove zip unzip \
     && microdnf -y clean all \
-    && rm -rf ${HZ_HOME}/maven.functions.sh ${HZ_HOME}/hazelcast-enterprise-distribution.zip maven.functions.sh${HZ_HOME}/tmp \
+    && rm -rf ${HZ_HOME}/maven.functions.sh ${HZ_HOME}/${HAZELCAST_ZIP_FILE_NAME} maven.functions.sh${HZ_HOME}/tmp \
     # Grant execute permission to scripts in order to address the issue of permissions not being accurately propagated on Windows OS
     && chmod +x ${HZ_HOME}/bin/*
 
 COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml ${HZ_HOME}/config/
 
-RUN echo "Adding non-root user" \
-    && groupadd --system hazelcast \
-    && useradd --no-log-init --system --gid hazelcast --create-home ${USER_NAME}
-
 WORKDIR ${HZ_HOME}
 
-### Switch to hazelcast user
+RUN echo "Adding non-root user" \
+    && groupadd --system ${USER_GROUP} \
+    && useradd --no-log-init --system --gid ${USER_GROUP} --create-home ${USER_NAME}
 USER ${USER_NAME}
 
 # Start Hazelcast server

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -6,9 +6,12 @@ ARG HZ_VERSION=5.7.0-SNAPSHOT
 
 # Build constants
 ARG HZ_HOME="/opt/hazelcast"
+ARG USER_NAME="hazelcast"
+ARG USER_GROUP="hazelcast"
 ARG JDK_VERSION="21"
 # Optional, defaults to latest released version
 ARG HAZELCAST_ZIP_URL=""
+ARG HAZELCAST_ZIP_FILE_NAME="hazelcast-distribution.zip"
 
 # Runtime variables
 ENV HZ_HOME="${HZ_HOME}" \
@@ -28,30 +31,30 @@ EXPOSE 5701
 COPY *.jar hazelcast-*.zip maven.functions.sh ${HZ_HOME}/
 
 # Install
-RUN echo "Upgrading APK packages" \
+RUN echo "Upgrading packages" \
     && apk upgrade --no-cache \
-    && echo "Installing new APK packages" \
+    && echo "Installing new packages" \
     && apk add --no-cache openjdk${JDK_VERSION}-jre-headless bash curl libxml2-utils zip unzip \
-    && if [[ ! -f ${HZ_HOME}/hazelcast-distribution.zip ]]; then \
+    && if [[ ! -f ${HZ_HOME}/${HAZELCAST_ZIP_FILE_NAME} ]]; then \
        if [ -z ${HAZELCAST_ZIP_URL} ]; then \
             source ${HZ_HOME}/maven.functions.sh; \
             HAZELCAST_ZIP_URL="$(get_latest_url_without_extension com.hazelcast hazelcast-distribution https://repo.maven.apache.org/maven2)".zip; \
        fi; \
        echo "Downloading Hazelcast distribution zip from ${HAZELCAST_ZIP_URL}..."; \
        mkdir --parents ${HZ_HOME}; \
-       curl --fail --silent --show-error --location ${HAZELCAST_ZIP_URL} --output ${HZ_HOME}/hazelcast-distribution.zip; \
+       curl --fail --silent --show-error --location ${HAZELCAST_ZIP_URL} --output ${HZ_HOME}/${HAZELCAST_ZIP_FILE_NAME}; \
     else \
-           echo "Using local hazelcast-distribution.zip"; \
+           echo "Using local ${HAZELCAST_ZIP_FILE_NAME}"; \
     fi \
-    && unzip -qq ${HZ_HOME}/hazelcast-distribution.zip 'hazelcast-*/**' -d ${HZ_HOME}/tmp/ \
+    && unzip -qq ${HZ_HOME}/${HAZELCAST_ZIP_FILE_NAME} 'hazelcast-*/**' -d ${HZ_HOME}/tmp/ \
     && mv ${HZ_HOME}/tmp/*/* ${HZ_HOME}/ \
     && echo "Setting Pardot ID to 'docker'" \
     && echo 'hazelcastDownloadId=docker' > "${HZ_HOME}/lib/hazelcast-download.properties" \
     && echo "Granting read permission to ${HZ_HOME}" \
     && chmod -R +r ${HZ_HOME} \
-    && echo "Cleaning APK packages and redundant files/folders" \
+    && echo "Removing unnecessary packages and redundant files/folders" \
     && apk del libxml2-utils zip unzip \
-    && rm -rf /var/cache/apk/* ${HZ_HOME}/maven.functions.sh ${HZ_HOME}/hazelcast-distribution.zip ${HZ_HOME}/tmp \
+    && rm -rf /var/cache/apk/* ${HZ_HOME}/maven.functions.sh ${HZ_HOME}/${HAZELCAST_ZIP_FILE_NAME} ${HZ_HOME}/tmp \
     # Grant execute permission to scripts in order to address the issue of permissions not being accurately propagated on Windows OS
     && chmod +x ${HZ_HOME}/bin/*
 
@@ -59,8 +62,10 @@ COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml ${HZ_HOME}/c
 
 WORKDIR ${HZ_HOME}
 
-RUN addgroup -S hazelcast && adduser -S hazelcast -G hazelcast
-USER hazelcast
+RUN echo "Adding non-root user" \
+    && addgroup -S ${USER_GROUP} \
+    && adduser -S ${USER_NAME} -G ${USER_GROUP}
+USER ${USER_NAME}
 
 # Start Hazelcast server
 CMD ["hz", "start"]


### PR DESCRIPTION
The OS & EE Dockerfiles are _very_ similar, but because of the duplication have diverged a little, e.g.:
- EE uses a central `USER_NAME` property, OS duplicates it instead

I've gone through each file side-by-side to make them as equivalent as possible without _actually_ changing anything functional:
- copying additional comments from one file to another
- normalising naming between files
- externalise EE/OS specific names

Note - it would be _nice_ to actually centralise the duplication but this isn't practical:
- we need to support "simply" calling build on the Dockerfile
- Docker requires any included scripts to be in the same directory - hence duplication of `maven.functions.sh`