### PR TITLE
Remove `DISTINCT_ID` release workflow inputs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,9 +20,6 @@ on:
         description: 'Environment to use'
         required: true
         type: environment
-      distinct_id:
-        description: 'Required exclusively for automated execution to track status of workflow execution'
-        required: false
   workflow_call:
     inputs:
       VERSION:
@@ -39,16 +36,6 @@ on:
         type: string
 
 jobs:
-  log-distinct-id:
-    runs-on: ubuntu-slim
-    if: inputs.distinct_id != ''
-    steps:
-        # https://github.com/Codex-/return-dispatch#receiving-repository-action
-      - name: Logging distinct ID (${{ inputs.distinct_id }})
-        run: echo "${DISTINCT_ID}"
-        env:
-          DISTINCT_ID: ${{ inputs.distinct_id }}
-
   package:
     uses: ./.github/workflows/tag_image_package.yml
     with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -20,9 +20,6 @@ on:
         description: 'Environment to use'
         required: true
         type: environment
-      distinct_id:
-        description: 'Required exclusively for automated execution to track status of workflow execution'
-        required: false
   workflow_call:
     inputs:
       VERSION:
@@ -44,12 +41,6 @@ jobs:
     permissions:
       contents: write
     steps:
-        # https://github.com/Codex-/return-dispatch#receiving-repository-action
-      - name: Logging distinct ID (${{ inputs.distinct_id }})
-        run: echo "${DISTINCT_ID}"
-        env:
-          DISTINCT_ID: ${{ inputs.distinct_id }}
-
       - uses: hazelcast/docker-actions/create-tag@master
         with:
           TOKEN: ${{ github.token }}


### PR DESCRIPTION
No longer required since https://github.com/Codex-/return-dispatch/releases/tag/v4.0.0, as [GitHub now has built in functionality to support](https://github.blog/changelog/2026-02-19-workflow-dispatch-api-now-returns-run-ids/).