### PR TITLE
Fix reproducible builds + Docker rebuilds + RedHat

### DIFF
--- a/.github/workflows/tag_image_promote_rhel.yml
+++ b/.github/workflows/tag_image_promote_rhel.yml
@@ -222,6 +222,7 @@ jobs:
           done
 
       - name: Copy remaining tags to RedHat Container Registry
+        if: steps.image-already-published.outputs.IMAGE_ALREADY_PUBLISHED != 'true'
         run: |
           for tag in ${TAGS_TO_PUSH}
           do
@@ -242,6 +243,7 @@ jobs:
         # RedHat has a `sync-tags` operation that is performed asynchronously after publish - and there have been scenarios where this has gone wrong and the tag is not accessible
         # As such, await completion and test 
         timeout-minutes: 240
+        if: steps.image-already-published.outputs.IMAGE_ALREADY_PUBLISHED != 'true'
         run: |
           set -o errexit ${RUNNER_DEBUG:+-x}
 


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-docker/pull/1236 we introduced reproducible builds - where repeated builds create identical images.

This flagged that RedHat does not allow republishing the same image (unlike Docker, which does), hence we identify this scenario: https://github.com/hazelcast/hazelcast-docker/blob/98f76d5d73e3864e2e6289bb2809675e8697e662/.github/workflows/tag_image_promote_rhel.yml#L117-L146

And then skip publishing:
https://github.com/hazelcast/hazelcast-docker/blob/98f76d5d73e3864e2e6289bb2809675e8697e662/.github/workflows/tag_image_promote_rhel.yml#L162-L163

However, we don't skip other operations such as copying the remaining tags / checking the tags are synced.

We don't need to do these operations (nothings changed) and messing with tags introduces periods of inaccessibility while RedHat reprocesses them.