### PR TITLE
Migrate Docker release version updates out of pipeline

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           ref: ${{ inputs.VERSION }}
 
-      - name: Update `SNAPSHOT` to release version
+      - name: Update Dockerfile `SNAPSHOT` version to release version
         run: |
           find . -type f -iname 'Dockerfile' \
             -exec sed -i -E "s/^ARG HZ_VERSION=.*/ARG HZ_VERSION=${VERSION}/" {} +

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -39,9 +39,12 @@ on:
         type: string
 
 jobs:
-  log-distinct-id:
+  update-version:
     runs-on: ubuntu-slim
-    if: inputs.distinct_id != ''
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ inputs.VERSION }}
     steps:
         # https://github.com/Codex-/return-dispatch#receiving-repository-action
       - name: Logging distinct ID (${{ inputs.distinct_id }})
@@ -49,7 +52,25 @@ jobs:
         env:
           DISTINCT_ID: ${{ inputs.distinct_id }}
 
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.VERSION }}
+
+      - name: Update `SNAPSHOT` to release version
+        run: |
+          find . -type f -iname 'Dockerfile' \
+            -exec sed -i -E "s/^ARG HZ_VERSION=.*/ARG HZ_VERSION=${VERSION}/" {} +
+
+      - name: Commit
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+          git commit --all --message "Upgrade version to \`${VERSION}\`"
+          git push
+
   package:
+    needs: update-version
     uses: ./.github/workflows/tag_image_package.yml
     with:
       SOURCE_REF: ${{ inputs.VERSION }}
@@ -59,6 +80,7 @@ jobs:
 
   package-nlc:
     if: inputs.RELEASE_TYPE != 'OSS'
+    needs: update-version
     uses: ./.github/workflows/ee-nlc-tag-package.yml
     with:
       SOURCE_REF: ${{ inputs.VERSION }}


### PR DESCRIPTION
The `Dockerfile`s start off with `SNAPSHOT` versions:
https://github.com/hazelcast/hazelcast-docker/blame/2016f509c9efd8976f0ef546f1d8cc589545880e/hazelcast-enterprise/Dockerfile#L3

But before release, the pipeline migrates those to release versions before the release itself is triggered.
We can simplify by moving this update into the action, too.

[Sandbox execution](https://github.com/hz-devops-test/hazelcast-docker/actions/runs/29088665218), compare the [previous pipeline commit](https://github.com/hz-devops-test/hazelcast-docker/commit/46b27d521163daa130242ef97e2a193a17828023) to the [new one created by the action](https://github.com/hz-devops-test/hazelcast-docker/commit/85d710d7f0b56403228ea4976563967738e4189a). 