### PR TITLE
Support passing `environment` into `hazelcast-docker` [DI-498]

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,6 +31,8 @@ jobs:
       SOURCE_REF: ${{ github.ref }}
       RELEASE_TYPE: ALL
       DRY_RUN: true
+      # DI-635 - Should Docker PR builder push to sandbox?
+      ENVIRONMENT: live
     secrets: inherit
 
   test-push-nlc:
@@ -39,4 +41,6 @@ jobs:
     with:
       SOURCE_REF: ${{ github.ref }}
       DRY_RUN: true
+      # DI-635 - Should Docker PR builder push to sandbox?
+      ENVIRONMENT: live
     secrets: inherit

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -20,7 +20,7 @@ jobs:
   get-environment:
     runs-on: ubuntu-latest
     outputs:
-      environment: ${{ steps.determine-environment.outputs.determine-environment }}
+      environment: ${{ steps.determine-environment.outputs.environment }}
     steps:
       - id: determine-environment
         run: |
@@ -105,7 +105,9 @@ jobs:
 
   rebuild-ee:
     name: Rebuild EE images
-    needs: convert-rebuilds-to-matrix
+    needs:
+      - get-environment
+      - convert-rebuilds-to-matrix
     if: ${{ needs.convert-rebuilds-to-matrix.outputs.rebuild-ee-matrix != '[]' }}
     strategy:
       matrix:
@@ -113,11 +115,14 @@ jobs:
     uses: ./.github/workflows/tag_image_push.yml
     with:
       SOURCE_REF: v${{ matrix.version }}
+      ENVIRONMENT: ${{ needs.get-environment.outputs.environment }}
     secrets: inherit
 
   rebuild-nlc:
     name: Rebuild EE NLC images
-    needs: convert-rebuilds-to-matrix
+    needs:
+      - get-environment
+      - convert-rebuilds-to-matrix
     if: ${{ needs.convert-rebuilds-to-matrix.outputs.rebuild-ee-matrix != '[]' }}
     strategy:
       matrix:
@@ -125,6 +130,7 @@ jobs:
     uses: ./.github/workflows/ee-nlc-tag-push.yml
     with:
       SOURCE_REF: v${{ matrix.version }}
+      ENVIRONMENT: ${{ needs.get-environment.outputs.environment }}
     secrets: inherit
 
   failure-notifications:

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -20,15 +20,9 @@ jobs:
   get-environment:
     runs-on: ubuntu-latest
     outputs:
-      environment: ${{ steps.determine-environment.outputs.environment }}
+      environment: ${{ inputs.ENVIRONMENT || 'live' }}
     steps:
-      - id: determine-environment
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "environment=${{ inputs.ENVIRONMENT }}" >> "${GITHUB_OUTPUT}"
-          else
-            echo "environment=live" >> "${GITHUB_OUTPUT}"
-          fi
+      - run: exit 0
 
   get-latest-patch-versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -17,6 +17,13 @@ on:
       HZ_REVISION:
         description: 'Commit id of Hazelcast snapshot jar'
         required: false
+      ENVIRONMENT:
+        description: 'Environment to use'
+        required: true
+        type: choice
+        options:
+          - sandbox
+          - live
   workflow_call:
     inputs:
       SOURCE_REF:
@@ -31,6 +38,10 @@ on:
       HZ_REVISION:
         description: 'Commit id of Hazelcast snapshot jar'
         required: false
+        type: string
+      ENVIRONMENT:
+        description: 'Environment to use'
+        required: true
         type: string
 
 jobs:
@@ -56,7 +67,7 @@ jobs:
           HZ_VERSION: '${{ steps.get_hz_versions.outputs.HZ_VERSION }}'
 
   push:
-    environment: live
+    environment: ${{ inputs.ENVIRONMENT }}
     runs-on: ubuntu-latest
     needs: prepare
     strategy:

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -35,6 +35,13 @@ on:
       HZ_REVISION:
         description: 'Commit id of Hazelcast snapshot jar'
         required: false
+      ENVIRONMENT:
+        description: 'Environment to use'
+        required: true
+        type: choice
+        options:
+          - sandbox
+          - live
   workflow_call:
     inputs:
       SOURCE_REF:
@@ -60,10 +67,14 @@ on:
         description: 'Commit id of Hazelcast snapshot jar'
         required: false
         type: string
+      ENVIRONMENT:
+        description: 'Environment to use'
+        required: true
+        type: string
 
 jobs:
   prepare:
-    environment: live
+    environment: ${{ inputs.ENVIRONMENT }}
     runs-on: ubuntu-latest
     env:
       RELEASE_TYPE: ${{ inputs.RELEASE_TYPE }}
@@ -120,6 +131,7 @@ jobs:
     uses: hazelcast/hazelcast-docker/.github/workflows/get-distribution-variants.yaml@master
 
   push:
+    environment: ${{ inputs.ENVIRONMENT }}
     runs-on: ubuntu-latest
     needs:
       - prepare
@@ -332,7 +344,7 @@ jobs:
     if: inputs.DRY_RUN != 'true' && !contains(needs.prepare.outputs.HZ_VERSION, 'SNAPSHOT')
     uses: ./.github/workflows/update_readme.yml
     with:
-      ENVIRONMENT: live
+      ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
     secrets: inherit
 
   push-rhel:
@@ -347,7 +359,7 @@ jobs:
       JDKS: ${{ needs.prepare.outputs.jdks }} 
       IS_LATEST_LTS: ${{ needs.push.outputs.is_latest_lts }}
       DEFAULT_JDK: ${{ needs.push.outputs.default_jdk }}
-      ENVIRONMENT: live
+      ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
     secrets: inherit
 
   failure-notifications:


### PR DESCRIPTION
Updates the actions to _require_ an `environment` is provided, over using a default hardcoded value.

Post-merge actions:
- [x] update Jenkins builds
- [x] https://github.com/hazelcast/hazelcast-pipeline-library/pull/296

Fixes: [DI-498](https://hazelcast.atlassian.net/browse/DI-498)

[DI-498]: https://hazelcast.atlassian.net/browse/DI-498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ