### PR TITLE
Inline repo vars

### DIFF
--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -69,7 +69,7 @@ jobs:
         uses: hazelcast/docker-actions/check-base-images@master
         with:
           ref: v${{ matrix.version }}
-          image-name: ${{ vars.DOCKERHUB_NAMESPACE }}/${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ matrix.version }}-slim
+          image-name: hazelcast/${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ matrix.version }}-slim
           dockerfile-path: "hazelcast-enterprise/Dockerfile"
 
       - name: Check if ${{ matrix.version }} base images updated

--- a/.github/workflows/ee-nlc-tag-package.yml
+++ b/.github/workflows/ee-nlc-tag-package.yml
@@ -190,7 +190,7 @@ jobs:
             --retry-times 3 \
             --src-tls-verify=false \
             docker://${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
-            docker://${NLC_IMAGE_REGISTRY_URL}/${{ vars.NLC_NAMESPACE }}/${NLC_IMAGE_NAME}-${{ vars.PREPROD_REGISTRY }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
+            docker://${NLC_IMAGE_REGISTRY_URL}/hazelcast_cloud/${NLC_IMAGE_NAME}-${{ vars.PREPROD_REGISTRY }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
         env:
           NLC_IMAGE_NAME: ${{ secrets.NLC_IMAGE_NAME }}
 

--- a/.github/workflows/ee-nlc-tag-promote.yml
+++ b/.github/workflows/ee-nlc-tag-promote.yml
@@ -91,8 +91,8 @@ jobs:
             skopeo copy \
               --all \
               --retry-times 3 \
-              docker://${NLC_IMAGE_REGISTRY_URL}/${{ vars.NLC_NAMESPACE }}/${NLC_IMAGE_NAME}-${{ vars.PREPROD_REGISTRY }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
-              docker://${NLC_IMAGE_REGISTRY_URL}/${{ vars.NLC_NAMESPACE }}/${NLC_IMAGE_NAME}:${tag}
+              docker://${NLC_IMAGE_REGISTRY_URL}/hazelcast_cloud/${NLC_IMAGE_NAME}-${{ vars.PREPROD_REGISTRY }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
+              docker://${NLC_IMAGE_REGISTRY_URL}/hazelcast_cloud/${NLC_IMAGE_NAME}:${tag}
           done
         env:
           TAGS_TO_PUSH: ${{ steps.get-tags-to-push.outputs.all-destination-tags }}

--- a/.github/workflows/tag_image_package.yml
+++ b/.github/workflows/tag_image_package.yml
@@ -185,7 +185,7 @@ jobs:
             --retry-times 3 \
             --src-tls-verify=false \
             docker://${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
-            docker://${{ vars.DOCKERHUB_NAMESPACE }}/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
+            docker://hazelcast/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
 
   failure-notifications:
     name: Failure notification

--- a/.github/workflows/tag_image_promote_docker_registry.yml
+++ b/.github/workflows/tag_image_promote_docker_registry.yml
@@ -103,7 +103,7 @@ jobs:
           if [[ "${{ matrix.distribution-type.label }}" == "oss" && "${HZ_VERSION}" =~ SNAPSHOT ]]; then
             remote_registry=${{ steps.authenticate-jfrog-write-dev-account.outputs.url }}/docker/hazelcast
           else
-            remote_registry=${{ vars.DOCKERHUB_NAMESPACE }}
+            remote_registry=hazelcast
           fi
 
           for tag in ${TAGS_TO_PUSH}
@@ -111,7 +111,7 @@ jobs:
             skopeo copy \
               --all \
               --retry-times 3 \
-              docker://${{ vars.DOCKERHUB_NAMESPACE }}/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
+              docker://hazelcast/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
               docker://${remote_registry}/${{ matrix.distribution-type.image-name }}:${tag}
           done
         env:

--- a/.github/workflows/tag_image_promote_rhel.yml
+++ b/.github/workflows/tag_image_promote_rhel.yml
@@ -120,7 +120,7 @@ jobs:
         # To work around this RedHat quirk we need to skip these steps for republish
         id: image-already-published
         env:
-          FULL_PRIMARY_TAG: ${{ vars.DOCKERHUB_NAMESPACE }}/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
+          FULL_PRIMARY_TAG: hazelcast/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
         run: |
           source .github/scripts/logging.functions.sh
           source .github/scripts/rhel.functions.sh
@@ -168,7 +168,7 @@ jobs:
             --retry-times 3 \
             --override-os "${PLATFORM_OS}" \
             --override-arch "${PLATFORM_ARCH}" \
-            docker://${{ vars.DOCKERHUB_NAMESPACE }}/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
+            docker://hazelcast/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
             docker://${{ steps.scan_registry_secrets.outputs.SCAN_REPOSITORY }}:${{ steps.unique-destination-tag.outputs.tag }}
 
       - name: Install `preflight` OpenShift tool from GitHub
@@ -236,7 +236,7 @@ jobs:
           done
         env:
           TAGS_TO_PUSH: ${{ steps.get-tags-to-push.outputs.all-destination-tags }}
-          FULL_PRIMARY_TAG: ${{ vars.DOCKERHUB_NAMESPACE }}/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
+          FULL_PRIMARY_TAG: hazelcast/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
 
       - name: Check tags published
         # Just because the tag has been pushed to the registry, does not guarantee it's accessible

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -200,7 +200,7 @@ jobs:
           fi
 
           echo "Testing Docker registry"
-          simple-smoke-test "${{ vars.DOCKERHUB_NAMESPACE }}" "${image_name}"
+          simple-smoke-test "hazelcast" "${image_name}"
 
           # Check additional EE repos
           # Only populated for default variant, not "slim"
@@ -209,7 +209,7 @@ jobs:
             # Identify absolute version based on earlier parsing of version number
             if [[ -n "${{ steps.image-version.outputs.major }}" ]]; then
               echo "Testing NLC"
-              simple-smoke-test "${NLC_IMAGE_REGISTRY_URL}/${{ vars.NLC_NAMESPACE }}" "${{ secrets.NLC_IMAGE_NAME }}"
+              simple-smoke-test "${NLC_IMAGE_REGISTRY_URL}/hazelcast_cloud" "${{ secrets.NLC_IMAGE_NAME }}"
             fi
 
             echo "Testing Red Hat Catalog"

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           .github/scripts/generate-docker-hub-description.sh
         env:
-          NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
+          NAMESPACE: hazelcast
           OSS_IMAGE_NAME: ${{ vars.DOCKERHUB_OSS_IMAGE_NAME }}
           EE_IMAGE_NAME: ${{ vars.DOCKERHUB_EE_IMAGE_NAME }}
           USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
We have externalised some config to repo `vars` to support sandbox, but sandbox uses the same values so redundant.

Inlining means it does not need to be kept in sync between repos.

Post-mege actions:
- [x] remove from repo config.