### PR TITLE
In `package.yml`, skip version update if not required

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -52,13 +52,15 @@ jobs:
           find . -type f -iname 'Dockerfile' \
             -exec sed -i -E "s/^ARG HZ_VERSION=.*/ARG HZ_VERSION=${VERSION}/" {} +
 
-      - name: Commit
+      - name: Commit if required
         run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-
-          git commit --all --message "Upgrade version to \`${VERSION}\`"
-          git push
+          if ! git diff --quiet; then
+            git config user.name "${GITHUB_ACTOR}"
+            git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+  
+            git commit --all --message "Upgrade version to \`${VERSION}\`"
+            git push
+          fi
 
   package:
     needs: update-version


### PR DESCRIPTION
Updated commit step to check for changes before committing.If the version has _already_ been updated (e.g. re-run), the commit will fail with no changes.

Instead, in this case, we should skip.