### PR TITLE
Replace `secrets` with `vars` [DI-814]

### DIFF
--- a/.github/workflows/ee-nlc-tag-package.yml
+++ b/.github/workflows/ee-nlc-tag-package.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         jdk: ${{ fromJSON(needs.prepare.outputs.jdks) }}
     env:
-      LOCAL_IMAGE_NAME: localhost:5000/${{ secrets.NLC_IMAGE_NAME }}
+      LOCAL_IMAGE_NAME: localhost:5000/${{ vars.NLC_IMAGE_NAME }}
       DOCKER_DIR: hazelcast-enterprise
       TEST_CONTAINER_NAME: hazelcast-test
     services:
@@ -90,7 +90,7 @@ jobs:
 
           echo "output_file=${OUTPUT_FILE}" >> "${GITHUB_OUTPUT}"
         env:
-          S3_NLC_URL: ${{ secrets.S3_NLC_URL }}
+          S3_NLC_URL: ${{ vars.S3_NLC_URL }}
 
       - id: get-tags-to-push
         uses: ./.github/actions/get-tags-to-push-nlc
@@ -192,7 +192,7 @@ jobs:
             docker://${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
             docker://${NLC_IMAGE_REGISTRY_URL}/${{ vars.NLC_NAMESPACE }}/${NLC_IMAGE_NAME}-${{ vars.PREPROD_REGISTRY }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
         env:
-          NLC_IMAGE_NAME: ${{ secrets.NLC_IMAGE_NAME }}
+          NLC_IMAGE_NAME: ${{ vars.NLC_IMAGE_NAME }}
 
   failure-notifications:
     name: Failure notification

--- a/.github/workflows/ee-nlc-tag-promote.yml
+++ b/.github/workflows/ee-nlc-tag-promote.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         jdk: ${{ fromJSON(needs.prepare.outputs.jdks) }}
     env:
-      LOCAL_IMAGE_NAME: localhost:5000/${{ secrets.NLC_IMAGE_NAME }}
+      LOCAL_IMAGE_NAME: localhost:5000/${{ vars.NLC_IMAGE_NAME }}
     services:
       registry:
         image: registry:latest
@@ -96,7 +96,7 @@ jobs:
           done
         env:
           TAGS_TO_PUSH: ${{ steps.get-tags-to-push.outputs.all-destination-tags }}
-          NLC_IMAGE_NAME: ${{ secrets.NLC_IMAGE_NAME }}
+          NLC_IMAGE_NAME: ${{ vars.NLC_IMAGE_NAME }}
 
       - name: Check RedHat service status
         if: failure()

--- a/.github/workflows/tag_image_promote_rhel.yml
+++ b/.github/workflows/tag_image_promote_rhel.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           # Some repositories have a separate projects for each (major) version
           # First see if a version-specific secret exists, falling back to default
-          RHEL_PROJECT_ID: ${{ secrets[format('RHEL_PROJECT_ID_V{0}', steps.version.outputs.major)] || secrets.RHEL_PROJECT_ID }}
+          RHEL_PROJECT_ID: ${{ vars[format('RHEL_PROJECT_ID_V{0}', steps.version.outputs.major)] || vars.RHEL_PROJECT_ID }}
           SCAN_REPOSITORY: ${{ secrets[format('SCAN_REPOSITORY_V{0}', steps.version.outputs.major)] || secrets.SCAN_REPOSITORY }}
         run: |
           echo "PROJECT_ID=${RHEL_PROJECT_ID}" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -209,7 +209,7 @@ jobs:
             # Identify absolute version based on earlier parsing of version number
             if [[ -n "${{ steps.image-version.outputs.major }}" ]]; then
               echo "Testing NLC"
-              simple-smoke-test "${NLC_IMAGE_REGISTRY_URL}/${{ vars.NLC_NAMESPACE }}" "${{ secrets.NLC_IMAGE_NAME }}"
+              simple-smoke-test "${NLC_IMAGE_REGISTRY_URL}/${{ vars.NLC_NAMESPACE }}" "${{ vars.NLC_IMAGE_NAME }}"
             fi
 
             echo "Testing Red Hat Catalog"


### PR DESCRIPTION
We store some repository configuration in `secrets` when it's better suited as `var` - where leakage is of no concern, but seeing the real value would help understanding when reading the logs.

In all cases, the resources are already protected by authentication so knowing the URL or ID risks nothing.