### PR TITLE
Remove `workflow_dispatch` / `workflow_call` `inputs` duplication with YAML anchors

### DIFF
--- a/.github/workflows/ee-nlc-tag-push.yml
+++ b/.github/workflows/ee-nlc-tag-push.yml
@@ -3,26 +3,22 @@ name: Build EE NLC image
 on:
   workflow_dispatch:
     inputs:
-      SOURCE_REF:
+      SOURCE_REF: &INPUT_SOURCE_REF
         description: 'The hazelcast-docker branch to build the image from'
         required: true
-      HZ_REVISION:
+        type: string
+      HZ_REVISION: &INPUT_HZ_REVISION
         description: 'Commit id of Hazelcast snapshot jar'
         required: false
+        type: string
       ENVIRONMENT:
         description: 'Environment to use'
         required: true
         type: environment
   workflow_call:
     inputs:
-      SOURCE_REF:
-        description: 'The hazelcast-docker branch to build the image from'
-        required: true
-        type: string
-      HZ_REVISION:
-        description: 'Commit id of Hazelcast snapshot jar'
-        required: false
-        type: string
+      SOURCE_REF: *INPUT_SOURCE_REF
+      HZ_REVISION: *INPUT_HZ_REVISION
       ENVIRONMENT:
         description: 'Environment to use'
         required: true

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -3,9 +3,10 @@ name: Build OS and EE image
 on:
   workflow_dispatch:
     inputs:
-      SOURCE_REF:
+      SOURCE_REF: &INPUT_SOURCE_REF
         description: 'The hazelcast-docker branch to build the image from'
         required: true
+        type: string
       RELEASE_TYPE:
         description: 'What should be built'
         required: true
@@ -14,27 +15,22 @@ on:
           - ALL
           - OSS
           - EE
-      HZ_REVISION:
+      HZ_REVISION: &INPUT_HZ_REVISION
         description: 'Commit id of Hazelcast snapshot jar'
         required: false
+        type: string
       ENVIRONMENT:
         description: 'Environment to use'
         required: true
         type: environment
   workflow_call:
     inputs:
-      SOURCE_REF:
-        description: 'The hazelcast-docker branch to build the image from'
-        required: true
-        type: string
+      SOURCE_REF: *INPUT_SOURCE_REF
       RELEASE_TYPE:
         description: 'What should be built'
         required: true
         type: string
-      HZ_REVISION:
-        description: 'Commit id of Hazelcast snapshot jar'
-        required: false
-        type: string
+      HZ_REVISION: *INPUT_HZ_REVISION
       ENVIRONMENT:
         description: 'Environment to use'
         required: true

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -3,40 +3,32 @@ name: Push EE RHEL image
 on:
   workflow_dispatch:
     inputs:
-      HZ_VERSION:
+      HZ_VERSION: &INPUT_HZ_VERSION
         description: 'Version of Hazelcast to build the image for, e.g. 5.1.1, 5.0.1'
         required: true
-      JDKS:
+        type: string
+      JDKS: &INPUT_JDKS
         description: 'Supported JDKs - e.g. `[17, 21]`'
         required: true
-      IS_LATEST_LTS:
+        type: string
+      IS_LATEST_LTS: &INPUT_IS_LATEST_LTS
         description: 'Is Latest LTS? e.g. `false`'
         required: true
-      DEFAULT_JDK:
+        type: string
+      DEFAULT_JDK: &INPUT_DEFAULT_JDK
         description: 'The Java major version (e.g. `21`, `8`) used by default in the image'
         required: true
+        type: string
       ENVIRONMENT:
         description: 'Environment to use'
         required: true
         type: environment
   workflow_call:
     inputs:
-      HZ_VERSION:
-        description: 'Version of Hazelcast to build the image for, e.g. 5.1.1, 5.0.1'
-        required: true
-        type: string
-      JDKS:
-        description: 'Supported JDKs - e.g. `[17, 21]`'
-        required: true
-        type: string
-      IS_LATEST_LTS:
-        description: 'Is Latest LTS? e.g. `false`'
-        required: true
-        type: string
-      DEFAULT_JDK:
-        description: 'The Java major version (e.g. `21`, `8`) used by default in the image'
-        required: true
-        type: string
+      HZ_VERSION: *INPUT_HZ_VERSION
+      JDKS: *INPUT_JDKS
+      IS_LATEST_LTS: *INPUT_IS_LATEST_LTS
+      DEFAULT_JDK: *INPUT_DEFAULT_JDK
       ENVIRONMENT:
         description: 'Environment to use'
         required: true

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -2,7 +2,7 @@ name: Vulnerability Scan
 
 on:
   workflow_call:
-    inputs:
+    inputs: &INPUTS
       ref:
         required: true
         type: string
@@ -10,10 +10,7 @@ on:
       SNYK_TOKEN:
         required: true
   workflow_dispatch:
-    inputs:
-      ref:
-        required: true
-        type: string
+    inputs: *INPUTS
 
 jobs:
   scan:


### PR DESCRIPTION
Using ([newly supported](https://github.blog/changelog/2025-09-18-actions-yaml-anchors-and-non-public-workflow-templates/)) [YAML anchors](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#yaml-anchors-and-aliases) we can avoid duplicating inputs between `workflow_dispatch` and `workflow_call` triggers - when the inputs are identical.

This isn't _always_ possible as they support different types (e.g. [`workflow_dispatch` supports `choice`](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_dispatchinputsinput_idtype), [`workflow_call` does not](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_callinputsinput_idtype)).