### PR TITLE
Use GitHub `environment` without `deployment` for non-deploying workflows

### DIFF
--- a/.github/workflows/ee-nlc-tag-package.yml
+++ b/.github/workflows/ee-nlc-tag-package.yml
@@ -38,7 +38,9 @@ jobs:
       ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
 
   package-nlc:
-    environment: ${{ inputs.ENVIRONMENT }}
+    environment:
+      name: ${{ inputs.ENVIRONMENT }}
+      deployment: false
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/tag_image_package.yml
+++ b/.github/workflows/tag_image_package.yml
@@ -51,7 +51,9 @@ jobs:
       ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
 
   package:
-    environment: ${{ inputs.ENVIRONMENT }}
+    environment:
+      name: ${{ inputs.ENVIRONMENT }}
+      deployment: false
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/tag_image_prepare.yml
+++ b/.github/workflows/tag_image_prepare.yml
@@ -32,7 +32,9 @@ on:
 
 jobs:
   prepare:
-    environment: ${{ inputs.ENVIRONMENT }}
+    environment:
+      name: ${{ inputs.ENVIRONMENT }}
+      deployment: false
     runs-on: ubuntu-latest
     outputs:
       distribution-classifiers: ${{ steps.distribution-classifiers.outputs.classifiers }}

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -83,7 +83,9 @@ jobs:
         uses: hazelcast/docker-actions/get-distribution-classifiers@master
 
   test:
-    environment: live
+    environment:
+      name: live
+      deployment: false
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
See:
- https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/#github-actions-now-allows-developers-to-use-environments-without-auto-deployment
- https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments

We want to avoid endless `temporary deployed` notices for workflows (eg https://github.com/hazelcast/hazelcast-docker/pull/1278) that don't deploy anything as it's just confusing.