### PR TITLE
Fix Dockerhub authentication issues due to credential timeout

### DIFF
--- a/.github/workflows/check-base-images.yml
+++ b/.github/workflows/check-base-images.yml
@@ -66,15 +66,6 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.get-latest-patch-versions.outputs.matrix) }}
     steps:
-      - name: Login to Docker Hub
-        # Always login to Dockerhub to avoid rate limiting when pulling base images
-        if: ${{ !inputs.FORCE_REBUILD }}
-        uses: docker/login-action@v4
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
-        with:
-          username: ${{ vars.DOCKERHUB_ORGANIZATION }}
-
       - id: check-base-images
         if: ${{ !inputs.FORCE_REBUILD }}
         uses: hazelcast/docker-actions/check-base-images@master

--- a/.github/workflows/ee-nlc-tag-package.yml
+++ b/.github/workflows/ee-nlc-tag-package.yml
@@ -70,14 +70,6 @@ jobs:
       - name: Setup Docker
         uses: ./.github/actions/setup-docker
 
-      - name: Login to Docker Hub
-        # Always login to Dockerhub to avoid rate limiting when pulling base images
-        uses: docker/login-action@v4
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
-        with:
-          username: ${{ vars.DOCKERHUB_ORGANIZATION }}
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/tag_image_package.yml
+++ b/.github/workflows/tag_image_package.yml
@@ -95,14 +95,6 @@ jobs:
         with:
           platforms: ${{ steps.platforms.outputs.platforms }}
 
-      - name: Login to Docker Hub
-        # Always login to Dockerhub to avoid rate limiting when pulling base images
-        uses: docker/login-action@v4
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
-        with:
-          username: ${{ vars.DOCKERHUB_ORGANIZATION }}
-
       - name: Download the distribution file
         uses: hazelcast/docker-actions/download-hz-dist@master
         id: download-hz-dist
@@ -180,6 +172,13 @@ jobs:
         with:
           name: docker-logs-tag-image-push-${{ matrix.distribution-type.image-name }}-${{ steps.get-tags-to-push.outputs.primary-tag }}
           path: docker.log
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
+        with:
+          username: ${{ vars.DOCKERHUB_ORGANIZATION }}
 
       - name: Push image to remote registry
         run: |

--- a/.github/workflows/tag_image_promote_rhel.yml
+++ b/.github/workflows/tag_image_promote_rhel.yml
@@ -94,6 +94,8 @@ jobs:
         uses: docker/login-action@v4
         env:
           DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
+          # We need the token to be kept alive until the image has finished testing
+          DOCKERHUB_OIDC_EXPIREIN: 3600
         with:
           username: ${{ vars.DOCKERHUB_ORGANIZATION }}
 
@@ -208,7 +210,7 @@ jobs:
         # Although we use autopublish, this simply triggers an asynchronous process on the server side
         # To _try_ to attain republish atomicity, we want to await the successful publishing of the new, unique tag _before_ we push (and implicitly replace) the existing tags
         # Otherwise we'd replace a published image with an unpublished one
-        timeout-minutes: 240
+        timeout-minutes: 60
         if: steps.image-already-published.outputs.IMAGE_ALREADY_PUBLISHED != 'true'   
         run: |
           set -o errexit ${RUNNER_DEBUG:+-x}

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -116,6 +116,8 @@ jobs:
         uses: docker/login-action@v4
         env:
           DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
+          # We need the token to be kept alive until the image has finished testing
+          DOCKERHUB_OIDC_EXPIREIN: 3600
         with:
           username: ${{ vars.DOCKERHUB_ORGANIZATION }}
 

--- a/.github/workflows/vulnerability_scan_subworkflow.yml
+++ b/.github/workflows/vulnerability_scan_subworkflow.yml
@@ -39,14 +39,6 @@ jobs:
           ref: ${{ inputs.ref }}
           path: ref
 
-      - name: Login to Docker Hub
-        # Always login to Dockerhub to avoid rate limiting when pulling base images
-        uses: docker/login-action@v4
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
-        with:
-          username: ${{ vars.DOCKERHUB_ORGANIZATION }}
-
       - name: Generate ${{ matrix.image.label }} dist ZIP
         run: |
           # Make a dummy empty ZIP file to avoid scanning Java dependencies, as managed downstream


### PR DESCRIPTION
[Builds are failing](https://github.com/hazelcast/hazelcast-docker/actions/runs/31231129634/job/93060391418) with a strange authentication issue when pulling a (public) image:
>   docker: Error response from daemon: Head "https://registry-1.docker.io/v2/wagoodman/dive/manifests/latest": unauthorized: incorrect username or password

The root cause is the _combination_ of:
- https://github.com/hazelcast/hazelcast-docker/pull/1292
- https://github.com/hazelcast/hazelcast-docker/pull/1293

Specifically:
- https://github.com/hazelcast/hazelcast-docker/pull/1292
   - we broadened the usage of our credentials
   - logging in _before_ we build the images, rather than _after_
   - _explicitly_ using our credentials when not specified previously
   - [wasn't even necessary](https://github.com/hazelcast/hazelcast-docker/pull/1292#issuecomment-5224664612)
- https://github.com/hazelcast/hazelcast-docker/pull/1293
   - swap from a long-lived token to use OIDC authentication
   - internally, the OIDC validation returns a short-lived token
   - this token is only valid for [5 minutes](https://github.com/docker/login-action/blob/v4.6.0/README.md?plain=1#L763) by default

As building the image takes ~5 minutes on it's own, the net result is that before the workflow has finished, the token has already expired - and this prevents authentication to pull even a public image.

By reverting https://github.com/hazelcast/hazelcast-docker/pull/1292 we can largely avoid having to increase this timeout and leave most at default, as before we only authenticated before copying from local to remote registry which was trivial (seconds).

I've also raised an [upstream discussion on this topic](https://github.com/docker/login-action/discussions/1069).

[Example execution for NLC builds](https://github.com/hazelcast/hazelcast-docker/actions/runs/31246056907).