### PR TITLE
In smoke test, merge Docker logs into main job execution logs instead of distinct artifact

### DIFF
--- a/.github/scripts/simple-smoke-test.sh
+++ b/.github/scripts/simple-smoke-test.sh
@@ -8,28 +8,8 @@ set -o errexit ${RUNNER_DEBUG:+-x}
 # shellcheck source=../.github/scripts/version.functions.sh
 . .github/scripts/version.functions.sh
 
-function remove_container_if_exists() {
-    local containers
-    containers=$(docker ps --all --quiet --filter name="${container_name}")
-
-    if [[ -n "${containers}" ]]; then
-      echo "Removing existing '${container_name}' container"
-      docker container rm --force "${container_name}"
-    fi
-}
-
-function start_container() {
-    echo "Starting container '${container_name}' from image '${image}'"
-    docker run -it --name "${container_name}" -e HZ_LICENSEKEY -e HZ_INSTANCETRACKING_FILENAME -d -p5701:5701 "${image}"
-}
-
 function get_hz_logs() {
     docker logs "${container_name}"
-}
-
-function stop_container() {
-    echo "Stopping container ${container_name}"
-    docker stop "${container_name}"
 }
 
 function check_java_version() {
@@ -78,12 +58,6 @@ container_name=$2
 input_distribution_type=$3
 expected_version=$4
 expected_java_major_version=$5
-
-
-remove_container_if_exists
-start_container
-
-trap stop_container EXIT
 
 expected_distribution_type=$(derive_expected_distribution_type "${input_distribution_type}")
 test_package "${expected_distribution_type}" "${expected_version}"

--- a/.github/workflows/ee-nlc-tag-package.yml
+++ b/.github/workflows/ee-nlc-tag-package.yml
@@ -143,7 +143,7 @@ jobs:
           docker run \
             --name "${TEST_CONTAINER_NAME}" \
             --env HZ_INSTANCETRACKING_FILENAME \
-            --expose 5701:5701 \
+            -p5701:5701 \
             "${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }}"
         env:
           HZ_INSTANCETRACKING_FILENAME: instance-tracking.txt

--- a/.github/workflows/ee-nlc-tag-package.yml
+++ b/.github/workflows/ee-nlc-tag-package.yml
@@ -142,8 +142,8 @@ jobs:
         run: |
           docker run \
             --name "${TEST_CONTAINER_NAME}" \
-            -e HZ_INSTANCETRACKING_FILENAME \
-            -p5701:5701 \
+            --env HZ_INSTANCETRACKING_FILENAME \
+            --expose 5701:5701 \
             "${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }}"
         env:
           HZ_INSTANCETRACKING_FILENAME: instance-tracking.txt

--- a/.github/workflows/ee-nlc-tag-package.yml
+++ b/.github/workflows/ee-nlc-tag-package.yml
@@ -136,6 +136,18 @@ jobs:
           # The distribution is large and no longer required now the image has been built
           rm "${{ steps.download-hz-dist.outputs.output_file }}"
 
+      - name: Run test container
+        id: test-container
+        background: true
+        run: |
+          docker run \
+            --name "${TEST_CONTAINER_NAME}" \
+            -e HZ_INSTANCETRACKING_FILENAME \
+            -p5701:5701 \
+            "${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }}"
+        env:
+          HZ_INSTANCETRACKING_FILENAME: instance-tracking.txt
+
       - name: Run smoke test against image
         timeout-minutes: 2
         run: |
@@ -145,24 +157,13 @@ jobs:
             ee \
             "${{ needs.prepare.outputs.hz-version }}" \
             "${{ matrix.jdk }}"
-        env:
-          HZ_INSTANCETRACKING_FILENAME: instance-tracking.txt
+
+      - name: Stop test container
+        cancel: test-container
 
       - uses: hazelcast/docker-actions/assert-image-size@master
         with:
           image: ${{ env.LOCAL_IMAGE_NAME}}:${{ steps.get-tags-to-push.outputs.primary-tag }}
-
-      - name: Get docker logs
-        if: ${{ always() }}
-        run: |
-          docker logs "${TEST_CONTAINER_NAME}" > "docker.log" || true
-
-      - name: Store docker logs as artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: docker-logs-tag-image-push-nlc-${{ steps.get-tags-to-push.outputs.primary-tag }}
-          path: docker.log
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/tag_image_package.yml
+++ b/.github/workflows/tag_image_package.yml
@@ -151,8 +151,8 @@ jobs:
         run: |
           docker run \
             --name "${TEST_CONTAINER_NAME}" \
-            -e HZ_LICENSEKEY \
-            -p5701:5701 \
+            --env HZ_LICENSEKEY \
+            --expose 5701:5701 \
             "${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }}"
         env:
           HZ_LICENSEKEY: ${{ matrix.distribution-type.label == 'ee' && secrets.HAZELCAST_ENTERPRISE_KEY || '' }}

--- a/.github/workflows/tag_image_package.yml
+++ b/.github/workflows/tag_image_package.yml
@@ -152,7 +152,7 @@ jobs:
           docker run \
             --name "${TEST_CONTAINER_NAME}" \
             --env HZ_LICENSEKEY \
-            --expose 5701:5701 \
+            -p5701:5701 \
             "${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }}"
         env:
           HZ_LICENSEKEY: ${{ matrix.distribution-type.label == 'ee' && secrets.HAZELCAST_ENTERPRISE_KEY || '' }}

--- a/.github/workflows/tag_image_package.yml
+++ b/.github/workflows/tag_image_package.yml
@@ -145,6 +145,18 @@ jobs:
           # The distribution is large and no longer required now the image has been built
           rm "${{ steps.download-hz-dist.outputs.output_file }}"
 
+      - name: Run test container
+        id: test-container
+        background: true
+        run: |
+          docker run \
+            --name "${TEST_CONTAINER_NAME}" \
+            -e HZ_LICENSEKEY \
+            -p5701:5701 \
+            "${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }}"
+        env:
+          HZ_LICENSEKEY: ${{ matrix.distribution-type.label == 'ee' && secrets.HAZELCAST_ENTERPRISE_KEY || '' }}
+
       - name: Run smoke test against image
         timeout-minutes: 2
         run: |
@@ -154,24 +166,13 @@ jobs:
             ${{ matrix.distribution-type.label }} \
             "${{ needs.prepare.outputs.hz-version }}" \
             "${{ matrix.jdk }}"
-        env:
-          HZ_LICENSEKEY: ${{ matrix.distribution-type.label == 'ee' && secrets.HAZELCAST_ENTERPRISE_KEY || '' }}
+
+      - name: Stop test container
+        cancel: test-container
 
       - uses: hazelcast/docker-actions/assert-image-size@master
         with:
           image: ${{ env.LOCAL_IMAGE_NAME}}:${{ steps.get-tags-to-push.outputs.primary-tag }}
-
-      - name: Get docker logs
-        if: ${{ always() }}
-        run: |
-          docker logs "${TEST_CONTAINER_NAME}" > "docker.log" || true
-
-      - name: Store docker logs as artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: docker-logs-tag-image-push-${{ matrix.distribution-type.image-name }}-${{ steps.get-tags-to-push.outputs.primary-tag }}
-          path: docker.log
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -182,7 +182,14 @@ jobs:
               --name "${CONTAINER_NAME}" \
               --tty \
               "${image}"
-            .github/scripts/simple-smoke-test.sh "${image}" "${CONTAINER_NAME}" "${{ matrix.distribution-type }}" "${{ inputs.EXPECTED_HZ_VERSION }}" "${expected_jdk_version}"
+
+            .github/scripts/simple-smoke-test.sh \
+              "${image}" \
+              "${CONTAINER_NAME}" \
+              "${{ matrix.distribution-type }}" \
+              "${{ inputs.EXPECTED_HZ_VERSION }}" \
+              "${expected_jdk_version}"
+
             docker stop "${CONTAINER_NAME}"
           }
 

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -184,7 +184,7 @@ jobs:
               --detach \
               --env HZ_INSTANCETRACKING_FILENAME \
               --env HZ_LICENSEKEY \
-              --expose 5701:5701 \
+              -p5701:5701 \
               --interactive \
               --name "${CONTAINER_NAME}" \
               --tty \

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -171,7 +171,11 @@ jobs:
             fi
 
             # Compute tag by concatenating tag_elements
-            .github/scripts/simple-smoke-test.sh "${repository}/${image_name}":$(IFS=- ; echo "${tag_elements[*]}") "${CONTAINER_NAME}" "${{ matrix.distribution-type }}" "${{ inputs.EXPECTED_HZ_VERSION }}" "${expected_jdk_version}"
+            local image="${repository}/${image_name}":$(IFS=- ; echo "${tag_elements[*]}")
+
+            docker run -it --name "${CONTAINER_NAME}" -e HZ_LICENSEKEY -e HZ_INSTANCETRACKING_FILENAME -d -p5701:5701 "${image}"
+            .github/scripts/simple-smoke-test.sh "${image}" "${CONTAINER_NAME}" "${{ matrix.distribution-type }}" "${{ inputs.EXPECTED_HZ_VERSION }}" "${expected_jdk_version}"
+            docker stop "${CONTAINER_NAME}"
           }
 
           case "${{ matrix.distribution-type }}" in

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -33,15 +33,22 @@ jobs:
     steps:
       - name: Add workflow inputs to summary
         run: |
-          echo "### Workflow inputs" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Name | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| IMAGE_VERSION | ${{ inputs.IMAGE_VERSION }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| EXPECTED_HZ_VERSION | ${{ inputs.EXPECTED_HZ_VERSION }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| DISTRIBUTION_TYPE | ${{ inputs.DISTRIBUTION_TYPE }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| EXPECTED_DEFAULT_JAVA_VERSION | ${{ inputs.EXPECTED_DEFAULT_JAVA_VERSION }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| OTHER_JDKS | ${{ inputs.OTHER_JDKS }} |" >> $GITHUB_STEP_SUMMARY
+          echo "### Workflow inputs" >> ${GITHUB_STEP_SUMMARY}
+          echo "" >> ${GITHUB_STEP_SUMMARY}
+          echo "| Name | Value |" >> ${GITHUB_STEP_SUMMARY}
+          echo "|------|-------|" >> ${GITHUB_STEP_SUMMARY}
+          echo "| IMAGE_VERSION | ${IMAGE_VERSION} |" >> ${GITHUB_STEP_SUMMARY}
+          echo "| EXPECTED_HZ_VERSION | ${EXPECTED_HZ_VERSION} |" >> ${GITHUB_STEP_SUMMARY}
+          echo "| DISTRIBUTION_TYPE | ${DISTRIBUTION_TYPE} |" >> ${GITHUB_STEP_SUMMARY}
+          echo "| EXPECTED_DEFAULT_JAVA_VERSION | ${EXPECTED_DEFAULT_JAVA_VERSION} |" >> ${GITHUB_STEP_SUMMARY}
+          echo "| OTHER_JDKS | ${OTHER_JDKS} |" >> ${GITHUB_STEP_SUMMARY}
+        env:
+          IMAGE_VERSION: ${{ inputs.IMAGE_VERSION }}
+          EXPECTED_HZ_VERSION: ${{ inputs.EXPECTED_HZ_VERSION }}
+          DISTRIBUTION_TYPE: ${{ inputs.DISTRIBUTION_TYPE }}
+          EXPECTED_DEFAULT_JAVA_VERSION: ${{ inputs.EXPECTED_DEFAULT_JAVA_VERSION }}
+          OTHER_JDKS: ${{ inputs.OTHER_JDKS }}
+
   set-matrix:
     runs-on: ubuntu-latest
     outputs:
@@ -72,12 +79,12 @@ jobs:
               exit 1
               ;;
           esac
-          echo "distribution-type-matrix=${matrix}" >> $GITHUB_OUTPUT
+          echo "distribution-type-matrix=${matrix}" >> ${GITHUB_OUTPUT}
 
           # https://unix.stackexchange.com/a/719752 + trim
           # Add an "empty" option for base image
           matrix=$(echo '"${{ inputs.OTHER_JDKS }}"' | jq --compact-output 'split(",") + [""] | map(gsub("^\\s+|\\s+$"; ""))' )
-          echo "jdk-image-variants-matrix=${matrix}" >> $GITHUB_OUTPUT
+          echo "jdk-image-variants-matrix=${matrix}" >> ${GITHUB_OUTPUT}
 
       - id: distribution-classifiers
         uses: hazelcast/docker-actions/get-distribution-classifiers@master
@@ -167,7 +174,7 @@ jobs:
             if [ -n "${{ matrix.jdk-image-variant }}" ]; then
               expected_jdk_version=${{ matrix.jdk-image-variant }}
             else
-              expected_jdk_version=${{ inputs.EXPECTED_DEFAULT_JAVA_VERSION }}
+              expected_jdk_version=${EXPECTED_DEFAULT_JAVA_VERSION}
             fi
 
             # Compute tag by concatenating tag_elements
@@ -187,7 +194,7 @@ jobs:
               "${image}" \
               "${CONTAINER_NAME}" \
               "${{ matrix.distribution-type }}" \
-              "${{ inputs.EXPECTED_HZ_VERSION }}" \
+              "${EXPECTED_HZ_VERSION}" \
               "${expected_jdk_version}"
 
             docker stop "${CONTAINER_NAME}"
@@ -213,7 +220,7 @@ jobs:
           fi
 
           # To allow computing the required tag, store the elements in an array
-          tag_elements=("${{ inputs.IMAGE_VERSION }}")
+          tag_elements=("${IMAGE_VERSION}")
 
           if [[ -n "${{ matrix.classifier }}" ]]; then
             tag_elements+=("${{ matrix.classifier }}")
@@ -239,6 +246,10 @@ jobs:
             echo "Testing Red Hat Catalog"
             simple-smoke-test "registry.connect.redhat.com/hazelcast" "${image_name}-${{ steps.expected-hz-version.outputs.major }}-rhel8"
           fi
+        env:
+          IMAGE_VERSION: ${{ inputs.IMAGE_VERSION }}
+          EXPECTED_HZ_VERSION: ${{ inputs.EXPECTED_HZ_VERSION }}
+          EXPECTED_DEFAULT_JAVA_VERSION: ${{ inputs.EXPECTED_DEFAULT_JAVA_VERSION }}
 
       - name: Get docker logs
         if: always()

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -173,7 +173,7 @@ jobs:
             # Compute tag by concatenating tag_elements
             local image="${repository}/${image_name}":$(IFS=- ; echo "${tag_elements[*]}")
 
-            docker run -it --name "${CONTAINER_NAME}" -e HZ_LICENSEKEY -e HZ_INSTANCETRACKING_FILENAME -d -p5701:5701 "${image}"
+            docker run --interactive --tty --name "${CONTAINER_NAME}" --env HZ_LICENSEKEY --env HZ_INSTANCETRACKING_FILENAME --detach --expose 5701:5701 "${image}"
             .github/scripts/simple-smoke-test.sh "${image}" "${CONTAINER_NAME}" "${{ matrix.distribution-type }}" "${{ inputs.EXPECTED_HZ_VERSION }}" "${expected_jdk_version}"
             docker stop "${CONTAINER_NAME}"
           }

--- a/.github/workflows/test_published_images.yml
+++ b/.github/workflows/test_published_images.yml
@@ -173,7 +173,15 @@ jobs:
             # Compute tag by concatenating tag_elements
             local image="${repository}/${image_name}":$(IFS=- ; echo "${tag_elements[*]}")
 
-            docker run --interactive --tty --name "${CONTAINER_NAME}" --env HZ_LICENSEKEY --env HZ_INSTANCETRACKING_FILENAME --detach --expose 5701:5701 "${image}"
+            docker run \
+              --detach \
+              --env HZ_INSTANCETRACKING_FILENAME \
+              --env HZ_LICENSEKEY \
+              --expose 5701:5701 \
+              --interactive \
+              --name "${CONTAINER_NAME}" \
+              --tty \
+              "${image}"
             .github/scripts/simple-smoke-test.sh "${image}" "${CONTAINER_NAME}" "${{ matrix.distribution-type }}" "${{ inputs.EXPECTED_HZ_VERSION }}" "${expected_jdk_version}"
             docker stop "${CONTAINER_NAME}"
           }


### PR DESCRIPTION
When we run the Docker container as part of the smoke test, we run it in [detached mode](https://docs.docker.com/reference/cli/docker/container/run/#detach) to allow subsequent steps to continue. But when running in a detached way, logs are not displayed - so we have a separate step to dump and upload those logs as an artifact.

GitHub artifacts [consume storage credits](https://docs.github.com/en/billing/concepts/product-billing/github-actions#how-storage-billing-works), and this artifact exists only as a workaround to capture the logs.

[Using the new `background` functionality](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsbackground), we can then convert this detached execution into an _attached_ execution of a background step - and the logs are then rendered as part of the job logs, and no storage credits are consumed:
<img width="1040" height="872" alt="image" src="https://github.com/user-attachments/assets/430e1db7-b10d-422e-80c6-e7dbbe7c6f15" />