### PR TITLE
Remove redundant `env` in `tag_image_promote_rhel`

### DIFF
--- a/.github/workflows/tag_image_promote_rhel.yml
+++ b/.github/workflows/tag_image_promote_rhel.yml
@@ -73,7 +73,6 @@ jobs:
           # Some repositories have a separate projects for each (major) version
           # First see if a version-specific secret exists, falling back to default
           RHEL_PROJECT_ID: ${{ secrets[format('RHEL_PROJECT_ID_V{0}', steps.version.outputs.major)] || secrets.RHEL_PROJECT_ID }}
-          SCAN_REPOSITORY: ${{ secrets[format('SCAN_REPOSITORY_V{0}', steps.version.outputs.major)] || secrets.SCAN_REPOSITORY }}
         run: |
           echo "PROJECT_ID=${RHEL_PROJECT_ID}" >> ${GITHUB_OUTPUT}
           echo "SCAN_REPOSITORY=${SCAN_REPOSITORY}${SCAN_REGISTRY}/redhat-isv-containers/${RHEL_PROJECT_ID}" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/tag_image_promote_rhel.yml
+++ b/.github/workflows/tag_image_promote_rhel.yml
@@ -75,7 +75,7 @@ jobs:
           RHEL_PROJECT_ID: ${{ secrets[format('RHEL_PROJECT_ID_V{0}', steps.version.outputs.major)] || secrets.RHEL_PROJECT_ID }}
         run: |
           echo "PROJECT_ID=${RHEL_PROJECT_ID}" >> ${GITHUB_OUTPUT}
-          echo "SCAN_REPOSITORY=${SCAN_REPOSITORY}${SCAN_REGISTRY}/redhat-isv-containers/${RHEL_PROJECT_ID}" >> ${GITHUB_OUTPUT}
+          echo "SCAN_REPOSITORY=${SCAN_REGISTRY}/redhat-isv-containers/${RHEL_PROJECT_ID}" >> ${GITHUB_OUTPUT}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
`SCAN_REPOSITORY` was introduced in https://github.com/hazelcast/hazelcast-docker/pull/1207 in error - the `SCAN_REPOSITORY` secret hasn't existed for a long time.

It evaluates to empty string, which is why it's caused no issues. But it should simply be removed.

[See the recent job logs to show that it's not actually _in_ the resultant command](https://github.com/hazelcast/hazelcast-docker/actions/runs/25800866922/job/75790278368#step:12:8).