### PR TITLE
Update `download-hz-dist` to support multiple repositories [DI-730]

### DIFF
--- a/.github/workflows/tag_image_package.yml
+++ b/.github/workflows/tag_image_package.yml
@@ -99,7 +99,7 @@ jobs:
         uses: hazelcast/docker-actions/download-hz-dist@master
         id: download-hz-dist
         with:
-          repo-vars-as-json: ${{ toJSON(vars) }}
+          environment: ${{ inputs.ENVIRONMENT == 'test' && 'live' || inputs.ENVIRONMENT }}
           aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           distribution: ${{ matrix.distribution-type.distribution }}
           hz_version: ${{ needs.prepare.outputs.hz-version }}


### PR DESCRIPTION
See https://github.com/hazelcast/docker-actions/pull/67

Post-merge actions:
- [x] remove environment-specific repo config (inc sandbox)