### PR TITLE
Support older images _without_ `HEALTHCHECK` in `simple-smoke-test`

### DIFF
--- a/.github/scripts/abstract-simple-smoke-test.sh
+++ b/.github/scripts/abstract-simple-smoke-test.sh
@@ -44,7 +44,7 @@ function check_metadata() {
 }
 
 function hz_health_check_cmd() {
-  curl_hz_health_check_cmd
+  hz_health_check_cmd_curl
 }
 
 # Default implementation

--- a/.github/scripts/abstract-simple-smoke-test.sh
+++ b/.github/scripts/abstract-simple-smoke-test.sh
@@ -44,6 +44,11 @@ function check_metadata() {
 }
 
 function hz_health_check_cmd() {
+  curl_hz_health_check_cmd
+}
+
+# Default implementation
+function hz_health_check_cmd_curl() {
   curl --silent --fail "127.0.0.1:5701/hazelcast/health/ready"
 }
 

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -59,10 +59,17 @@ function derive_expected_distribution_type() {
   esac
 }
 
+# Reference to super function
+eval "super_$(declare -f hz_health_check_cmd)"
+
 function hz_health_check_cmd() {
-  local status
-  status=$(docker inspect "${container_name}" --format '{{json .State.Health.Status}}' | jq -r)
-  [[ "${status}" == "healthy" ]]
+  # Not all image versions support healthcheck
+  local healthcheck_status
+  if healthcheck_status=$(docker inspect "${container_name}" --format '{{json .State.Health.Status}}' | jq -r); then
+    [[ "${healthcheck_status}" == "healthy" ]]
+  else
+    super_hz_health_check_cmd
+  fi
 }
 
 image=$1

--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -62,13 +62,10 @@ function derive_expected_distribution_type() {
   esac
 }
 
-# Reference to super function
-eval "super_$(declare -f hz_health_check_cmd)"
-
 function hz_health_check_cmd() {
   # Not all image versions support healthcheck
-  if version_less_or_equal ${expected_version} 5.6.99; then
-    super_hz_health_check_cmd
+  if version_less_or_equal "${expected_version}" 5.6.99; then
+    hz_health_check_cmd_curl
   else
     local status
     status=$(docker inspect "${container_name}" --format '{{json .State.Health.Status}}' | jq -r)

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -20,7 +20,7 @@ jobs:
   get-environment:
     runs-on: ubuntu-latest
     outputs:
-      environment: ${{ steps.determine-environment.outputs.determine-environment }}
+      environment: ${{ steps.determine-environment.outputs.environment }}
     steps:
       - id: determine-environment
         run: |


### PR DESCRIPTION
`HEALTHCHECK` was added to _new_ images in https://github.com/hazelcast/hazelcast-docker/pull/1097, but the build of an _older_ image [fails](https://github.com/hazelcast/hazelcast-docker/actions/runs/17964503180/job/51094174530) because `simple-smoke-test` assumes all versions contain it.

Updated to fallback to the previous implementation.

[Example execution (`dry-run`) building a `5.6.z` image](https://github.com/hazelcast/hazelcast-docker/actions/runs/17969165335).