### PR TITLE
Fix JFrog repo authentication

### DIFF
--- a/.github/workflows/tag_image_promote_docker_registry.yml
+++ b/.github/workflows/tag_image_promote_docker_registry.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Push image to remote registry
         run: |
           if [[ "${{ matrix.distribution-type.label }}" == "oss" && "${HZ_VERSION}" =~ SNAPSHOT ]]; then
-            remote_registry=docker.hazelcast.com/hazelcast
+            remote_registry=docker.hazelcast.com/docker/hazelcast
           else
             remote_registry=hazelcast
           fi


### PR DESCRIPTION
The change in https://github.com/hazelcast/hazelcast-docker/pull/1288 used the wrong URL, which meant Docker was pushing to a repo called `hazelcast` (not the `hazelcast` _directory_ of the `docker` repo) - leading to a [cryptic error](https://github.com/hazelcast/hazelcast-docker/actions/runs/29624637227/job/88222627729#step:7:294).