### PR TITLE
Ensure `fail` option used with curl to catch errors

### DIFF
--- a/.github/scripts/get-tags-to-push_tests.sh
+++ b/.github/scripts/get-tags-to-push_tests.sh
@@ -5,7 +5,7 @@ set -eu ${RUNNER_DEBUG:+-x}
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 . "$SCRIPT_DIR"/get-tags-to-push.sh
 

--- a/.github/scripts/logging.functions.sh
+++ b/.github/scripts/logging.functions.sh
@@ -1,2 +1,2 @@
 # Delegate to "github-actions-common-scripts" implementation
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"

--- a/.github/scripts/rhel.functions_tests.sh
+++ b/.github/scripts/rhel.functions_tests.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 . "$SCRIPT_DIR"/rhel.functions.sh
 

--- a/.github/scripts/version.functions_tests.sh
+++ b/.github/scripts/version.functions_tests.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 . "$SCRIPT_DIR"/version.functions.sh
 


### PR DESCRIPTION
By default, curl returns a `0` exit code even in the case of 404 errors.

This means that errors like the one in https://github.com/hazelcast/hazelcast-mono/pull/7091 are tricky to spot. It would be better if we used the [`fail` option](https://curl.se/docs/manpage.html#--fail) to ensure the failure is visible.