### PR TITLE
Fix NLC `push`

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -32,3 +32,11 @@ jobs:
       RELEASE_TYPE: ALL
       DRY_RUN: true
     secrets: inherit
+
+  test-push-nlc:
+    name: Test pushing image (dry run)
+    uses: ./.github/workflows/ee-nlc-tag-push.yml
+    with:
+      SOURCE_REF: ${{ github.ref }}
+      DRY_RUN: true
+    secrets: inherit

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -17,14 +17,6 @@ on:
       HZ_REVISION:
         description: 'Commit id of Hazelcast snapshot jar'
         required: false
-      ENVIRONMENT:
-        description: 'Environment to use'
-        required: true
-        default: live
-        type: choice
-        options:
-          - sandbox
-          - live
   workflow_call:
     inputs:
       SOURCE_REF:
@@ -39,10 +31,6 @@ on:
       HZ_REVISION:
         description: 'Commit id of Hazelcast snapshot jar'
         required: false
-        type: string
-      ENVIRONMENT:
-        description: 'Environment to use'
-        required: true
         type: string
 
 jobs:
@@ -68,7 +56,7 @@ jobs:
           HZ_VERSION: '${{ steps.get_hz_versions.outputs.HZ_VERSION }}'
 
   push:
-    environment: ${{ inputs.ENVIRONMENT }}
+    environment: live
     runs-on: ubuntu-latest
     needs: prepare
     strategy:
@@ -150,7 +138,7 @@ jobs:
         run: |
           . .github/scripts/docker.functions.sh
 
-          platforms=$(get_ubi_supported_platforms ${{ matrix.jdk }})" >> ${GITHUB_OUTPUT}
+          echo "platforms=$(get_ubi_supported_platforms ${{ matrix.jdk }})" >> ${GITHUB_OUTPUT}
 
       - name: Determine labels
         id: labels


### PR DESCRIPTION
The [NLC push failed](https://github.com/hazelcast/hazelcast-docker/actions/runs/17934065545).

Changes:
- environment should be hardcoded _for now_ until logic to decide introduced
- fixed platform logic updated in https://github.com/hazelcast/hazelcast-docker/pull/1101
- added execution to PR builder to catch these kind of errors in future
