### PR TITLE
Move to Hazelcast 6.0 development cycle

### DIFF
--- a/hazelcast-enterprise/Dockerfile
+++ b/hazelcast-enterprise/Dockerfile
@@ -1,7 +1,7 @@
 # Used for image metadata only
 # Describes the version of the Dockerfile, *not* the version of the bundled Hazelcast binary as this is/can be controlled externally
 # Dockerfile needs some concept of versioning so that the release pipeline can tag/archive with an appropriate label
-ARG HZ_VERSION=5.8.0-SNAPSHOT
+ARG HZ_VERSION=6.0.0-SNAPSHOT
 
 # Build constants
 ARG HZ_HOME="/opt/hazelcast"

--- a/hazelcast-oss/Dockerfile
+++ b/hazelcast-oss/Dockerfile
@@ -1,7 +1,7 @@
 # Used for image metadata only
 # Describes the version of the Dockerfile, *not* the version of the bundled Hazelcast binary as this is/can be controlled externally
 # Dockerfile needs some concept of versioning so that the release pipeline can tag/archive with an appropriate label
-ARG HZ_VERSION=5.8.0-SNAPSHOT
+ARG HZ_VERSION=6.0.0-SNAPSHOT
 
 # Build constants
 ARG HZ_HOME="/opt/hazelcast"


### PR DESCRIPTION
At the back of https://github.com/hazelcast/hazelcast-mono/pull/7393
Normally, the Release Pipeline does this update during release branch creation
But we have agreed to update manually