### PR TITLE
Externalise Dockerhub organisation name

### DIFF
--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -69,7 +69,7 @@ jobs:
         uses: hazelcast/docker-actions/check-base-images@master
         with:
           ref: v${{ matrix.version }}
-          image-name: hazelcast/${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ matrix.version }}-slim
+          image-name: ${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ matrix.version }}-slim
           dockerfile-path: "hazelcast-enterprise/Dockerfile"
 
       - name: Check if ${{ matrix.version }} base images updated

--- a/.github/workflows/tag_image_package.yml
+++ b/.github/workflows/tag_image_package.yml
@@ -187,7 +187,7 @@ jobs:
             --retry-times 10 \
             --src-tls-verify=false \
             docker://${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
-            docker://hazelcast/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
+            docker://${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
 
   failure-notifications:
     name: Failure notification

--- a/.github/workflows/tag_image_promote_docker_registry.yml
+++ b/.github/workflows/tag_image_promote_docker_registry.yml
@@ -103,7 +103,7 @@ jobs:
           if [[ "${{ matrix.distribution-type.label }}" == "oss" && "${HZ_VERSION}" =~ SNAPSHOT ]]; then
             remote_registry=docker.hazelcast.com/docker/hazelcast
           else
-            remote_registry=hazelcast
+            remote_registry=${{ vars.DOCKERHUB_ORGANIZATION }}
           fi
 
           for tag in ${TAGS_TO_PUSH}
@@ -111,7 +111,7 @@ jobs:
             skopeo copy \
               --all \
               --retry-times 10 \
-              docker://hazelcast/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
+              docker://${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
               docker://${remote_registry}/${{ matrix.distribution-type.image-name }}:${tag}
           done
         env:

--- a/.github/workflows/tag_image_promote_rhel.yml
+++ b/.github/workflows/tag_image_promote_rhel.yml
@@ -119,7 +119,7 @@ jobs:
         # To work around this RedHat quirk we need to skip these steps for republish
         id: image-already-published
         env:
-          FULL_PRIMARY_TAG: hazelcast/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
+          FULL_PRIMARY_TAG: ${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
         run: |
           source .github/scripts/logging.functions.sh
           source .github/scripts/rhel.functions.sh
@@ -167,7 +167,7 @@ jobs:
             --retry-times 10 \
             --override-os "${PLATFORM_OS}" \
             --override-arch "${PLATFORM_ARCH}" \
-            docker://hazelcast/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
+            docker://${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
             docker://${{ steps.scan_registry_secrets.outputs.SCAN_REPOSITORY }}:${{ steps.unique-destination-tag.outputs.tag }}
 
       - name: Install `preflight` OpenShift tool from GitHub
@@ -236,7 +236,7 @@ jobs:
           done
         env:
           TAGS_TO_PUSH: ${{ steps.get-tags-to-push.outputs.all-destination-tags }}
-          FULL_PRIMARY_TAG: hazelcast/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
+          FULL_PRIMARY_TAG: ${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
 
       - name: Check tags published
         # Just because the tag has been pushed to the registry, does not guarantee it's accessible

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -202,7 +202,7 @@ jobs:
           fi
 
           echo "Testing Docker registry"
-          simple-smoke-test "hazelcast" "${image_name}"
+          simple-smoke-test "${{ vars.DOCKERHUB_ORGANIZATION }}" "${image_name}"
 
           # Check additional EE repos
           # Only populated for default variant, not "slim"

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           .github/scripts/generate-docker-hub-description.sh
         env:
-          NAMESPACE: hazelcast
+          NAMESPACE: ${{ vars.DOCKERHUB_ORGANIZATION }}
           OSS_IMAGE_NAME: ${{ vars.DOCKERHUB_OSS_IMAGE_NAME }}
           EE_IMAGE_NAME: ${{ vars.DOCKERHUB_EE_IMAGE_NAME }}
           USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -56,7 +56,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: hazelcast/${{ matrix.image_name }}
+          repository: ${{ vars.DOCKERHUB_ORGANIZATION }}/${{ matrix.image_name }}
           short-description: ${{ matrix.label }} Docker Image
           readme-filepath: ./README-docker.md
 

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -27,7 +27,7 @@ jobs:
             distribution_zip_name: hazelcast-enterprise-distribution.zip
     env:
       DIRECTORY: ref/hazelcast-${{ matrix.image.label }}
-      IMAGE_TAG: hazelcast/${{ matrix.image.label }}:${{ github.sha }}
+      IMAGE_TAG: ${{ vars.DOCKERHUB_ORGANIZATION }}/${{ matrix.image.label }}:${{ github.sha }}
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
We should externalise to make errors more obvious, and to support potential future alternate organisations (e.g. sandbox).