### PR TITLE
Ensure `maven.functions` returns the _latest_ version

### DIFF
--- a/hazelcast-enterprise/maven.functions.sh
+++ b/hazelcast-enterprise/maven.functions.sh
@@ -18,7 +18,7 @@ function get_latest_version() {
   local artifact_id=$2
   local repository_url=$3
 
-  curl --fail --silent --show-error --location "${repository_url}/${group_id//./\/}/${artifact_id}/maven-metadata.xml" | awk -F'<release>|</release>' 'NF>1 {print $2; exit}'
+  curl --fail --silent --show-error --location "${repository_url}/${group_id//./\/}/${artifact_id}/maven-metadata.xml" | awk -F'<latest>|</latest>' 'NF>1 {print $2; exit}'
 }
 
 # Prints a URL to the latest version in the Maven repository, without a file extension

--- a/hazelcast-oss/maven.functions.sh
+++ b/hazelcast-oss/maven.functions.sh
@@ -18,7 +18,7 @@ function get_latest_version() {
   local artifact_id=$2
   local repository_url=$3
 
-  curl --fail --silent --show-error --location "${repository_url}/${group_id//./\/}/${artifact_id}/maven-metadata.xml" | awk -F'<release>|</release>' 'NF>1 {print $2; exit}'
+  curl --fail --silent --show-error --location "${repository_url}/${group_id//./\/}/${artifact_id}/maven-metadata.xml" | awk -F'<latest>|</latest>' 'NF>1 {print $2; exit}'
 }
 
 # Prints a URL to the latest version in the Maven repository, without a file extension


### PR DESCRIPTION
When querying the [Maven metadata](https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise/maven-metadata.xml), the `release` was outdated:
```
<latest>5.5.7</latest>
<release>5.4.3</release>
```

[This was displayed when building a `5.7` image when _no_ Hazelcast distribution (`ZIP` or URL) was specified](https://github.com/hazelcast/hazelcast-docker/actions/runs/18002619054/job/51215340207) - `5.4.3` was downloaded:
```
#24 72.54 Downloading Hazelcast distribution zip from https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-distribution/5.4.3/hazelcast-enterprise-distribution-5.4.3.zip...
```

After further investigation, it _appears_ that Maven sets one value to the most _recently deployed_ version, whereas the repository is setting the other to the _highest_ version. Updated to suit.

This behaviour was only used when no Hazelcast distribution (`ZIP` or URL) was specified - i.e. when building locally. Our "official" images had no issues.

[Slack discussion](https://hazelcast.slack.com/archives/C05LM8B80UT/p1758792652310999)