### PR TITLE
Make docker images fully reproducible

### DIFF
--- a/.github/workflows/tag_image_package.yml
+++ b/.github/workflows/tag_image_package.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Get supported platforms
         id: platforms
-        uses: hazelcast/docker-actions/get-supported-platforms@master
+        uses: hazelcast/docker-actions/get-supported-platforms@no-s390x-in-os
         with:
           dockerfile: ${{ matrix.distribution-type.docker-dir }}/Dockerfile
           jdk: ${{ matrix.jdk }}

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -41,7 +41,7 @@ COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml /build_root$
 # Normalize timestamps for reproducible layer
 RUN find /build_root -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
 
-FROM redhat/ubi9-minimal:9.7
+FROM eclipse-temurin:${JDK_VERSION}-jre-ubi9-minimal
 
 ARG HZ_VERSION
 ARG HZ_HOME
@@ -78,24 +78,19 @@ COPY licenses /licenses
 COPY --link --from=get-distribution /build_root/ /
 
 # Install
-RUN echo "Upgrading packages" \
+RUN touch /tmp/.timestamp-marker && sleep 1 \
+    && echo "Adding non-root user" \
+    && groupadd --system ${USER_GROUP} \
+    && useradd --no-log-init --system --gid ${USER_GROUP} --create-home ${USER_NAME} \
+    && echo "Upgrading packages" \
     && microdnf -y update --nodocs \
-    && echo "Installing new packages" \
-    && microdnf -y --nodocs --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms \
-        --disableplugin=subscription-manager install \
-        java-${JDK_VERSION}-openjdk-headless \
-        shadow-utils \
-        tar \
-        tzdata-java \
-        util-linux \
     && echo "Removing unnecessary packages and redundant files/folders" \
-    && microdnf -y clean all
+    && microdnf -y clean all \
+    && find / -depth -newer /tmp/.timestamp-marker -xdev \
+            -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} + 2>/dev/null; rm -f /tmp/.timestamp-marker; touch -d "@$SOURCE_DATE_EPOCH" /tmp
 
 WORKDIR ${HZ_HOME}
 
-RUN echo "Adding non-root user" \
-    && groupadd --system ${USER_GROUP} \
-    && useradd --no-log-init --system --gid ${USER_GROUP} --create-home ${USER_NAME}
 USER ${USER_NAME}
 
 HEALTHCHECK CMD ["hz-healthcheck"]

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -8,32 +8,38 @@ ARG HZ_HOME="/opt/hazelcast"
 ARG USER_NAME="hazelcast"
 ARG USER_GROUP="hazelcast"
 ARG JDK_VERSION="21"
+ARG SOURCE_DATE_EPOCH=1688223600
 
 FROM alpine:3 AS get-distribution
 
 ARG HZ_HOME
+ARG SOURCE_DATE_EPOCH
 ARG HAZELCAST_ZIP_FILE_NAME="hazelcast-enterprise-distribution.zip"
 
 # Expects distribution ZIP to be on the local filesystem within the build context
 COPY ${HAZELCAST_ZIP_FILE_NAME} /tmp/
 
-RUN mkdir -p ${HZ_HOME} \
+ENV SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH
+
+RUN mkdir -p /build_root${HZ_HOME} \
     && apk add --no-cache unzip \
     && unzip -qq /tmp/${HAZELCAST_ZIP_FILE_NAME} -d /tmp/hz \
     # Distribution ZIP structure is a single folder (e.g. "hazelcast-5.4.0-slim") containing the content
     # Move all the content up a level so that the path contains no version and is constant
-    && mv /tmp/hz/*/* ${HZ_HOME}/ \
+    && mv /tmp/hz/*/* /build_root${HZ_HOME}/ \
     && apk del unzip \
     && rm -rf /tmp/* \
     && echo "Setting Pardot ID to 'docker'" \
-    && echo 'hazelcastDownloadId=docker' > "${HZ_HOME}/lib/hazelcast-download.properties" \
-    && echo "Granting read permission to ${HZ_HOME}" \
-    && chmod -R +r ${HZ_HOME} \
+    && echo 'hazelcastDownloadId=docker' > "/build_root${HZ_HOME}/lib/hazelcast-download.properties" \
+    && echo "Granting read permission to /build_root${HZ_HOME}" \
+    && chmod -R +r /build_root${HZ_HOME} \
     && echo "Grant execute permission to scripts in order to address the issue of permissions not being accurately propagated on Windows OS" \
-    && chmod +x ${HZ_HOME}/bin/*
+    && chmod +x /build_root${HZ_HOME}/bin/*
 
-COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml ${HZ_HOME}/config/
+COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml /build_root${HZ_HOME}/config/
 
+# Normalize timestamps for reproducible layer
+RUN find /build_root -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
 
 FROM redhat/ubi9-minimal:9.7
 
@@ -42,6 +48,7 @@ ARG HZ_HOME
 ARG USER_NAME
 ARG USER_GROUP
 ARG JDK_VERSION
+ARG SOURCE_DATE_EPOCH
 
 # Runtime variables
 ENV HZ_HOME="${HZ_HOME}" \
@@ -53,7 +60,8 @@ ENV HZ_HOME="${HZ_HOME}" \
     JAVA_OPTS="" \
     HAZELCAST_CONFIG=config/hazelcast-docker.xml \
     LANG=C.UTF-8 \
-    PATH=${HZ_HOME}/bin:$PATH
+    PATH=${HZ_HOME}/bin:$PATH \
+    SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH
 
 LABEL name="Hazelcast Enterprise" \
       maintainer="info@hazelcast.com" \
@@ -67,7 +75,7 @@ LABEL name="Hazelcast Enterprise" \
 EXPOSE 5701
 
 COPY licenses /licenses
-COPY --from=get-distribution ${HZ_HOME} ${HZ_HOME}/
+COPY --link --from=get-distribution /build_root/ /
 
 # Install
 RUN echo "Upgrading packages" \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -10,14 +10,18 @@ ARG HZ_HOME="/opt/hazelcast"
 ARG USER_NAME="hazelcast"
 ARG USER_GROUP="hazelcast"
 ARG JDK_VERSION="21"
+ARG SOURCE_DATE_EPOCH=1688223600
 
 FROM alpine:3 AS get-distribution
 
 ARG HZ_HOME
+ARG SOURCE_DATE_EPOCH
 ARG HAZELCAST_ZIP_FILE_NAME="hazelcast-distribution.zip"
 
 # Expects distribution ZIP to be on the local filesystem within the build context
 COPY ${HAZELCAST_ZIP_FILE_NAME} /tmp/
+
+ENV SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH
 
 RUN mkdir -p /build_root${HZ_HOME} \
     && apk add --no-cache unzip \
@@ -37,13 +41,14 @@ RUN mkdir -p /build_root${HZ_HOME} \
 COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml /build_root${HZ_HOME}/config/
 
 # Normalize timestamps for reproducible layer
-RUN find /build_root -exec touch -h -t 202307011700.00 {} +
+RUN find /build_root -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
 
 FROM eclipse-temurin:${JDK_VERSION}-jre-alpine
 
 ARG HZ_HOME
 ARG USER_NAME
 ARG USER_GROUP
+ARG SOURCE_DATE_EPOCH
 
 # Runtime variables
 ENV HZ_HOME="${HZ_HOME}" \
@@ -55,28 +60,31 @@ ENV HZ_HOME="${HZ_HOME}" \
     JAVA_OPTS="" \
     HAZELCAST_CONFIG=config/hazelcast-docker.xml \
     LANG=C.UTF-8 \
-    PATH=${HZ_HOME}/bin:$PATH
+    PATH=${HZ_HOME}/bin:$PATH \
+    SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH
 
 # Expose port
 EXPOSE 5701
 
 COPY --link --from=get-distribution /build_root/ /
 
-# Install
-RUN echo "Upgrading packages" \
-    && apk upgrade --no-cache \
+RUN touch /tmp/.timestamp-marker && sleep 1 \
+    && echo "Adding non-root user" \
+    && addgroup -S ${USER_GROUP} \
+    && adduser -S ${USER_NAME} -G ${USER_GROUP} \
+    && echo "Upgrading packages" \
+    && apk upgrade --no-cache --no-logfile \
     && echo "Installing new packages" \
-    && apk add --no-cache \
+    && apk add --no-cache --no-logfile \
         bash \
         curl \
     && echo "Removing unnecessary packages and redundant files/folders" \
-    && rm -rf /var/cache/apk/* 
+    && rm -rf /var/cache/apk/* \
+    && find / -newer /tmp/.timestamp-marker -xdev \
+            -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} + 2>/dev/null; rm -f /tmp/.timestamp-marker; touch -d "@$SOURCE_DATE_EPOCH" /tmp
 
 WORKDIR ${HZ_HOME}
 
-RUN echo "Adding non-root user" \
-    && addgroup -S ${USER_GROUP} \
-    && adduser -S ${USER_NAME} -G ${USER_GROUP}
 USER ${USER_NAME}
 
 HEALTHCHECK CMD ["hz-healthcheck"]

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -77,7 +77,6 @@ RUN touch /tmp/.timestamp-marker && sleep 1 \
     && echo "Installing new packages" \
     && apk add --no-cache --no-logfile \
         bash \
-        curl \
     && echo "Removing unnecessary packages and redundant files/folders" \
     && rm -rf /var/cache/apk/* \
     && find / -newer /tmp/.timestamp-marker -xdev \

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -39,12 +39,11 @@ COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml /build_root$
 # Normalize timestamps for reproducible layer
 RUN find /build_root -exec touch -h -t 202307011700.00 {} +
 
-FROM alpine:3
+FROM eclipse-temurin:${JDK_VERSION}-jre-alpine
 
 ARG HZ_HOME
 ARG USER_NAME
 ARG USER_GROUP
-ARG JDK_VERSION
 
 # Runtime variables
 ENV HZ_HOME="${HZ_HOME}" \
@@ -70,7 +69,6 @@ RUN echo "Upgrading packages" \
     && apk add --no-cache \
         bash \
         curl \
-        openjdk${JDK_VERSION}-jre-headless \
     && echo "Removing unnecessary packages and redundant files/folders" \
     && rm -rf /var/cache/apk/* 
 

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # Used for image metadata only
 # Describes the version of the Dockerfile, *not* the version of the bundled Hazelcast binary as this is/can be controlled externally
 # Dockerfile needs some concept of versioning so that the release pipeline can tag/archive with an appropriate label
@@ -17,23 +19,25 @@ ARG HAZELCAST_ZIP_FILE_NAME="hazelcast-distribution.zip"
 # Expects distribution ZIP to be on the local filesystem within the build context
 COPY ${HAZELCAST_ZIP_FILE_NAME} /tmp/
 
-RUN mkdir -p ${HZ_HOME} \
+RUN mkdir -p /build_root${HZ_HOME} \
     && apk add --no-cache unzip \
     && unzip -qq /tmp/${HAZELCAST_ZIP_FILE_NAME} -d /tmp/hz \
     # Distribution ZIP structure is a single folder (e.g. "hazelcast-5.4.0-slim") containing the content
     # Move all the content up a level so that the path contains no version and is constant
-    && mv /tmp/hz/*/* ${HZ_HOME}/ \
+    && mv /tmp/hz/*/* /build_root${HZ_HOME}/ \
     && apk del unzip \
     && rm -rf /tmp/* \
     && echo "Setting Pardot ID to 'docker'" \
-    && echo 'hazelcastDownloadId=docker' > "${HZ_HOME}/lib/hazelcast-download.properties" \
-    && echo "Granting read permission to ${HZ_HOME}" \
-    && chmod -R +r ${HZ_HOME} \
+    && echo 'hazelcastDownloadId=docker' > "/build_root${HZ_HOME}/lib/hazelcast-download.properties" \
+    && echo "Granting read permission to /build_root${HZ_HOME}" \
+    && chmod -R +r /build_root${HZ_HOME} \
     && echo "Grant execute permission to scripts in order to address the issue of permissions not being accurately propagated on Windows OS" \
-    && chmod +x ${HZ_HOME}/bin/*
+    && chmod +x /build_root${HZ_HOME}/bin/*
 
-COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml ${HZ_HOME}/config/
+COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml /build_root${HZ_HOME}/config/
 
+# Normalize timestamps for reproducible layer
+RUN find /build_root -exec touch -h -t 202307011700.00 {} +
 
 FROM alpine:3
 
@@ -57,7 +61,7 @@ ENV HZ_HOME="${HZ_HOME}" \
 # Expose port
 EXPOSE 5701
 
-COPY --from=get-distribution ${HZ_HOME} ${HZ_HOME}/
+COPY --link --from=get-distribution /build_root/ /
 
 # Install
 RUN echo "Upgrading packages" \


### PR DESCRIPTION
- Make all layers in both OSS and Enterprise Dockerfiles produce identical hashes across clean  builds
- Migrate to `eclipse-temurin` base images (Alpine for OSS, UBI9-minimal for EE), removing explicit JDK/package installs                                                                                                                                                                                                                                                                                               
- Normalize timestamps via `SOURCE_DATE_EPOCH` and `find -depth -newer` marker pattern                                                                                                                                                                                                                                                                                                                                 
