### PR TITLE
Always authenticate with Dockerhub when _building_ images

### DIFF
--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -1,4 +1,5 @@
 name: Setup Docker
+description: Configures runner with tools required to build (not just manage) Docker images 
 inputs:
   platforms:
     description: Platforms to install (e.g., `arm64,riscv64,arm`)

--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -64,6 +64,14 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.get-latest-patch-versions.outputs.matrix) }}
     steps:
+      - name: Login to Docker Hub
+        # Always login to Dockerhub to avoid rate limiting when pulling base images
+        if: ${{ !inputs.FORCE_REBUILD }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - id: check-base-images
         if: ${{ !inputs.FORCE_REBUILD }}
         uses: hazelcast/docker-actions/check-base-images@master

--- a/.github/workflows/ee-nlc-tag-package.yml
+++ b/.github/workflows/ee-nlc-tag-package.yml
@@ -70,6 +70,13 @@ jobs:
       - name: Setup Docker
         uses: ./.github/actions/setup-docker
 
+      - name: Login to Docker Hub
+        # Always login to Dockerhub to avoid rate limiting when pulling base images
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/tag_image_package.yml
+++ b/.github/workflows/tag_image_package.yml
@@ -95,6 +95,13 @@ jobs:
         with:
           platforms: ${{ steps.platforms.outputs.platforms }}
 
+      - name: Login to Docker Hub
+        # Always login to Dockerhub to avoid rate limiting when pulling base images
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Download the distribution file
         uses: hazelcast/docker-actions/download-hz-dist@master
         id: download-hz-dist
@@ -172,12 +179,6 @@ jobs:
         with:
           name: docker-logs-tag-image-push-${{ matrix.distribution-type.image-name }}-${{ steps.get-tags-to-push.outputs.primary-tag }}
           path: docker.log
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Push image to remote registry
         run: |

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -37,6 +37,13 @@ jobs:
           ref: ${{ inputs.ref }}
           path: ref
 
+      - name: Login to Docker Hub
+        # Always login to Dockerhub to avoid rate limiting when pulling base images
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Generate ${{ matrix.image.label }} dist ZIP
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream


### PR DESCRIPTION
[A build failed](https://github.com/hazelcast/hazelcast-docker/actions/runs/30504812595/job/90752173509#step:11:207):
> #4 ERROR: failed to authorize: failed to fetch oauth token: Post "https://auth.docker.io/token": read tcp 10.1.0.114:53532->172.64.144.78:443: read: connection reset by peer

While the error is cryptic, [Dockerhub has rate limits](https://docs.docker.com/docker-hub/usage/) which _might_ be causing the issue.

Specifically - whenever we build an image, we implicitly pull the base image from Dockerhub - in the case of NLC builds, as we never _push_ to Dockerhub, we don't authenticate and therefore these pulls _might_ be unauthenticated.

Updated to _always_ authenticate with Dockerhub when building.