### PR TITLE
Make `environment` input a dropdown selection

### DIFF
--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -13,7 +13,12 @@ on:
       DEFAULT_JDK:
         required: true
       ENVIRONMENT:
+        description: 'Environment to use'
         required: true
+        type: choice
+        options:
+          - sandbox
+          - live
   workflow_call:
     inputs:
       HZ_VERSION:


### PR DESCRIPTION
In `hazelcast-packaging`, `workflow_dispatch` events use a dropdown option for `environment`: https://github.com/hazelcast/hazelcast-packaging/blob/908f97db39a33c739adf09c3f7cc2dc1e7fc9009/.github/workflows/publish-packages.yml#L27-L35

For consistency, should do the same.