### PR TITLE
Add `skopeo` retries to workaround transient network issues

### DIFF
--- a/.github/workflows/ee-nlc-tag-package.yml
+++ b/.github/workflows/ee-nlc-tag-package.yml
@@ -187,6 +187,7 @@ jobs:
           # Skopeo expects HTTPS registry but local is HTTP
           skopeo copy \
             --all \
+            --retry-times 3 \
             --src-tls-verify=false \
             docker://${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
             docker://${NLC_IMAGE_REGISTRY_URL}/${{ vars.NLC_NAMESPACE }}/${NLC_IMAGE_NAME}-${{ vars.PREPROD_REGISTRY }}:${{ steps.get-tags-to-push.outputs.primary-tag }}

--- a/.github/workflows/ee-nlc-tag-promote.yml
+++ b/.github/workflows/ee-nlc-tag-promote.yml
@@ -90,6 +90,7 @@ jobs:
           do
             skopeo copy \
               --all \
+              --retry-times 3 \
               docker://${NLC_IMAGE_REGISTRY_URL}/${{ vars.NLC_NAMESPACE }}/${NLC_IMAGE_NAME}-${{ vars.PREPROD_REGISTRY }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
               docker://${NLC_IMAGE_REGISTRY_URL}/${{ vars.NLC_NAMESPACE }}/${NLC_IMAGE_NAME}:${tag}
           done

--- a/.github/workflows/tag_image_package.yml
+++ b/.github/workflows/tag_image_package.yml
@@ -182,6 +182,7 @@ jobs:
           # Skopeo expects HTTPS registry but local is HTTP
           skopeo copy \
             --all \
+            --retry-times 3 \
             --src-tls-verify=false \
             docker://${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
             docker://${{ vars.DOCKERHUB_NAMESPACE }}/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }}

--- a/.github/workflows/tag_image_promote_docker_registry.yml
+++ b/.github/workflows/tag_image_promote_docker_registry.yml
@@ -110,6 +110,7 @@ jobs:
           do
             skopeo copy \
               --all \
+              --retry-times 3 \
               docker://${{ vars.DOCKERHUB_NAMESPACE }}/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
               docker://${remote_registry}/${{ matrix.distribution-type.image-name }}:${tag}
           done

--- a/.github/workflows/tag_image_promote_rhel.yml
+++ b/.github/workflows/tag_image_promote_rhel.yml
@@ -165,6 +165,7 @@ jobs:
         run: |
           # Deliberately only copy a single architecture - https://github.com/hazelcast/hazelcast-docker/pull/1042#issuecomment-3141395993
           skopeo copy \
+            --retry-times 3 \
             --override-os "${PLATFORM_OS}" \
             --override-arch "${PLATFORM_ARCH}" \
             docker://${{ vars.DOCKERHUB_NAMESPACE }}/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
@@ -227,6 +228,7 @@ jobs:
           do
             echo "Copying tag: ${FULL_PRIMARY_TAG} -> ${tag}"
             skopeo copy \
+              --retry-times 3 \
               --override-os "${PLATFORM_OS}" \
               --override-arch "${PLATFORM_ARCH}" \
               docker://${FULL_PRIMARY_TAG} \


### PR DESCRIPTION
The builds can fail due to transient network issues ([example](https://github.com/hazelcast/hazelcast-docker/actions/runs/25142812174/job/73696834059)) but work fine after re-runs.

By default, [Skopeo does not retry in case of failures](https://github.com/containers/skopeo/blob/main/docs/skopeo-copy.1.md) - as network reliability is not guaranteed, it seems safer to retry before declaring failure.