### PR TITLE
Sign Docker images with `cosign`

### DIFF
--- a/.github/actions/sign-image/action.yml
+++ b/.github/actions/sign-image/action.yml
@@ -1,0 +1,19 @@
+name: Sign image with Cosign
+inputs:
+  image-name:
+    required: true
+  digest:
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # https://github.com/sigstore/cosign-installer#usage
+    - name: Sign the image
+      shell: bash
+      run: |
+        cosign sign --yes "${IMAGE_NAME}@${DIGEST}"
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        DIGEST: ${{ inputs.digest }}

--- a/.github/workflows/ee-nlc-tag-package.yml
+++ b/.github/workflows/ee-nlc-tag-package.yml
@@ -117,6 +117,7 @@ jobs:
           HZ_REVISION: ${{ inputs.HZ_REVISION }}
 
       - name: Build and push image
+        id: build-and-push
         uses: docker/build-push-action@v7
         env:
           # Fixed timestamp (0 = Unix Epoch) needed for reproducible builds
@@ -129,6 +130,11 @@ jobs:
           tags: ${{ env.LOCAL_IMAGE_NAME}}:${{ steps.get-tags-to-push.outputs.primary-tag }}
           build-args: |
             JDK_VERSION=${{ matrix.jdk }}
+
+      - uses: ./.github/actions/sign-image
+        with:
+          image-name: ${{ env.LOCAL_IMAGE_NAME }}
+          digest: ${{ steps.build-and-push.outputs.digest }}
 
       - name: Delete the distribution file
         run: |
@@ -185,15 +191,16 @@ jobs:
           username: ${{ env.NLC_IMAGE_REGISTRY_USERNAME }}
           password: ${{ env.NLC_IMAGE_REGISTRY_TOKEN }}
 
+      - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+
       - name: Push image to remote registry
         run: |
-          # Skopeo expects HTTPS registry but local is HTTP
-          skopeo copy \
-            --all \
-            --retry-times 10 \
-            --src-tls-verify=false \
-            docker://${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
-            docker://${NLC_IMAGE_REGISTRY_URL}/hazelcast_cloud/${NLC_IMAGE_NAME}-${{ vars.PREPROD_REGISTRY }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
+          # oras expects HTTPS registry but local is HTTP
+          oras cp \
+            --from-plain-http \
+            --recursive \
+            ${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
+            ${NLC_IMAGE_REGISTRY_URL}/hazelcast_cloud/${NLC_IMAGE_NAME}-${{ vars.PREPROD_REGISTRY }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
         env:
           NLC_IMAGE_NAME: ${{ vars.NLC_IMAGE_NAME }}
 

--- a/.github/workflows/ee-nlc-tag-promote.yml
+++ b/.github/workflows/ee-nlc-tag-promote.yml
@@ -84,16 +84,14 @@ jobs:
           username: ${{ env.NLC_IMAGE_REGISTRY_USERNAME }}
           password: ${{ env.NLC_IMAGE_REGISTRY_TOKEN }}
 
+      - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+
       - name: Push image to remote registry
         run: |
-          for tag in ${TAGS_TO_PUSH}
-          do
-            skopeo copy \
-              --all \
-              --retry-times 10 \
-              docker://${NLC_IMAGE_REGISTRY_URL}/hazelcast_cloud/${NLC_IMAGE_NAME}-${{ vars.PREPROD_REGISTRY }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
-              docker://${NLC_IMAGE_REGISTRY_URL}/hazelcast_cloud/${NLC_IMAGE_NAME}:${tag}
-          done
+          oras cp \
+            --recursive \
+            ${NLC_IMAGE_REGISTRY_URL}/hazelcast_cloud/${NLC_IMAGE_NAME}-${{ vars.PREPROD_REGISTRY }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
+            ${NLC_IMAGE_REGISTRY_URL}/hazelcast_cloud/${NLC_IMAGE_NAME}:${TAGS_TO_PUSH// /,}
         env:
           TAGS_TO_PUSH: ${{ steps.get-tags-to-push.outputs.all-destination-tags }}
           NLC_IMAGE_NAME: ${{ vars.NLC_IMAGE_NAME }}

--- a/.github/workflows/tag_image_package.yml
+++ b/.github/workflows/tag_image_package.yml
@@ -126,6 +126,7 @@ jobs:
           HZ_REVISION: ${{ inputs.HZ_REVISION }}
 
       - name: Build and push image
+        id: build-and-push
         uses: docker/build-push-action@v7
         env:
           # Fixed timestamp (like 0 EPOCH) is needed for reproducible builds
@@ -138,6 +139,11 @@ jobs:
           tags: ${{ env.LOCAL_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
           build-args: |
             JDK_VERSION=${{ matrix.jdk }}
+
+      - uses: ./.github/actions/sign-image
+        with:
+          image-name: ${{ env.LOCAL_IMAGE_NAME }}
+          digest: ${{ steps.build-and-push.outputs.digest }}
 
       - name: Delete the distribution file
         run: |
@@ -181,15 +187,16 @@ jobs:
         with:
           username: ${{ vars.DOCKERHUB_ORGANIZATION }}
 
+      - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+
       - name: Push image to remote registry
         run: |
-          # Skopeo expects HTTPS registry but local is HTTP
-          skopeo copy \
-            --all \
-            --retry-times 10 \
-            --src-tls-verify=false \
-            docker://${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
-            docker://${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
+          # oras expects HTTPS registry but local is HTTP
+          oras cp \
+            --from-plain-http \
+            --recursive \
+            ${LOCAL_IMAGE_NAME}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
+            docker.io/${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
 
   failure-notifications:
     name: Failure notification

--- a/.github/workflows/tag_image_promote_docker_registry.yml
+++ b/.github/workflows/tag_image_promote_docker_registry.yml
@@ -99,22 +99,20 @@ jobs:
           username: ${{ steps.authenticate-jfrog-write-dev-account.outputs.user }}
           password: ${{ steps.authenticate-jfrog-write-dev-account.outputs.token }}
 
+      - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+
       - name: Push image to remote registry
         run: |
           if [[ "${{ matrix.distribution-type.label }}" == "oss" && "${HZ_VERSION}" =~ SNAPSHOT ]]; then
             remote_registry=docker.hazelcast.com/docker/hazelcast
           else
-            remote_registry=${{ vars.DOCKERHUB_ORGANIZATION }}
+            remote_registry=docker.io/${{ vars.DOCKERHUB_ORGANIZATION }}
           fi
 
-          for tag in ${TAGS_TO_PUSH}
-          do
-            skopeo copy \
-              --all \
-              --retry-times 10 \
-              docker://${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
-              docker://${remote_registry}/${{ matrix.distribution-type.image-name }}:${tag}
-          done
+          oras cp \
+            --recursive \
+            docker.io/${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.PREPROD_REGISTRY }}-${{ matrix.distribution-type.image-name }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
+            ${remote_registry}/${{ matrix.distribution-type.image-name }}:${TAGS_TO_PUSH// /,}
         env:
           HZ_VERSION: ${{ inputs.HZ_VERSION }}
           TAGS_TO_PUSH: ${{ steps.get-tags-to-push.outputs.all-destination-tags }}

--- a/.github/workflows/tag_image_promote_rhel.yml
+++ b/.github/workflows/tag_image_promote_rhel.yml
@@ -162,16 +162,18 @@ jobs:
           # Add date suffix to create unique output tag (e.g. 5.4.1-jdk17-20250909130347)
           echo "tag=${{ steps.get-tags-to-push.outputs.primary-tag }}-$(date +"%Y%m%d%H%M%S")" >> ${GITHUB_OUTPUT}
 
+      - if: steps.image-already-published.outputs.IMAGE_ALREADY_PUBLISHED != 'true'   
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+
       - name: Copy new unique tag to RedHat Container Registry
         if: steps.image-already-published.outputs.IMAGE_ALREADY_PUBLISHED != 'true'
         run: |
           # Deliberately only copy a single architecture - https://github.com/hazelcast/hazelcast-docker/pull/1042#issuecomment-3141395993
-          skopeo copy \
-            --retry-times 10 \
-            --override-os "${PLATFORM_OS}" \
-            --override-arch "${PLATFORM_ARCH}" \
-            docker://${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
-            docker://${{ steps.scan_registry_secrets.outputs.SCAN_REPOSITORY }}:${{ steps.unique-destination-tag.outputs.tag }}
+          oras cp \
+            --recursive \
+            --platform ${PLATFORM_OS}/${PLATFORM_ARCH} \
+            docker.io/${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
+            docker.io/${{ steps.scan_registry_secrets.outputs.SCAN_REPOSITORY }}:${{ steps.unique-destination-tag.outputs.tag }}
 
       - name: Install `preflight` OpenShift tool from GitHub
         if: steps.image-already-published.outputs.IMAGE_ALREADY_PUBLISHED != 'true'
@@ -227,19 +229,13 @@ jobs:
       - name: Copy remaining tags to RedHat Container Registry
         if: steps.image-already-published.outputs.IMAGE_ALREADY_PUBLISHED != 'true'
         run: |
-          for tag in ${TAGS_TO_PUSH}
-          do
-            echo "Copying tag: ${FULL_PRIMARY_TAG} -> ${tag}"
-            skopeo copy \
-              --retry-times 10 \
-              --override-os "${PLATFORM_OS}" \
-              --override-arch "${PLATFORM_ARCH}" \
-              docker://${FULL_PRIMARY_TAG} \
-              docker://${{ steps.scan_registry_secrets.outputs.SCAN_REPOSITORY }}:${tag}
-          done
+          oras cp \
+            --recursive \
+            --platform ${PLATFORM_OS}/${PLATFORM_ARCH} \
+            docker.io/${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }} \
+            ${{ steps.scan_registry_secrets.outputs.SCAN_REPOSITORY }}:${TAGS_TO_PUSH// /,}
         env:
           TAGS_TO_PUSH: ${{ steps.get-tags-to-push.outputs.all-destination-tags }}
-          FULL_PRIMARY_TAG: ${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.PREPROD_REGISTRY }}-${{ vars.DOCKERHUB_EE_IMAGE_NAME }}:${{ steps.get-tags-to-push.outputs.primary-tag }}
 
       - name: Check tags published
         # Just because the tag has been pushed to the registry, does not guarantee it's accessible


### PR DESCRIPTION
See:
- https://docs.docker.com/dhi/explore/security-concepts/signatures
- https://edu.chainguard.dev/open-source/sigstore/cosign/an-introduction-to-cosign/

We can use `cosign` in conjunction with our GitHub OIDC token to sign that the image deployed to Docker registries was built inside an action running within our GitHub organisation - as a pose to by some third party actor pushing _their_ build to the registries in some supply chain attack.

Docker's "hardened images" are signed.

Examples of usage:
```
% cosign verify {sandbox-hazelcast-enterprise-image} --certificate-identity dummy-to-query --certificate-oidc-issuer https://token.actions.githubusercontent.com

{...} expected SAN value "dummy-to-query", got "https://github.com/hazelcast/hazelcast-docker/.github/workflows/tag_image_package.yml@refs/pull/1301/merge"
```

```
% osign verify {sandbox-hazelcast-enterprise-image}  --certificate-identity https://github.com/hazelcast/hazelcast-docker/.github/workflows/tag_image_package.yml@refs/pull/1301/merge --certificate-oidc-issuer https://token.actions.githubusercontent.com


Verification for index.docker.io/{sandbox-hazelcast-enterprise-image} --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates

[{"critical":{"identity":{"docker-reference":"index.docker.io/{sandbox-hazelcast-enterprise-image}"},"image":{"docker-manifest-digest":"sha256:2282ba9f8f224b9c86209f36e780563651d2eba64bd8bd24d17e8ab90e2bf87e"},"type":"https://sigstore.dev/cosign/sign/v1"},"optional":{}}]
```

Changes:
- sign images when building
- migrate from `skopeo` to [`oras`](https://oras.land/docs/commands/oras_cp) for copying images
   - `skopeo` only copies _images_
   - `oras` copies OCI artifacts, which includes images _and attached metadata_ (e.g. the signatures)

