### PR TITLE
Harden `curl` usage - add retries and error logging

### DIFF
--- a/.github/scripts/get-tags-to-push_tests.sh
+++ b/.github/scripts/get-tags-to-push_tests.sh
@@ -5,7 +5,7 @@ set -eu ${RUNNER_DEBUG:+-x}
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 . "$SCRIPT_DIR"/get-tags-to-push.sh
 

--- a/.github/scripts/logging.functions.sh
+++ b/.github/scripts/logging.functions.sh
@@ -1,2 +1,2 @@
 # Delegate to "github-actions-common-scripts" implementation
-source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"

--- a/.github/scripts/rhel.functions_tests.sh
+++ b/.github/scripts/rhel.functions_tests.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 . "$SCRIPT_DIR"/rhel.functions.sh
 

--- a/.github/scripts/version.functions_tests.sh
+++ b/.github/scripts/version.functions_tests.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 . "$SCRIPT_DIR"/version.functions.sh
 


### PR DESCRIPTION
The change in https://github.com/hazelcast/hazelcast-docker/pull/1284 ensured failure was reported and the execution was halted, but the error message [wasn't clear](https://github.com/hazelcast/hazelcast-docker/actions/runs/28910263431/job/85765974279#step:6:31):
> Error: Process completed with exit code 22.

By adding the [`--show-error` option](https://curl.se/docs/manpage.html#--show-error) we can ensure the human readable error is printed to stderr, e.g.:
> curl: (56) The requested URL returned error: 404


In addition, the root cause of the failure is _probably_ an intermittent blip on the GitHub side ([related discussion](https://github.com/orgs/community/discussions/53538)) - so adding a simple retry-on-failure seems sensible.