### PR TITLE
Bundle SBOM for Enterprise image [DI-745]

### DIFF
--- a/.github/workflows/tag_image_package.yml
+++ b/.github/workflows/tag_image_package.yml
@@ -104,6 +104,29 @@ jobs:
           packaging: "zip"
           output_file: "source_path/${{ matrix.distribution-type.docker-dir }}/${{ matrix.distribution-type.distribution }}-distribution.zip"
 
+      - name: Determine if SBOM applicable
+        uses: madhead/semver-utils@latest
+        id: sbom-applicable
+        if: matrix.distribution-type.label == 'ee'
+        with:
+          version: ${{ needs.prepare.outputs.hz-version }}
+          # The first version that SBOMs were introduced
+          # Needs to be a SNAPSHOT as the action is smart enough to tell the difference
+          compare-to: 5.7.0-SNAPSHOT
+
+      - name: Download the SBOM
+        uses: hazelcast/docker-actions/download-hz-dist@master
+        if: steps.sbom-applicable.outputs.comparison-result == '=' || steps.sbom-applicable.outputs.comparison-result == '>' 
+        id: download-hz-sbom
+        with:
+          repo-vars-as-json: ${{ toJSON(vars) }}
+          aws-role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          distribution: ${{ matrix.distribution-type.distribution }}
+          hz_version: ${{ needs.prepare.outputs.hz-version }}
+          classifier: cyclonedx
+          packaging: "json"
+          output_file: "source_path/${{ matrix.distribution-type.docker-dir }}/hazelcast-sbom.json"
+
       - id: get-tags-to-push
         uses: ./.github/actions/get-tags-to-push
         with:
@@ -128,6 +151,7 @@ jobs:
           context: source_path/${{ matrix.distribution-type.docker-dir }}
           labels: ${{ steps.labels.outputs.label }}
           platforms: ${{ steps.platforms.outputs.platforms }}
+          sbom: ${{ steps.download-hz-sbom.outcome == 'success' }}
           push: true
           tags: ${{ env.LOCAL_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
           build-args: |

--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -32,6 +32,8 @@ RUN mkdir -p ${HZ_HOME} \
     && echo "Grant execute permission to scripts in order to address the issue of permissions not being accurately propagated on Windows OS" \
     && chmod +x ${HZ_HOME}/bin/*
 
+# Include SBOM if present
+COPY *-sbom.json ${HZ_HOME}/spdx
 COPY log4j2.properties log4j2-json.properties jmx_agent_config.yaml ${HZ_HOME}/config/
 
 


### PR DESCRIPTION
Requires https://github.com/hazelcast/hazelcast-mono/pull/6061

Bundles the SBOM generated from the deployed artifacts (download via Maven), along with the SBOM generated via Docker for the system state (e.g. installed packages etc).
This bundling is required as in isolation, Docker cannot reliably determine the packages used in the artifact.

Until SBOM deployed upstream, tested with a hardcoded SBOM and then checking resultant image:
```
% docker buildx imagetools inspect sandbox-hazelcast-enterprise:5.7.0-SNAPSHOT-slim-jdk17 --format "{{ json .SBOM }}"
{
  "linux/amd64": {
    "SPDX": {
      "SPDXID": "SPDXRef-DOCUMENT",
      "creationInfo": {
        "created": "2026-02-25T19:37:28Z",
{...}
            {
              "referenceCategory": "PACKAGE-MANAGER",
              "referenceLocator": "pkg:maven/com.google.code.gson/gson@2.12.1",
              "referenceType": "purl"
            }
{...}
```

Fixes: [DI-745](https://hazelcast.atlassian.net/browse/DI-745)

[DI-745]: https://hazelcast.atlassian.net/browse/DI-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ